### PR TITLE
Support **nil in method signature

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -822,6 +822,17 @@ nodes:
 
           nil
           ^^^
+  - name: NoKeywordsParameterNode
+    child_nodes:
+      - name: keyword
+        type: token
+    location: keyword
+    comment: |
+      Represents the use of `**nil` inside method arguments.
+
+          def a(**nil)
+                ^^^^^
+          end
   - name: OperatorAssignmentNode
     child_nodes:
       - name: target

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1711,6 +1711,9 @@ parse_parameters(yp_parser_t *parser) {
         if (accept(parser, YP_TOKEN_IDENTIFIER)) {
           name = parser->previous;
           yp_token_list_append(&parser->current_scope->as.scope.locals, &name);
+        } else if (accept(parser, YP_TOKEN_KEYWORD_NIL)) {
+          name = parser->previous;
+          yp_token_list_append(&parser->current_scope->as.scope.locals, &name);
         } else {
           not_provided(&name, parser->previous.end);
         }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1705,20 +1705,24 @@ parse_parameters(yp_parser_t *parser) {
       case YP_TOKEN_STAR_STAR: {
         parser_lex(parser);
 
-        yp_token_t operator = parser->previous;
-        yp_token_t name;
+        yp_node_t *param;
 
-        if (accept(parser, YP_TOKEN_IDENTIFIER)) {
-          name = parser->previous;
-          yp_token_list_append(&parser->current_scope->as.scope.locals, &name);
-        } else if (accept(parser, YP_TOKEN_KEYWORD_NIL)) {
-          name = parser->previous;
-          yp_token_list_append(&parser->current_scope->as.scope.locals, &name);
+        if (accept(parser, YP_TOKEN_KEYWORD_NIL)) {
+          param = yp_node_no_keywords_parameter_node_create(parser, &parser->previous);
         } else {
-          not_provided(&name, parser->previous.end);
+          yp_token_t operator = parser->previous;
+          yp_token_t name;
+
+          if (accept(parser, YP_TOKEN_IDENTIFIER)) {
+            name = parser->previous;
+            yp_token_list_append(&parser->current_scope->as.scope.locals, &name);
+          } else {
+            not_provided(&name, parser->previous.end);
+          }
+
+          param = yp_node_keyword_rest_parameter_node_create(parser, &operator, &name);
         }
 
-        yp_node_t *param = yp_node_keyword_rest_parameter_node_create(parser, &operator, &name);
         params->as.parameters_node.keyword_rest = param;
         if (!accept(parser, YP_TOKEN_COMMA)) parsing = false;
         break;

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -657,6 +657,29 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "def a &\nend"
   end
 
+  test "def with **nil" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("m"),
+      nil,
+      ParametersNode(
+        [RequiredParameterNode(IDENTIFIER("a"))],
+        [],
+        nil,
+        [KeywordParameterNode(LABEL("b:"))],
+        KeywordRestParameterNode(STAR_STAR("**"), KEYWORD_NIL("nil")),
+        nil
+      ),
+      nil,
+      nil,
+      Statements([]),
+      KEYWORD_END("end"),
+      Scope([IDENTIFIER("a"), LABEL("b"), KEYWORD_NIL("nil")])
+    )
+
+    assert_parses expected, "def m a, b:, **nil\nend"
+  end
+
   test "defined? without parentheses" do
     assert_parses DefinedNode(KEYWORD_DEFINED("defined?"), nil, expression("1"), nil), "defined? 1"
   end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -667,14 +667,14 @@ class ParseTest < Test::Unit::TestCase
         [],
         nil,
         [KeywordParameterNode(LABEL("b:"))],
-        KeywordRestParameterNode(STAR_STAR("**"), KEYWORD_NIL("nil")),
+        NoKeywordsParameterNode(KEYWORD_NIL("nil")),
         nil
       ),
       nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("a"), LABEL("b"), KEYWORD_NIL("nil")])
+      Scope([IDENTIFIER("a"), LABEL("b")])
     )
 
     assert_parses expected, "def m a, b:, **nil\nend"


### PR DESCRIPTION
Added support for `**nil`, please let me know if the test is correct (maybe we want to wrap in `NilNode`?)

Closes #160