### PR TITLE
Improve parenthesized expression handling

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -916,6 +916,20 @@ nodes:
           def a(b, c, d)
                 ^^^^^^^
           end
+  - name: ParenthesesNode
+    child_nodes:
+      - name: opening
+        type: token
+      - name: statements
+        type: node
+      - name: closing
+        type: token
+    location: opening->closing
+    comment: |
+      Represents a parentesized expression
+
+          (10 + 34)
+          ^^^^^^^^^
   - name: PostExecutionNode
     child_nodes:
       - name: keyword

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1926,6 +1926,22 @@ parse_expression_prefix(yp_parser_t *parser) {
 
       return array;
     }
+    case YP_TOKEN_PARENTHESIS_LEFT: {
+      yp_token_t opening = parser->previous;
+      yp_node_t *parentheses;
+
+      if (parser->current.type != YP_TOKEN_PARENTHESIS_RIGHT && parser->current.type != YP_TOKEN_EOF) {
+        yp_node_t *statements = parse_statements(parser, YP_CONTEXT_BEGIN);
+        parentheses = yp_node_parentheses_node_create(parser, &opening, statements, &opening);
+      } else {
+        yp_node_t *statements = yp_node_statements_create(parser);
+        parentheses = yp_node_parentheses_node_create(parser, &opening, statements, &opening);
+      }
+
+      expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, "Expected a closing parenthesis.");
+      parentheses->as.parentheses_node.closing = parser->previous;
+      return parentheses;
+    }
     case YP_TOKEN_CHARACTER_LITERAL: {
       yp_token_t opening = parser->previous;
       opening.type = YP_TOKEN_STRING_BEGIN;

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -123,6 +123,10 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expression("%s[abc"), "%s[abc", ["Expected a closing delimiter for a dynamic symbol."]
   end
 
+  test "unterminated parenthesized expression" do
+    assert_errors expression('(1 + 2'), '(1 + 2', ["Expected a closing parenthesis."]
+  end
+
   private
 
   def assert_errors(expected, source, errors)

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -79,6 +79,31 @@ class ParseTest < Test::Unit::TestCase
     assert_parses ArrayNode(BRACKET_LEFT("["), [], BRACKET_RIGHT("]")), "[]"
   end
 
+  test "empty parenteses" do
+    assert_parses ParenthesesNode(PARENTHESIS_LEFT("("), Statements([]), PARENTHESIS_RIGHT(")")), "()"
+  end
+
+
+  test "parentesized expression" do
+    expected = ParenthesesNode(
+      PARENTHESIS_LEFT("("),
+      Statements(
+        [CallNode(
+           IntegerLiteral(INTEGER("1")),
+           nil,
+           PLUS("+"),
+           nil,
+           ArgumentsNode([IntegerLiteral(INTEGER("1"))]),
+           nil,
+           "+"
+         )]
+      ),
+      PARENTHESIS_RIGHT(")")
+    )
+
+    assert_parses expected, "(1 + 1)"
+  end
+
   test "binary !=" do
     assert_parses CallNode(expression("1"), nil, BANG_EQUAL("!="), nil, ArgumentsNode([expression("2")]), nil, "!="), "1 != 2"
   end


### PR DESCRIPTION
Expressions in parentheses get their own node which wraps the expression in it.