### PR TITLE
Improve binary expression handling

### DIFF
--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -119,6 +119,14 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expression('"hello'), '"hello', ["Expected a closing delimiter for an interpolated string."]
   end
 
+  test "unterminated parenthesised expression" do
+    assert_errors expression('(1+2'), '(1+2', ["Expected a closing parenthesis."]
+  end
+
+  test "parenthesised expression with unparsable internals" do
+    assert_errors expression('(/+.'), '(/+.', ["Expected a closing delimiter for a regular expression.", "Expected a closing parenthesis."]
+  end
+
   private
 
   def assert_errors(expected, source, errors)

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -155,6 +155,51 @@ class ParseTest < Test::Unit::TestCase
     assert_parses CallNode(expression("1"), nil, SLASH("/"), nil, ArgumentsNode([expression("2")]), nil, "/"), "1 / 2"
   end
 
+  test "binary / no whitespace" do
+    assert_parses CallNode(expression("1"), nil, SLASH("/"), nil, ArgumentsNode([expression("2")]), nil, "/"), "1/2"
+  end
+
+  test "binary / variables no whitespace" do
+    expected = CallNode(
+      CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a"),
+      nil,
+      SLASH("/"),
+      nil,
+      ArgumentsNode([CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, "b")]),
+      nil,
+      "/"
+    )
+
+    assert_parses expected, "a/b"
+  end
+
+  test "binary + variables parenthesised" do
+    expected = CallNode(
+      ArrayNode(
+        PARENTHESIS_LEFT("("),
+        [CallNode(
+           CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a"),
+           nil,
+           PLUS("+"),
+           nil,
+           ArgumentsNode(
+             [CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, "b")]
+           ),
+           nil,
+           "+"
+         )],
+        PARENTHESIS_RIGHT(")")
+      ),
+      nil,
+      SLASH("/"),
+      nil,
+      ArgumentsNode([CallNode(nil, nil, IDENTIFIER("c"), nil, nil, nil, "c")]),
+      nil,
+      "/"
+    )
+    assert_parses expected, "(a+b)/c"
+  end
+
   test "binary *" do
     assert_parses CallNode(expression("1"), nil, STAR("*"), nil, ArgumentsNode([expression("2")]), nil, "*"), "1 * 2"
   end


### PR DESCRIPTION
binary / without a space after it was interpreted as the start of a regular expression Now expressions without spaces should produce the expected result more often.