### PR TITLE
Implement StringConcat

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1134,6 +1134,18 @@ nodes:
 
           foo; bar; baz
           ^^^^^^^^^^^^^
+  - name: StringConcatNode
+    child_nodes:
+      - name: left
+        type: node
+      - name: right
+        type: node
+    location: left->right
+    comment: |
+      Represents string concatenation with or without a backslash.
+
+          "foo" "bar"
+          ^^^^^^^^^^^
   - name: StringInterpolatedNode
     child_nodes:
       - name: opening

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1690,6 +1690,17 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "begin a; ensure b; end"
   end
 
+  test "string concatenation" do
+    expected = StringConcatNode(
+      StringNode(STRING_BEGIN("'"), STRING_CONTENT("foo"), STRING_END("'"), "foo"),
+      StringNode(STRING_BEGIN("'"), STRING_CONTENT("bar"), STRING_END("'"), "bar"),
+    )
+
+    assert_parses expected, "'foo' 'bar'"
+    assert_parses expected, "'foo' \ 'bar'"
+    assert_parses expected, "'foo' \\\n 'bar'"
+  end
+
   private
 
   def assert_serializes(expected, source)


### PR DESCRIPTION
Closes #115

Implement string concatenation node. I based it on the current behaviour in Ruby, where it will ignore as many blank spaces as there are after a backslash, but only ignores a single newline. E.g.:
```ruby
"foo" \             "bar" # => "foobar"

"foo" \





  "bar" # => "bar" (doesn't seem to include the "foo")
```

I extracted the logic to advance the parser during lexing on blank spaces and line breaks and tried reusing it. The backslash part is not working just yet.