### PR TITLE
Implement dynamic symbols

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -698,6 +698,20 @@ nodes:
 
           "foo #{bar} baz"
           ^^^^^^^^^^^^^^^^
+  - name: InterpolatedSymbolNode
+    child_nodes:
+      - name: opening
+        type: token?
+      - name: parts
+        type: node[]
+      - name: closing
+        type: token?
+    location: opening|parts->closing|parts
+    comment: |
+      Represents a symbol literal that contains interpolation.
+
+          :"foo #{bar} baz"
+          ^^^^^^^^^^^^^^^^^
   - name: KeywordParameterNode
     child_nodes:
       - name: name

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1774,6 +1774,68 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
   return parent;
 }
 
+static yp_node_t*
+parse_symbol(yp_parser_t *parser, int mode) {
+  yp_token_t opening = parser->previous;
+
+  if (mode == YP_LEX_SYMBOL) {
+    yp_token_t symbol = parser->current;
+    parser_lex(parser);
+
+    yp_token_t closing;
+    not_provided(&closing, parser->previous.end);
+
+    return yp_node_symbol_node_create(parser, &opening, &symbol, &closing);
+  }
+
+  if (parser->lex_modes.current->interp) {
+    yp_node_t *interpolated = yp_node_interpolated_symbol_node_create(parser, &opening, &opening);
+
+    while (parser->current.type != YP_TOKEN_STRING_END && parser->current.type != YP_TOKEN_EOF) {
+      switch (parser->current.type) {
+        case YP_TOKEN_STRING_CONTENT: {
+          parser_lex(parser);
+
+          yp_token_t string_content_opening;
+          not_provided(&string_content_opening, parser->previous.start);
+
+          yp_token_t string_content_closing;
+          not_provided(&string_content_closing, parser->previous.end);
+
+          yp_node_list_append(parser, interpolated, &interpolated->as.interpolated_symbol_node.parts, yp_node_string_node_create(parser, &string_content_opening, &parser->previous, &string_content_closing));
+          break;
+        }
+        case YP_TOKEN_EMBEXPR_BEGIN: {
+          parser_lex(parser);
+          yp_token_t embexpr_opening = parser->previous;
+          yp_node_t *statements = parse_statements(parser, YP_CONTEXT_EMBEXPR);
+          expect(parser, YP_TOKEN_EMBEXPR_END, "Expected a closing delimiter for an embedded expression.");
+          yp_node_list_append(parser, interpolated, &interpolated->as.interpolated_symbol_node.parts, yp_node_string_interpolated_node_create(parser, &embexpr_opening, statements, &parser->previous));
+          break;
+        }
+        default:
+          fprintf(stderr, "Could not understand token type %s in an interpolated symbol\n", yp_token_type_to_str(parser->previous.type));
+          return NULL;
+      }
+    }
+
+    expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for an interpolated symbol.");
+    interpolated->as.interpolated_symbol_node.closing = parser->previous;
+    return interpolated;
+  }
+
+  yp_token_t content;
+  if (accept(parser, YP_TOKEN_STRING_CONTENT)) {
+    content = parser->previous;
+  } else {
+    content = (yp_token_t) { .type = YP_TOKEN_STRING_CONTENT, .start = parser->previous.end, .end = parser->previous.end };
+  }
+
+  expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for a dynamic symbol.");
+  return yp_node_symbol_node_create(parser, &opening, &content, &parser->previous);
+
+}
+
 // Parse an argument to alias or undef which can either be a bare word, a
 // symbol, or an interpolated symbol.
 static inline yp_node_t *
@@ -1790,67 +1852,9 @@ parse_alias_or_undef_argument(yp_parser_t *parser) {
       return yp_node_symbol_node_create(parser, &opening, &parser->previous, &closing);
     }
     case YP_TOKEN_SYMBOL_BEGIN: {
-      yp_token_t opening = parser->current;
-
-      if (parser->lex_modes.current->mode == YP_LEX_SYMBOL) {
-        parser_lex(parser);
-        yp_token_t symbol = parser->current;
-        parser_lex(parser);
-
-        yp_token_t closing;
-        not_provided(&closing, parser->previous.end);
-
-        return yp_node_symbol_node_create(parser, &opening, &symbol, &closing);
-      }
-
+      int mode = parser->lex_modes.current->mode;
       parser_lex(parser);
-
-      if (parser->lex_modes.current->interp) {
-        yp_node_t *interpolated = yp_node_interpolated_symbol_node_create(parser, &opening, &opening);
-
-        while (parser->current.type != YP_TOKEN_STRING_END && parser->current.type != YP_TOKEN_EOF) {
-          switch (parser->current.type) {
-            case YP_TOKEN_STRING_CONTENT: {
-              parser_lex(parser);
-
-              yp_token_t string_content_opening;
-              not_provided(&string_content_opening, parser->previous.start);
-
-              yp_token_t string_content_closing;
-              not_provided(&string_content_closing, parser->previous.end);
-
-              yp_node_list_append(parser, interpolated, &interpolated->as.interpolated_symbol_node.parts, yp_node_string_node_create(parser, &string_content_opening, &parser->previous, &string_content_closing));
-              break;
-            }
-            case YP_TOKEN_EMBEXPR_BEGIN: {
-              parser_lex(parser);
-              yp_token_t embexpr_opening = parser->previous;
-              yp_node_t *statements = parse_statements(parser, YP_CONTEXT_EMBEXPR);
-              expect(parser, YP_TOKEN_EMBEXPR_END, "Expected a closing delimiter for an embedded expression.");
-              yp_node_list_append(parser, interpolated, &interpolated->as.interpolated_symbol_node.parts, yp_node_string_interpolated_node_create(parser, &embexpr_opening, statements, &parser->previous));
-              break;
-            }
-            default:
-              fprintf(stderr, "Could not understand token type %s in an interpolated symbol\n", yp_token_type_to_str(parser->previous.type));
-              return NULL;
-          }
-        }
-
-        expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for an interpolated symbol.");
-        interpolated->as.interpolated_symbol_node.closing = parser->previous;
-        return interpolated;
-      }
-
-      yp_token_t content;
-      if (accept(parser, YP_TOKEN_STRING_CONTENT)) {
-        content = parser->previous;
-      } else {
-        content = (yp_token_t) { .type = YP_TOKEN_STRING_CONTENT, .start = parser->previous.end, .end = parser->previous.end };
-      }
-
-      expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for a dynamic symbol.");
-      return yp_node_symbol_node_create(parser, &opening, &content, &parser->previous);
-
+      return parse_symbol(parser, mode);
     }
     default:
       yp_error_list_append(&parser->error_list, "Expected a bare word or symbol argument.", parser->current.start - parser->start);
@@ -1862,6 +1866,7 @@ parse_alias_or_undef_argument(yp_parser_t *parser) {
 static inline yp_node_t *
 parse_expression_prefix(yp_parser_t *parser) {
   yp_token_t recoverable = parser->previous;
+  int mode = parser->lex_modes.current->mode;
   parser_lex(parser);
 
   switch (parser->previous.type) {
@@ -2513,15 +2518,8 @@ parse_expression_prefix(yp_parser_t *parser) {
       expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for a string literal.");
       return yp_node_string_node_create(parser, &opening, &content, &parser->previous);
     }
-    case YP_TOKEN_SYMBOL_BEGIN: {
-      yp_token_t opening = parser->previous;
-      parser_lex(parser);
-
-      yp_token_t closing;
-      not_provided(&closing, parser->previous.end);
-
-      return yp_node_symbol_node_create(parser, &opening, &parser->previous, &closing);
-    }
+    case YP_TOKEN_SYMBOL_BEGIN:
+      return parse_symbol(parser, mode);
     default:
       if (context_recoverable(parser, &parser->previous)) {
         parser->recovering = true;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -712,6 +712,10 @@ lex_token_type(yp_parser_t *parser) {
           if (char_is_identifier(parser, parser->current.end)) {
             lex_mode_push(parser, (yp_lex_mode_t) { .mode = YP_LEX_SYMBOL, .term = '\0' });
             return YP_TOKEN_SYMBOL_BEGIN;
+          } else if ((*parser->current.end == '"') || (*parser->current.end == '\'')) {
+            lex_mode_push(parser, (yp_lex_mode_t) { .mode = YP_LEX_STRING, .term = *parser->current.end, .interp = *parser->current.end == '"' });
+            parser->current.end++;
+            return YP_TOKEN_SYMBOL_BEGIN;
           }
           return YP_TOKEN_COLON;
 
@@ -1049,11 +1053,14 @@ lex_token_type(yp_parser_t *parser) {
       parser->current.start = parser->current.end;
 
       // Lex as far as we can into the symbol.
-      if (parser->current.end < parser->end && char_is_identifier_start(parser, parser->current.end++)) {
-        lex_mode_pop(parser);
+      if (parser->current.end < parser->end) {
+        if (char_is_identifier_start(parser, parser->current.end)) {
+          parser->current.end++;
+          lex_mode_pop(parser);
 
-        yp_token_type_t type = lex_identifier(parser);
-        return match(parser, '=') ? YP_TOKEN_IDENTIFIER : type;
+          yp_token_type_t type = lex_identifier(parser);
+          return match(parser, '=') ? YP_TOKEN_IDENTIFIER : type;
+        }
       }
 
       // If we get here then we have the start of a symbol with no content. In
@@ -1784,15 +1791,66 @@ parse_alias_or_undef_argument(yp_parser_t *parser) {
     }
     case YP_TOKEN_SYMBOL_BEGIN: {
       yp_token_t opening = parser->current;
+
+      if (parser->lex_modes.current->mode == YP_LEX_SYMBOL) {
+        parser_lex(parser);
+        yp_token_t symbol = parser->current;
+        parser_lex(parser);
+
+        yp_token_t closing;
+        not_provided(&closing, parser->previous.end);
+
+        return yp_node_symbol_node_create(parser, &opening, &symbol, &closing);
+      }
+
       parser_lex(parser);
 
-      yp_token_t symbol = parser->current;
-      parser_lex(parser);
+      if (parser->lex_modes.current->interp) {
+        yp_node_t *interpolated = yp_node_interpolated_symbol_node_create(parser, &opening, &opening);
 
-      yp_token_t closing;
-      not_provided(&closing, parser->previous.end);
+        while (parser->current.type != YP_TOKEN_STRING_END && parser->current.type != YP_TOKEN_EOF) {
+          switch (parser->current.type) {
+            case YP_TOKEN_STRING_CONTENT: {
+              parser_lex(parser);
 
-      return yp_node_symbol_node_create(parser, &opening, &symbol, &closing);
+              yp_token_t string_content_opening;
+              not_provided(&string_content_opening, parser->previous.start);
+
+              yp_token_t string_content_closing;
+              not_provided(&string_content_closing, parser->previous.end);
+
+              yp_node_list_append(parser, interpolated, &interpolated->as.interpolated_symbol_node.parts, yp_node_string_node_create(parser, &string_content_opening, &parser->previous, &string_content_closing));
+              break;
+            }
+            case YP_TOKEN_EMBEXPR_BEGIN: {
+              parser_lex(parser);
+              yp_token_t embexpr_opening = parser->previous;
+              yp_node_t *statements = parse_statements(parser, YP_CONTEXT_EMBEXPR);
+              expect(parser, YP_TOKEN_EMBEXPR_END, "Expected a closing delimiter for an embedded expression.");
+              yp_node_list_append(parser, interpolated, &interpolated->as.interpolated_symbol_node.parts, yp_node_string_interpolated_node_create(parser, &embexpr_opening, statements, &parser->previous));
+              break;
+            }
+            default:
+              fprintf(stderr, "Could not understand token type %s in an interpolated symbol\n", yp_token_type_to_str(parser->previous.type));
+              return NULL;
+          }
+        }
+
+        expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for an interpolated symbol.");
+        interpolated->as.interpolated_symbol_node.closing = parser->previous;
+        return interpolated;
+      }
+
+      yp_token_t content;
+      if (accept(parser, YP_TOKEN_STRING_CONTENT)) {
+        content = parser->previous;
+      } else {
+        content = (yp_token_t) { .type = YP_TOKEN_STRING_CONTENT, .start = parser->previous.end, .end = parser->previous.end };
+      }
+
+      expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for a dynamic symbol.");
+      return yp_node_symbol_node_create(parser, &opening, &content, &parser->previous);
+
     }
     default:
       yp_error_list_append(&parser->error_list, "Expected a bare word or symbol argument.", parser->current.start - parser->start);

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ParseTest < Test::Unit::TestCase
   include YARP::DSL
-
+=begin
   test "empty string" do
     YARP.parse("") => YARP::ParseResult[node: YARP::Program[statements: YARP::Statements[body: []]]]
   end
@@ -981,7 +981,34 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "%i[a b c]"
   end
+=end
+  test "dynamic symbol" do
+    expected = AliasNode(
+      KEYWORD_ALIAS("alias"),
+      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("def"), STRING_END("'")),
+      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))
+    )
+    assert_parses expected, "alias :'def' :'abc'"
+  end
 
+  test "dynamic symbol with interpolation" do
+    expected = AliasNode(
+      KEYWORD_ALIAS("alias"),
+      InterpolatedSymbolNode(
+        SYMBOL_BEGIN(":\""),
+        [StringNode(nil, STRING_CONTENT("def"), nil),
+         StringInterpolatedNode(
+           EMBEXPR_BEGIN("\#{"),
+           Statements([expression("1")]),
+           EMBEXPR_END("}")
+         )],
+        STRING_END("\"")
+      ),
+      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))
+    )
+    assert_parses expected, "alias :\"def\#{1}\" :'abc'"
+  end
+=begin
   test "ternary" do
     expected = Ternary(
       CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a"),
@@ -1017,11 +1044,11 @@ class ParseTest < Test::Unit::TestCase
   test "undef bare, multiple" do
     assert_parses UndefNode(KEYWORD_UNDEF("undef"), [SymbolNode(nil, IDENTIFIER("a"), nil), SymbolNode(nil, IDENTIFIER("b"), nil)]), "undef a, b"
   end
-
+=end
   test "undef symbol" do
     assert_parses UndefNode(KEYWORD_UNDEF("undef"), [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil)]), "undef :a"
   end
-
+=begin
   test "undef symbol, multiple" do
     expected = UndefNode(
       KEYWORD_UNDEF("undef"),
@@ -1372,7 +1399,7 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "for i,j,k in 1..10\ni\nend"
   end
-
+=end
   private
 
   def assert_serializes(expected, source)

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1004,10 +1004,10 @@ class ParseTest < Test::Unit::TestCase
   test "alias with dynamic symbol" do
     expected = AliasNode(
       KEYWORD_ALIAS("alias"),
-      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("def"), STRING_END("'")),
-      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))
+      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'")),
+      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("def"), STRING_END("'"))
     )
-    assert_parses expected, "alias :'def' :'abc'"
+    assert_parses expected, "alias :'abc' :'def'"
   end
 
   test "alias with dynamic symbol with interpolation" do
@@ -1015,7 +1015,7 @@ class ParseTest < Test::Unit::TestCase
       KEYWORD_ALIAS("alias"),
       InterpolatedSymbolNode(
         SYMBOL_BEGIN(":\""),
-        [StringNode(nil, STRING_CONTENT("def"), nil),
+        [StringNode(nil, STRING_CONTENT("abc"), nil),
          StringInterpolatedNode(
            EMBEXPR_BEGIN("\#{"),
            Statements([expression("1")]),
@@ -1023,9 +1023,34 @@ class ParseTest < Test::Unit::TestCase
          )],
         STRING_END("\"")
       ),
-      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))
+      SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("def"), STRING_END("'"))
     )
-    assert_parses expected, "alias :\"def\#{1}\" :'abc'"
+    assert_parses expected, "alias :\"abc\#{1}\" :'def'"
+  end
+
+  test "undef with dynamic symbols" do
+    expected = UndefNode(
+      KEYWORD_UNDEF("undef"),
+      [SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))]
+    )
+    assert_parses expected, "undef :'abc'"
+  end
+
+  test "undef with dynamic symbols with interpolation" do
+    expected = UndefNode(
+      KEYWORD_UNDEF("undef"),
+      [InterpolatedSymbolNode(
+         SYMBOL_BEGIN(":\""),
+         [StringNode(nil, STRING_CONTENT("abc"), nil),
+          StringInterpolatedNode(
+            EMBEXPR_BEGIN("\#{"),
+            Statements([expression("1")]),
+            EMBEXPR_END("}")
+          )],
+         STRING_END("\"")
+       )]
+    )
+    assert_parses expected, "undef :\"abc\#{1}\""
   end
 
   test "ternary" do

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ParseTest < Test::Unit::TestCase
   include YARP::DSL
-=begin
+
   test "empty string" do
     YARP.parse("") => YARP::ParseResult[node: YARP::Program[statements: YARP::Statements[body: []]]]
   end
@@ -981,8 +981,27 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "%i[a b c]"
   end
-=end
+
   test "dynamic symbol" do
+    expected = SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))
+    assert_parses expected, ":'abc'"
+  end
+
+  test "dynamic symbol with interpolation" do
+    expected = InterpolatedSymbolNode(
+      SYMBOL_BEGIN(":\""),
+      [StringNode(nil, STRING_CONTENT("abc"), nil),
+       StringInterpolatedNode(
+         EMBEXPR_BEGIN("\#{"),
+         Statements([expression("1")]),
+         EMBEXPR_END("}")
+       )],
+      STRING_END("\"")
+    )
+    assert_parses expected, ":\"abc\#{1}\""
+  end
+
+  test "alias with dynamic symbol" do
     expected = AliasNode(
       KEYWORD_ALIAS("alias"),
       SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("def"), STRING_END("'")),
@@ -991,7 +1010,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "alias :'def' :'abc'"
   end
 
-  test "dynamic symbol with interpolation" do
+  test "alias with dynamic symbol with interpolation" do
     expected = AliasNode(
       KEYWORD_ALIAS("alias"),
       InterpolatedSymbolNode(
@@ -1008,7 +1027,7 @@ class ParseTest < Test::Unit::TestCase
     )
     assert_parses expected, "alias :\"def\#{1}\" :'abc'"
   end
-=begin
+
   test "ternary" do
     expected = Ternary(
       CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a"),
@@ -1044,11 +1063,11 @@ class ParseTest < Test::Unit::TestCase
   test "undef bare, multiple" do
     assert_parses UndefNode(KEYWORD_UNDEF("undef"), [SymbolNode(nil, IDENTIFIER("a"), nil), SymbolNode(nil, IDENTIFIER("b"), nil)]), "undef a, b"
   end
-=end
+
   test "undef symbol" do
     assert_parses UndefNode(KEYWORD_UNDEF("undef"), [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil)]), "undef :a"
   end
-=begin
+
   test "undef symbol, multiple" do
     expected = UndefNode(
       KEYWORD_UNDEF("undef"),
@@ -1399,7 +1418,7 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "for i,j,k in 1..10\ni\nend"
   end
-=end
+
   private
 
   def assert_serializes(expected, source)


### PR DESCRIPTION
Closes #118 

This PR implements parsing for dynamic symbols:
```ruby 
:'abc'
:"abc#{123}"
alias :'abc' :'def'
undef :"abc#{123}"
```