### PR TITLE
Implement other symbols

### DIFF
--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1841,6 +1841,35 @@ class ParseTest < Test::Unit::TestCase
     assert_parses SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil), ":a"
   end
 
+  test "keyword symbol" do
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), KEYWORD_SELF("self"), nil), ":self"
+  end
+
+  test "constant symbol" do
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), CONSTANT("Foo"), nil), ":Foo"
+  end
+
+  test "instance variable symbol" do
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), INSTANCE_VARIABLE("@foo"), nil), ":@foo"
+  end
+
+  test "class variable symbol" do
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), CLASS_VARIABLE("@@foo"), nil), ":@@foo"
+  end
+
+  test "operator symbol" do
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), PLUS("+"), nil), ":+"
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), PLUS_AT("+@"), nil), ":+@"
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), MINUS_AT("-@"), nil), ":-@"
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), TILDE_AT("~@"), nil), ":~@"
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), BANG_AT("!@"), nil), ":!@"
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), BRACKET_LEFT_RIGHT("[]"), nil), ":[]"
+  end
+
+  test "global variable symbol" do
+    assert_parses SymbolNode(SYMBOL_BEGIN(":"), GLOBAL_VARIABLE("$foo"), nil), ":$foo"
+  end
+
   test "symbol list" do
     expected = ArrayNode(
       PERCENT_LOWER_I("%i["),


### PR DESCRIPTION
I'm not 100% convinced of what I did (especially when we encounter an error) but here's a quick summary:

* When lexing, I used the presence of whitespace in the next character after a ":" to return an early `SYMBOL_COLON` (Natalie's parser is doing something similar) and correctly determine the start of a symbol. 

* Next when lexing with the `LEX_SYMBOL` mode, I used the same behavior as the `LEX_DEFAULT` mode to get all the tokens independently of being within a symbol, and let the parsing determine what is a correct symbol. It seems to match what Ripper does. 

* Then in parsing, I made a manual list of allowed tokens for symbols. Upon finding an unallowed one, I ended up returning a `TOKEN_INVALID` to fill the `SymbolNode` but it does not feel right. 

I also found an infinite loop when trying to parse `send(:[invalid])` but not when parsing `:[invalid]` nor `send(:[invalid)` which really makes me think I missed something in the error case 😅 

Closes #159 