### PR TITLE
Add support for empty statements

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1551,6 +1551,11 @@ parse_statements(yp_parser_t *parser, yp_context_t context) {
   yp_node_t *statements = yp_node_statements_create(parser);
 
   while (!context_terminator(context, &parser->current)) {
+    // Ignore semicolon without statements before them
+    if (accept(parser, YP_TOKEN_SEMICOLON) || accept(parser, YP_TOKEN_NEWLINE)) {
+      continue;
+    }
+
     yp_node_t *node = parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an expression.");
     yp_node_list_append(parser, statements, &statements->as.statements.body, node);
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -117,6 +117,10 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "(a; b; c)"
   end
 
+  test "parentesized with empty statements" do
+    assert_parses ParenthesesNode(PARENTHESIS_LEFT("("), Statements([]), PARENTHESIS_RIGHT(")")), "(\n;\n;\n)"
+  end
+
   test "binary !=" do
     assert_parses CallNode(expression("1"), nil, BANG_EQUAL("!="), nil, ArgumentsNode([expression("2")]), nil, "!="), "1 != 2"
   end


### PR DESCRIPTION
`parse_statements` should be able to ignore newlines and semicolons before starting to parse an expression.