### PR TITLE
Handle %I interpolated symbols

### DIFF
--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -982,6 +982,60 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "%i[a b c]"
   end
 
+  test "symbol list with ignored interpolation" do
+    expected = ArrayNode(
+      PERCENT_LOWER_I("%i["),
+      [SymbolNode(nil, STRING_CONTENT("a"), nil),
+       SymbolNode(nil, STRING_CONTENT("b\#{1}"), nil),
+       SymbolNode(nil, STRING_CONTENT("\#{2}c"), nil),
+       SymbolNode(nil, STRING_CONTENT("d\#{3}f"), nil)],
+      STRING_END("]")
+    )
+
+    assert_parses expected, "%i[a b\#{1} \#{2}c d\#{3}f]"
+  end
+
+  test "symbol list with interpreted interpolation" do
+    expected = ArrayNode(
+      PERCENT_UPPER_I("%I["),
+      [SymbolNode(nil, STRING_CONTENT("a"), nil),
+       InterpolatedSymbolNode(
+         nil,
+         [SymbolNode(nil, STRING_CONTENT("b"), nil),
+          StringInterpolatedNode(
+            EMBEXPR_BEGIN("\#{"),
+            Statements([IntegerLiteral(INTEGER("1"))]),
+            EMBEXPR_END("}")
+          )],
+         nil
+       ),
+       InterpolatedSymbolNode(
+         nil,
+         [StringInterpolatedNode(
+            EMBEXPR_BEGIN("\#{"),
+            Statements([IntegerLiteral(INTEGER("2"))]),
+            EMBEXPR_END("}")
+          ),
+          SymbolNode(nil, STRING_CONTENT("c"), nil)],
+         nil
+       ),
+       InterpolatedSymbolNode(
+         nil,
+         [SymbolNode(nil, STRING_CONTENT("d"), nil),
+          StringInterpolatedNode(
+            EMBEXPR_BEGIN("\#{"),
+            Statements([IntegerLiteral(INTEGER("3"))]),
+            EMBEXPR_END("}")
+          ),
+          SymbolNode(nil, STRING_CONTENT("f"), nil)],
+         nil
+       )],
+      STRING_END("]")
+    )
+
+    assert_parses expected, "%I[a b\#{1} \#{2}c d\#{3}f]"
+  end
+
   test "dynamic symbol" do
     expected = SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))
     assert_parses expected, ":'abc'"


### PR DESCRIPTION
closes: https://github.com/Shopify/yarp/issues/131

I attempted to shape the structure close to the current parse tree dump shape:

```
ruby --dump=parsetree -e "%I[a b#{2} c]"
###########################################################
## Do NOT use this node dump for any purpose other than  ##
## debug and research.  Compatibility is not guaranteed. ##
###########################################################

# @ NODE_SCOPE (id: 9, line: 1, location: (1,0)-(1,13))
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_LIST (id: 1, line: 1, location: (1,0)-(1,13))*
#     +- nd_alen: 3
#     +- nd_head:
#     |   @ NODE_LIT (id: 0, line: 1, location: (1,3)-(1,4))
#     |   +- nd_lit: :a
#     +- nd_head:
#     |   @ NODE_DSYM (id: 2, line: 1, location: (1,5)-(1,10))
#     |   +- nd_lit: "b"
#     |   +- nd_next->nd_head:
#     |   |   @ NODE_EVSTR (id: 4, line: 1, location: (1,6)-(1,10))
#     |   |   +- nd_body:
#     |   |       @ NODE_LIT (id: 3, line: 1, location: (1,8)-(1,9))
#     |   |       +- nd_lit: 2
#     |   +- nd_next->nd_next:
#     |       (null node)
#     +- nd_head:
#     |   @ NODE_LIT (id: 7, line: 1, location: (1,11)-(1,12))
#     |   +- nd_lit: :c
#     +- nd_next:
#         (null node)
```

This way symbol literal nodes are still just symbol nodes unless they are using interpolation.