### PR TITLE
Implement xstrings

### DIFF
--- a/bin/template.rb
+++ b/bin/template.rb
@@ -67,7 +67,7 @@ class NodeType
   def initialize(config)
     @name = config.fetch("name")
 
-    type = @name.gsub(/(.)([A-Z])/, "\\1_\\2")
+    type = @name.gsub(/(?<=.)[A-Z]/, "_\\0")
     @type = "YP_NODE_#{type.upcase}"
     @human = type.downcase
 

--- a/config.yml
+++ b/config.yml
@@ -732,6 +732,20 @@ nodes:
 
           /foo #{bar} baz/
           ^^^^^^^^^^^^^^^^
+  - name: InterpolatedXStringNode
+    child_nodes:
+      - name: opening
+        type: token
+      - name: parts
+        type: node[]
+      - name: closing
+        type: token
+    location: opening->closing
+    comment: |
+      Represents an xstring literal that contains interpolation.
+
+          `foo #{bar} baz`
+          ^^^^^^^^^^^^^^^^
   - name: InterpolatedStringNode
     child_nodes:
       - name: opening
@@ -1074,6 +1088,20 @@ nodes:
 
           /foo/i
           ^^^^^^
+  - name: XStringNode
+    child_nodes:
+      - name: opening
+        type: token
+      - name: content
+        type: token
+      - name: closing
+        type: token
+    location: opening->closing
+    comment: |
+      Represents an xstring literal with no interpolation.
+
+          `foo`
+          ^^^^^
   - name: RequiredParameterNode
     child_nodes:
       - name: name

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3241,6 +3241,21 @@ parse_expression_prefix(yp_parser_t *parser) {
       node->as.interpolated_regular_expression_node.closing = parser->previous;
       return node;
     }
+    case YP_TOKEN_BACKTICK:
+    case YP_TOKEN_PERCENT_LOWER_X: {
+      yp_token_t opening = parser->previous;
+      yp_token_t content;
+      if (parse_string_without_interpolation(parser, YP_TOKEN_STRING_END, &content)) {
+        return yp_node_x_string_node_create(parser, &opening, &content, &parser->previous);
+      }
+
+      yp_node_t *node = yp_node_interpolated_x_string_node_create(parser, &opening, &opening);
+      yp_node_list_t *parts = &node->as.interpolated_x_string_node.parts;
+      parse_interpolated_string_parts(parser, YP_TOKEN_STRING_END, node, parts);
+      expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for an xstring.");
+      node->as.interpolated_x_string_node.closing = parser->previous;
+      return node;
+    }
     case YP_TOKEN_BANG:
     case YP_TOKEN_TILDE: {
       yp_token_t operator_token = parser->previous;

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -115,6 +115,10 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expression("/hello"), "/hello", ["Expected a closing delimiter for a regular expression."]
   end
 
+  test "unterminated xstring" do
+    assert_errors expression("`hello"), "`hello", ["Expected a closing delimiter for an xstring."]
+  end
+
   test "unterminated string" do
     assert_errors expression('"hello'), '"hello', ["Expected a closing delimiter for an interpolated string."]
   end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1331,6 +1331,32 @@ class ParseTest < Test::Unit::TestCase
     assert_parses RedoNode(KEYWORD_REDO("redo")), "redo"
   end
 
+  test "xstring, `, no interpolation" do
+    assert_parses XStringNode(BACKTICK("`"), STRING_CONTENT("foo"), STRING_END("`")), "`foo`"
+  end
+
+  test "xstring with interpolation" do
+    expected = InterpolatedXStringNode(
+      BACKTICK("`"),
+      [
+        StringNode(nil, STRING_CONTENT("foo "), nil, "foo "),
+        StringInterpolatedNode(
+          EMBEXPR_BEGIN("\#{"),
+          Statements([expression("bar")]),
+          EMBEXPR_END("}")
+        ),
+       StringNode(nil, STRING_CONTENT(" baz"), nil, " baz")
+      ],
+      STRING_END("`")
+    )
+
+    assert_parses expected, "`foo \#{bar} baz`"
+  end
+
+  test "xstring with %x" do
+    assert_parses XStringNode(PERCENT_LOWER_X("%x["), STRING_CONTENT("foo"), STRING_END("]")), "%x[foo]"
+  end
+
   test "regular expression, /, no interpolation" do
     assert_parses RegularExpressionNode(REGEXP_BEGIN("/"), STRING_CONTENT("abc"), REGEXP_END("/i")), "/abc/i"
   end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1531,13 +1531,7 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "string interpolation allowed, but not used" do
-    expected = InterpolatedStringNode(
-      STRING_BEGIN("\""),
-      [StringNode(nil, STRING_CONTENT("abc"), nil, "abc")],
-      STRING_END("\"")
-    )
-
-    assert_parses expected, "\"abc\""
+    assert_parses StringNode(STRING_BEGIN("\""), STRING_CONTENT("abc"), STRING_END("\""), "abc"), "\"abc\""
   end
 
   test "string interpolation allowed, sed" do
@@ -1559,13 +1553,7 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "string interpolation allowed, not actually interpolated" do
-    expected = InterpolatedStringNode(
-      STRING_BEGIN("\""),
-      [StringNode(nil, STRING_CONTENT("\#@---"), nil, "\#@---")],
-      STRING_END("\"")
-    )
-
-    assert_parses expected, "\"#@---\""
+    assert_parses StringNode(STRING_BEGIN("\""), STRING_CONTENT("\#@---"), STRING_END("\""), "\#@---"), "\"#@---\""
   end
 
   test "string list" do
@@ -1631,23 +1619,11 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "string with octal escapes" do
-    expected = InterpolatedStringNode(
-      STRING_BEGIN("\""),
-      [StringNode(nil, STRING_CONTENT("\\7 \\43 \\141"), nil, "\a # a")],
-      STRING_END("\"")
-    )
-
-    assert_parses expected, "\"\\7 \\43 \\141\""
+    assert_parses StringNode(STRING_BEGIN("\""), STRING_CONTENT("\\7 \\43 \\141"), STRING_END("\""), "\a # a"), "\"\\7 \\43 \\141\""
   end
 
   test "string with hexadecimal escapes" do
-    expected = InterpolatedStringNode(
-      STRING_BEGIN("\""),
-      [StringNode(nil, STRING_CONTENT("\\x7 \\x23 \\x61"), nil, "\a # a")],
-      STRING_END("\"")
-    )
-
-    assert_parses expected, "\"\\x7 \\x23 \\x61\""
+    assert_parses StringNode(STRING_BEGIN("\""), STRING_CONTENT("\\x7 \\x23 \\x61"), STRING_END("\""), "\a # a"), "\"\\x7 \\x23 \\x61\""
   end
 
   test "string with embedded global variables" do


### PR DESCRIPTION
Closes #114

Related changes:

- Updated string parsing code to create an `InterpolatedStringNode` only if the string has interpolation
- Modified regex in `bin/template.rb` to use a positive lookbehind so that in `InterpolatedXStringNode` the letters `X` and `S` are handled individually, resulting in `Interpolated_X_String_Node` instead of `Interpolated_XString_Node`