### PR TITLE
Add documentation about running tests and installing bear

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ If you want to contribute code, please first open or contribute to a discussion.
 
 We could always use more tests! One of the biggest challenges of this project is building up a big test suite. If you want to contribute tests, feel free to open a pull request. These will get merged in as soon as possible.
 
+We can run the native (C) tests with `make test`.
+
+We can run the Ruby tests with `rake` (you will need to run `bundle` before)
+
 ## Documentation
 
 We could always use more documentation! If you want to contribute documentation, feel free to open a pull request. These will get merged in as soon as possible. Documenting functions or methods is always useful, but we also need more guides and tutorials. If you have an idea for a guide or tutorial, feel free to open an issue and we can discuss it.
@@ -22,6 +26,8 @@ We could always use more documentation! If you want to contribute documentation,
 
 To get `clangd` support in the editor for development, generate the compilation database. This command will
 create an ignored `compile_commands.json` file at the project root, which is used by clangd to provide functionality.
+
+You will need `bear` which can be installed on macOS with `brew install bear`.
 
 ```sh
 bundle exec rake generate_compilation_database


### PR DESCRIPTION
When setting up the project it wasn't clear how to run the tests and generate the compilation database.