### PR TITLE
Implement safe operator

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,8 @@ tokens:
     comment: "&&"
   - name: AMPERSAND_AMPERSAND_EQUAL
     comment: "&&="
+  - name: AMPERSAND_DOT
+    comment: "&."
   - name: AMPERSAND_EQUAL
     comment: "&="
   - name: BACK_REFERENCE

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -211,6 +211,7 @@ module YARP
     AMPERSAND: :on_op,
     AMPERSAND_AMPERSAND: :on_op,
     AMPERSAND_AMPERSAND_EQUAL: :on_op,
+    AMPERSAND_DOT: :on_op,
     AMPERSAND_EQUAL: :on_op,
     BACK_REFERENCE: :on_backref,
     BACKTICK: :on_backtick,

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -666,6 +666,8 @@ lex_token_type(yp_parser_t *parser) {
         case '&':
           if (match(parser, '&'))
             return match(parser, '=') ? YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL : YP_TOKEN_AMPERSAND_AMPERSAND;
+          if (match(parser, '.'))
+            return YP_TOKEN_AMPERSAND_DOT;
           return match(parser, '=') ? YP_TOKEN_AMPERSAND_EQUAL : YP_TOKEN_AMPERSAND;
 
         // | || ||= |=
@@ -1413,9 +1415,10 @@ binding_powers_t binding_powers[YP_TOKEN_MAXIMUM] = {
   // []
   [YP_TOKEN_BRACKET_LEFT_RIGHT] = LEFT_ASSOCIATIVE(BINDING_POWER_INDEX),
 
-  // :: .
+  // :: . &.
   [YP_TOKEN_COLON_COLON] = RIGHT_ASSOCIATIVE(BINDING_POWER_CALL),
-  [YP_TOKEN_DOT] = RIGHT_ASSOCIATIVE(BINDING_POWER_CALL)
+  [YP_TOKEN_DOT] = RIGHT_ASSOCIATIVE(BINDING_POWER_CALL),
+  [YP_TOKEN_AMPERSAND_DOT] = RIGHT_ASSOCIATIVE(BINDING_POWER_CALL)
 };
 
 #undef LEFT_ASSOCIATIVE
@@ -2716,6 +2719,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, binding_power_t bin
 
       return yp_node_call_node_create(parser, node, &call_operator, &token, &lparen, arguments, &rparen, name);
     }
+    case YP_TOKEN_AMPERSAND_DOT:
     case YP_TOKEN_DOT: {
       yp_token_t call_operator = parser->previous;
 

--- a/test/fixtures/lex.rb
+++ b/test/fixtures/lex.rb
@@ -182,3 +182,5 @@ def ~@() end
 abc.~@
 
 `abc`
+
+abc&.xyz

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -307,6 +307,77 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "a.b(c, d)"
   end
 
+  test "safe call" do
+    expected = CallNode(
+      expression("a"),
+      AMPERSAND_DOT("&."),
+      IDENTIFIER("b"),
+      nil,
+      nil,
+      nil,
+      "b"
+    )
+
+    assert_parses expected, "a&.b"
+  end
+
+  test "safe call with &.() shorthand and no arguments" do
+    expected = CallNode(
+      expression("a"),
+      AMPERSAND_DOT("&."),
+      NOT_PROVIDED(""),
+      PARENTHESIS_LEFT("("),
+      nil,
+      PARENTHESIS_RIGHT(")"),
+      "call"
+    )
+
+    assert_parses expected, "a&.()"
+  end
+
+  test "safe call with parentheses and no arguments" do
+    expected = CallNode(
+      expression("a"),
+      AMPERSAND_DOT("&."),
+      IDENTIFIER("b"),
+      PARENTHESIS_LEFT("("),
+      nil,
+      PARENTHESIS_RIGHT(")"),
+      "b"
+    )
+
+    assert_parses expected, "a&.b()"
+  end
+
+  test "safe call with parentheses and arguments" do
+    expected = CallNode(
+      expression("a"),
+      AMPERSAND_DOT("&."),
+      IDENTIFIER("b"),
+      PARENTHESIS_LEFT("("),
+      ArgumentsNode([expression("c")]),
+      PARENTHESIS_RIGHT(")"),
+      "b"
+    )
+
+    assert_parses expected, "a&.b(c)"
+  end
+
+  test "safe call with non identifier method name" do
+    omit("non identifier method call")
+    expected = CallNode(
+      IntegerLiteral(INTEGER("1")),
+      AMPERSAND_DOT("&."),
+      MINUS_AT("-@"),
+      nil,
+      nil,
+      nil,
+      "b"
+    )
+
+    assert_parses expected, "1&.-@"
+  end
+
   test "character literal" do
     assert_parses StringNode(STRING_BEGIN("?"), STRING_CONTENT("a"), nil), "?a"
   end


### PR DESCRIPTION
I added the new token in lexer and used it in the parser to behave like the `.` operator.

I added a test that does not pass yet, using `omit` but I wasn't sure if there was a better way or if we do not want failing tests at the moment. I did not fix it as I didn't think it was part of this PR's scope.

Closes #156