### PR TITLE
Nodes for __ENCODING__, __FILE__, and __LINE__

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1140,6 +1140,36 @@ nodes:
 
           self
           ^^^^
+  - name: SourceEncodingNode
+    child_nodes:
+      - name: keyword
+        type: token
+    location: keyword
+    comment: |
+      Represents the use of the `__ENCODING__` keyword.
+
+          __ENCODING__
+          ^^^^^^^^^^^^
+  - name: SourceFileNode
+    child_nodes:
+      - name: keyword
+        type: token
+    location: keyword
+    comment: |
+      Represents the use of the `__FILE__` keyword.
+
+          __FILE__
+          ^^^^^^^^
+  - name: SourceLineNode
+    child_nodes:
+      - name: keyword
+        type: token
+    location: keyword
+    comment: |
+      Represents the use of the `__LINE__` keyword.
+
+          __LINE__
+          ^^^^^^^^
   - name: Statements
     child_nodes:
       - name: body

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2328,6 +2328,12 @@ parse_expression_prefix(yp_parser_t *parser) {
       return yp_node_instance_variable_read_create(parser, &parser->previous);
     case YP_TOKEN_INTEGER:
       return yp_node_integer_literal_create(parser, &parser->previous);
+    case YP_TOKEN_KEYWORD___ENCODING__:
+      return yp_node_source_encoding_node_create(parser, &parser->previous);
+    case YP_TOKEN_KEYWORD___FILE__:
+      return yp_node_source_file_node_create(parser, &parser->previous);
+    case YP_TOKEN_KEYWORD___LINE__:
+      return yp_node_source_line_node_create(parser, &parser->previous);
     case YP_TOKEN_KEYWORD_ALIAS: {
       yp_token_t keyword = parser->previous;
       yp_node_t *left = parse_alias_or_undef_argument(parser);

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1024,6 +1024,18 @@ class ParseTest < Test::Unit::TestCase
     assert_parses SelfNode(KEYWORD_SELF("self")), "self"
   end
 
+  test "source encoding" do
+    assert_parses SourceEncodingNode(KEYWORD___ENCODING__("__ENCODING__")), "__ENCODING__"
+  end
+
+  test "source file" do
+    assert_parses SourceFileNode(KEYWORD___FILE__("__FILE__")), "__FILE__"
+  end
+
+  test "source line" do
+    assert_parses SourceLineNode(KEYWORD___LINE__("__LINE__")), "__LINE__"
+  end
+
   test "string empty" do
     assert_parses StringNode(STRING_BEGIN("'"), STRING_CONTENT(""), STRING_END("'"), ""), "''"
   end


### PR DESCRIPTION
I still want to add metadata onto the __FILE__ and __LINE__ nodes that has their actual information, but this is a good start.

Closes #163