### PR TITLE
Parse for loops

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1229,6 +1229,26 @@ nodes:
 
           while foo do bar end
           ^^^^^^^^^^^^^^^^^^^^
+  - name: ForNode
+    child_nodes:
+      - name: keyword
+        type: token
+      - name: index
+        type: node
+      - name: keyword_in
+        type: token
+      - name: collection
+        type: node
+      - name: statement
+        type: node
+      - name: end_keyword
+        type: token?
+    location: keyword->statement
+    comment: |
+      Represents the use of the `for` keyword.
+
+          for i in a end
+          ^^^^^^^^^^^^^^
   - name: YieldNode
     child_nodes:
       - name: keyword

--- a/config.yml
+++ b/config.yml
@@ -1241,11 +1241,11 @@ nodes:
         type: node
       - name: do_keyword
         type: token?
-      - name: statement
+      - name: statements
         type: node
       - name: end_keyword
         type: token
-    location: for_keyword->statement
+    location: for_keyword->statements
     comment: |
       Represents the use of the `for` keyword.
 

--- a/config.yml
+++ b/config.yml
@@ -772,6 +772,16 @@ nodes:
 
           module Foo end
           ^^^^^^^^^^^^^^
+  - name: MultiLeftHandNode
+    child_nodes:
+      - name: targets
+        type: node[]
+    location: targets
+    comment: |
+      Represents a multi-left-hand expression.
+
+        a, b, c = 1, 2, 3
+        ^^^^^^^
   - name: NextNode
     child_nodes:
       - name: keyword

--- a/config.yml
+++ b/config.yml
@@ -1231,19 +1231,21 @@ nodes:
           ^^^^^^^^^^^^^^^^^^^^
   - name: ForNode
     child_nodes:
-      - name: keyword
+      - name: for_keyword
         type: token
       - name: index
         type: node
-      - name: keyword_in
+      - name: in_keyword
         type: token
       - name: collection
         type: node
+      - name: do_keyword
+        type: token?
       - name: statement
         type: node
       - name: end_keyword
-        type: token?
-    location: keyword->statement
+        type: token
+    location: for_keyword->statement
     comment: |
       Represents the use of the `for` keyword.
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -81,6 +81,7 @@ typedef enum {
   YP_CONTEXT_EMBEXPR,  // an interpolated expression
   YP_CONTEXT_BEGIN,    // a begin statement
   YP_CONTEXT_SCLASS,   // a singleton class definition
+  YP_CONTEXT_FOR,      // a for loop
 } yp_context_t;
 
 // This is a node in a linked list of contexts.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1,4 +1,5 @@
 #include "yarp.h"
+#include "ast.h"
 #include "error.h"
 #include "node.h"
 
@@ -2059,6 +2060,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       yp_node_t *parent_scope = parser->current_scope;
       parser->current_scope = scope;
 
+      accept(parser, YP_TOKEN_SEMICOLON);
       accept(parser, YP_TOKEN_NEWLINE);
 
       yp_node_t *statements = parse_statements(parser, YP_CONTEXT_FOR);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2035,6 +2035,9 @@ parse_expression_prefix(yp_parser_t *parser) {
     }
     case YP_TOKEN_KEYWORD_FALSE:
       return yp_node_false_node_create(parser, &parser->previous);
+    case YP_TOKEN_KEYWORD_FOR:
+      printf("GOT HERE!\n");
+      return NULL;
     case YP_TOKEN_KEYWORD_IF:
       return parse_conditional(parser, YP_CONTEXT_IF);
     case YP_TOKEN_KEYWORD_UNDEF: {

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1,7 +1,4 @@
 #include "yarp.h"
-#include "ast.h"
-#include "error.h"
-#include "node.h"
 
 #define STRINGIZE0(expr) #expr
 #define STRINGIZE(expr) STRINGIZE0(expr)

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2047,9 +2047,6 @@ parse_expression_prefix(yp_parser_t *parser) {
       yp_token_t for_keyword = parser->previous;
       yp_node_t *index = parse_left_hand_side(parser, BINDING_POWER_INDEX, "Expected index after for.");
 
-      // expect(parser, YP_TOKEN_COMMA, "Expected comma.");
-      // parse_expression(parser, BINDING_POWER_INDEX, "Expected index after for.");
-
       expect(parser, YP_TOKEN_KEYWORD_IN, "Expected keyword in.");
       yp_token_t in_keyword = parser->previous;
 
@@ -2778,29 +2775,23 @@ parse_expression(yp_parser_t *parser, binding_power_t binding_power, const char 
 
 static yp_node_t *
 parse_left_hand_side(yp_parser_t *parser, binding_power_t binding_power, const char *message) {
-  yp_node_t *node = parse_expression(parser, binding_power, message);
+  yp_node_t *first_target = parse_expression(parser, binding_power, message);
 
-  if(!accept(parser, YP_TOKEN_COMMA)) {
-    return node;
+  if(parser->current.type != YP_TOKEN_COMMA) {
+    return first_target;
   } else {
     yp_node_t *multi_left_hand = yp_node_multi_left_hand_node_create(parser);
-    yp_node_t *target = parse_expression(parser, binding_power, message);
+    yp_node_t *target;
 
-    yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, node);
-    yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, target);
+    yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, first_target);
 
-    // while(accept(parser, YP_TOKEN_COMMA)) {
-    //   *target = parse_expression(parser, binding_power, message);
-    //   yp_node_list_append(parser, params, &params->as.parameters_node.optionals, param);
-    // }
+    while(accept(parser, YP_TOKEN_COMMA)) {
+      target = parse_expression(parser, binding_power, message);
+      yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, target);
+    }
 
     return multi_left_hand;
-
   }
-
-  // while(accept(parser, YP_TOKEN_COMMA)) {
-  //   yp_node_t *node = parse_expression(parser, BINDING_POWER_INDEX, "TODO: write me");
-  // }
 }
 
 static yp_node_t *

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1476,7 +1476,26 @@ static yp_node_t *
 parse_expression(yp_parser_t *parser, binding_power_t binding_power, const char *message);
 
 static yp_node_t *
-parse_left_hand_side(yp_parser_t *parser, binding_power_t binding_power, const char *message);
+parse_left_hand_side(yp_parser_t *parser, binding_power_t binding_power, const char *message) {
+  yp_node_t *first_target = parse_expression(parser, binding_power, message);
+
+  if(parser->current.type != YP_TOKEN_COMMA) {
+    return first_target;
+  } else {
+    yp_node_t *multi_left_hand = yp_node_multi_left_hand_node_create(parser);
+    yp_node_t *target;
+
+    yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, first_target);
+
+    while(accept(parser, YP_TOKEN_COMMA)) {
+      target = parse_expression(parser, binding_power, message);
+      yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, target);
+    }
+
+    return multi_left_hand;
+  }
+}
+
 
 static yp_node_t *
 parse_statements(yp_parser_t *parser, yp_context_t context) {
@@ -2768,27 +2787,6 @@ parse_expression(yp_parser_t *parser, binding_power_t binding_power, const char 
   }
 
   return node;
-}
-
-static yp_node_t *
-parse_left_hand_side(yp_parser_t *parser, binding_power_t binding_power, const char *message) {
-  yp_node_t *first_target = parse_expression(parser, binding_power, message);
-
-  if(parser->current.type != YP_TOKEN_COMMA) {
-    return first_target;
-  } else {
-    yp_node_t *multi_left_hand = yp_node_multi_left_hand_node_create(parser);
-    yp_node_t *target;
-
-    yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, first_target);
-
-    while(accept(parser, YP_TOKEN_COMMA)) {
-      target = parse_expression(parser, binding_power, message);
-      yp_node_list_append(parser, multi_left_hand, &multi_left_hand->as.multi_left_hand_node.targets, target);
-    }
-
-    return multi_left_hand;
-  }
 }
 
 static yp_node_t *

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1,4 +1,6 @@
 #include "yarp.h"
+#include "error.h"
+#include "node.h"
 
 #define STRINGIZE0(expr) #expr
 #define STRINGIZE(expr) STRINGIZE0(expr)
@@ -2443,14 +2445,12 @@ parse_expression_prefix(yp_parser_t *parser) {
     }
     default:
       if (context_recoverable(parser, &parser->previous)) {
-        parser->current = parser->previous;
-        parser->previous = recoverable;
         parser->recovering = true;
-        return yp_node_missing_node_create(parser, parser->previous.start - parser->start);
       }
 
-      fprintf(stderr, "Could not understand token type %s in the prefix position\n", yp_token_type_to_str(parser->previous.type));
-      return NULL;
+      parser->current = parser->previous;
+      parser->previous = recoverable;
+      return yp_node_missing_node_create(parser, parser->previous.start - parser->start);
   }
 }
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -96,27 +96,27 @@ class ErrorsTest < Test::Unit::TestCase
   end
 
   test "unterminated embdoc" do
-    assert_errors expression("1"), "1\n=begin\n", "Unterminated embdoc"
+    assert_errors expression("1"), "1\n=begin\n", ["Unterminated embdoc"]
   end
 
   test "unterminated %i list" do
-    assert_errors expression("%i["), "%i[", "Expected a closing delimiter for a `%i` list."
+    assert_errors expression("%i["), "%i[", ["Expected a closing delimiter for a `%i` list."]
   end
 
   test "unterminated %w list" do
-    assert_errors expression("%w["), "%w[", "Expected a closing delimiter for a `%w` list."
+    assert_errors expression("%w["), "%w[", ["Expected a closing delimiter for a `%w` list."]
   end
 
   test "unterminated %W list" do
-    assert_errors expression("%W["), "%W[", "Expected a closing delimiter for a `%W` list."
+    assert_errors expression("%W["), "%W[", ["Expected a closing delimiter for a `%W` list."]
   end
 
   test "unterminated regular expression" do
-    assert_errors expression("/hello"), "/hello", "Expected a closing delimiter for a regular expression."
+    assert_errors expression("/hello"), "/hello", ["Expected a closing delimiter for a regular expression."]
   end
 
   test "unterminated string" do
-    assert_errors expression('"hello'), '"hello', "Expected a closing delimiter for an interpolated string."
+    assert_errors expression('"hello'), '"hello', ["Expected a closing delimiter for an interpolated string."]
   end
 
   private

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1282,7 +1282,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "class << self;1 + 2;end"
   end
 
-  test "for loops" do
+  test "for loop" do
     expected = ForNode(
       KEYWORD_FOR("for"),
       expression("i"),
@@ -1295,6 +1295,62 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "for i in 1..10\ni\nend"
   end
+
+  test "for loop with do keyword" do
+    expected = ForNode(
+      KEYWORD_FOR("for"),
+      expression("i"),
+      KEYWORD_IN("in"),
+      expression("1..10"),
+      KEYWORD_DO("do"),
+      Statements([expression("i")]),
+      KEYWORD_END("end"),
+    )
+
+    assert_parses expected, "for i in 1..10 do\ni\nend"
+  end
+
+  test "for loop no newlines" do
+    expected = ForNode(
+      KEYWORD_FOR("for"),
+      expression("i"),
+      KEYWORD_IN("in"),
+      expression("1..10"),
+      nil,
+      Statements([expression("i")]),
+      KEYWORD_END("end"),
+    )
+
+    assert_parses expected, "for i in 1..10 i end"
+  end
+
+  test "for loop with semicolons" do
+    expected = ForNode(
+      KEYWORD_FOR("for"),
+      expression("i"),
+      KEYWORD_IN("in"),
+      expression("1..10"),
+      nil,
+      Statements([expression("i")]),
+      KEYWORD_END("end"),
+    )
+
+    assert_parses expected, "for i in 1..10; i; end"
+  end
+
+  # test "for loops" do
+  #   expected = ForNode(
+  #     KEYWORD_FOR("for"),
+  #     expression("i"),
+  #     KEYWORD_IN("in"),
+  #     expression("1..10"),
+  #     nil,
+  #     Statements([expression("i")]),
+  #     KEYWORD_END("end"),
+  #   )
+
+  #   assert_parses expected, "for i,j in 1..10\ni\nend"
+  # end
 
   private
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1288,6 +1288,7 @@ class ParseTest < Test::Unit::TestCase
       expression("i"),
       KEYWORD_IN("in"),
       expression("1..10"),
+      nil,
       Statements([expression("i")]),
       KEYWORD_END("end"),
     )

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1338,7 +1338,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "for i in 1..10; i; end"
   end
 
-  test "for loop with destructured index" do
+  test "for loop with 2 indexes" do
     expected = ForNode(
       KEYWORD_FOR("for"),
       MultiLeftHandNode([
@@ -1353,6 +1353,24 @@ class ParseTest < Test::Unit::TestCase
     )
 
     assert_parses expected, "for i,j in 1..10\ni\nend"
+  end
+
+  test "for loop with 3 indexes" do
+    expected = ForNode(
+      KEYWORD_FOR("for"),
+      MultiLeftHandNode([
+        expression("i"),
+        expression("j"),
+        expression("k"),
+      ]),
+      KEYWORD_IN("in"),
+      expression("1..10"),
+      nil,
+      Statements([expression("i")]),
+      KEYWORD_END("end"),
+    )
+
+    assert_parses expected, "for i,j,k in 1..10\ni\nend"
   end
 
   private

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1177,7 +1177,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "a if b if c"
   end
 
-   test "begin statements" do
+  test "begin statements" do
     expected = BeginNode(
       KEYWORD_BEGIN("begin"),
       Statements([expression("a")]),
@@ -1190,7 +1190,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "begin a; end"
   end
 
-   test "endless method definition without arguments" do
+  test "endless method definition without arguments" do
     expected = DefNode(
       KEYWORD_DEF("def"),
       IDENTIFIER("foo"),
@@ -1206,7 +1206,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "def foo = 123"
   end
 
-   test "endless method definition with arguments" do
+  test "endless method definition with arguments" do
     expected = DefNode(
       KEYWORD_DEF("def"),
       IDENTIFIER("foo"),
@@ -1280,6 +1280,19 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "class << self\n1 + 2\nend"
     assert_parses expected, "class << self;1 + 2;end"
+  end
+
+  test "for loops" do
+    expected = ForNode(
+      KEYWORD_FOR("for"),
+      expression("i"),
+      KEYWORD_IN("in"),
+      expression("1..10"),
+      Statements([expression("i")]),
+      KEYWORD_END("end"),
+    )
+
+    assert_parses expected, "for i in a\nend"
   end
 
   private

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1293,7 +1293,7 @@ class ParseTest < Test::Unit::TestCase
       KEYWORD_END("end"),
     )
 
-    assert_parses expected, "for i in a\nend"
+    assert_parses expected, "for i in 1..10\ni\nend"
   end
 
   private

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1338,19 +1338,22 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "for i in 1..10; i; end"
   end
 
-  # test "for loops" do
-  #   expected = ForNode(
-  #     KEYWORD_FOR("for"),
-  #     expression("i"),
-  #     KEYWORD_IN("in"),
-  #     expression("1..10"),
-  #     nil,
-  #     Statements([expression("i")]),
-  #     KEYWORD_END("end"),
-  #   )
+  test "for loop with destructured index" do
+    expected = ForNode(
+      KEYWORD_FOR("for"),
+      MultiLeftHandNode([
+        expression("i"),
+        expression("j"),
+      ]),
+      KEYWORD_IN("in"),
+      expression("1..10"),
+      nil,
+      Statements([expression("i")]),
+      KEYWORD_END("end"),
+    )
 
-  #   assert_parses expected, "for i,j in 1..10\ni\nend"
-  # end
+    assert_parses expected, "for i,j in 1..10\ni\nend"
+  end
 
   private
 


### PR DESCRIPTION
This PR implements parsing for loops in the structure:

```ruby
for i in 0..10 do
  i # or some other expression here
end
```

This PR handles multiple indexes e.g. `for i, j in 0..10` and makes error handling more robust.