### PR TITLE
Add location tests that use the comments in config.yml underlines

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -382,10 +382,8 @@ nodes:
     comment: |
       Represents a begin statement.
 
-          begin
-            foo
-          end
-          ^^^^^
+          begin; foo; end
+          ^^^^^^^^^^^^^^^
   - name: BlockParameterNode
     child_nodes:
       - name: operator
@@ -427,7 +425,7 @@ nodes:
         type: token?
       - name: name
         type: string
-    location: receiver|message->rparen|arguments|message
+    location: call_operator|receiver|message->rparen|arguments|message
     comment: |
       Represents a method call, in all of the various forms that that can take.
 
@@ -435,13 +433,13 @@ nodes:
           ^^^
 
           +foo
-          ^^^^
+          ^
 
           foo + bar
-          ^^^^^^^^^
+              ^
 
           foo.bar
-          ^^^^^^^
+             ^^^^
   - name: ClassNode
     child_nodes:
       - name: scope
@@ -640,7 +638,7 @@ nodes:
         type: node
       - name: end_keyword
         type: token
-    location: for_keyword->statements
+    location: for_keyword->end_keyword|statements
     comment: |
       Represents the use of the `for` keyword.
 
@@ -734,7 +732,7 @@ nodes:
       Represents the use of the `if` keyword, either in the block form or the modifier form.
 
           bar if foo
-          ^^^^^^^^^^
+              ^^^^^^
 
           if foo then bar end
           ^^^^^^^^^^^^^^^^^^^
@@ -1436,12 +1434,12 @@ nodes:
         type: node?
       - name: end_keyword
         type: token?
-    location: keyword->statements
+    location: keyword->end_keyword|statements
     comment: |
       Represents the use of the `unless` keyword, either in the block form or the modifier form.
 
           bar unless foo
-          ^^^^^^^^^^^^^^
+              ^^^^^^^^^^
 
           unless foo then bar end
           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -1453,15 +1451,17 @@ nodes:
         type: node
       - name: statement
         type: node
-    location: keyword->statement
+      - name: end_keyword
+        type: token?
+    location: keyword->end_keyword|statement
     comment: |
       Represents the use of the `until` keyword, either in the block form or the modifier form.
 
           bar until foo
-          ^^^^^^^^^^^^^
+              ^^^^^^^^^
 
           until foo do bar end
-          ^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^
   - name: WhileNode
     child_nodes:
       - name: keyword
@@ -1470,15 +1470,17 @@ nodes:
         type: node
       - name: statement
         type: node
-    location: keyword->statement
+      - name: end_keyword
+        type: token?
+    location: keyword->end_keyword|statement
     comment: |
       Represents the use of the `while` keyword, either in the block form or the modifier form.
 
           bar while foo
-          ^^^^^^^^^^^^^
+              ^^^^^^^^^
 
           while foo do bar end
-          ^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^
   - name: XStringNode
     child_nodes:
       - name: opening
@@ -1508,4 +1510,4 @@ nodes:
       Represents the use of the `yield` keyword.
 
           yield 1
-          ^^^^^^^
+          ^^^^^

--- a/test/config_comment_test.rb
+++ b/test/config_comment_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "yaml"
+
+class ConfigCommentTest < Test::Unit::TestCase
+  include YARP::DSL
+
+  YAML.load_file(File.expand_path("../config.yml", __dir__)).fetch("nodes").each do |node|
+    test "node #{node["name"]} has correct comment underline" do
+      code = node["comment"].lines.filter { |l| l.start_with?("    ") }
+
+      code_lines = []
+      underlined_sections = []
+      underlined_indexes = []
+      code.each_with_index do |line, index|
+        if line.match?(/^[\W\^]+$/) # underline line
+          start = 0
+          finish = 0
+          line.chars.each_with_index do |char, char_index|
+            if start.zero?
+              if char == "^"
+                start = char_index
+                finish = char_index+1
+              end
+            else
+              if char == "^"
+                finish = char_index+1
+              end
+            end
+          end
+          underlined_sections << code[index - 1][start..finish]
+          s = code_lines.join("\n").chars.size - code_lines.last.chars.size + start
+          e = code_lines.join("\n").chars.size - code_lines.last.chars.size + finish
+          underlined_indexes << [s, e]
+        else
+          code_lines << line
+        end
+      end
+
+      code_str = code_lines.join("\n")
+
+      yarp_underlines = []
+      YARP.parse(code_str).node.statements.child_nodes.each do |yarv_node|
+        if node["name"] == "DefNode"
+          next
+        end
+
+        if "YARP::" + node["name"] == yarv_node.class.name
+          s = yarv_node.location.start_offset
+          e = yarv_node.location.end_offset
+          yarp_underlines << [s, e]
+        end
+      end
+
+      yarp_underlines.zip(underlined_indexes).each do |yarp_undreline, comment_underline|
+        assert_equal code_str[comment_underline[0]...comment_underline[1]], code_str[yarp_undreline[0]...yarp_undreline[1]]
+      end
+    end
+  end
+end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1946,19 +1946,46 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "until" do
-    assert_parses UntilNode(KEYWORD_UNTIL("until"), expression("true"), Statements([expression("1")])), "until true; 1; end"
+    expected = UntilNode(
+      KEYWORD_UNTIL("until"),
+      TrueNode(KEYWORD_TRUE("true")),
+      Statements([IntegerLiteral(INTEGER("1"))]),
+      KEYWORD_END("end")
+    )
+    assert_parses expected, "until true; 1; end"
   end
 
   test "until modifier" do
-    assert_parses UntilNode(KEYWORD_UNTIL("until"), expression("true"), Statements([expression("1")])), "1 until true"
+    expected = UntilNode(
+      KEYWORD_UNTIL("until"),
+      TrueNode(KEYWORD_TRUE("true")),
+      Statements([IntegerLiteral(INTEGER("1"))]),
+      nil
+    )
+
+    assert_parses expected, "1 until true"
   end
 
   test "while" do
-    assert_parses WhileNode(KEYWORD_WHILE("while"), expression("true"), Statements([expression("1")])), "while true; 1; end"
+    expected = WhileNode(
+      KEYWORD_WHILE("while"),
+      TrueNode(KEYWORD_TRUE("true")),
+      Statements([IntegerLiteral(INTEGER("1"))]),
+      KEYWORD_END("end")
+    )
+
+    assert_parses expected, "while true; 1; end"
   end
 
   test "while modifier" do
-    assert_parses WhileNode(KEYWORD_WHILE("while"), expression("true"), Statements([expression("1")])), "1 while true"
+    expected = WhileNode(
+      KEYWORD_WHILE("while"),
+      TrueNode(KEYWORD_TRUE("true")),
+      Statements([IntegerLiteral(INTEGER("1"))]),
+      nil
+    )
+
+    assert_parses expected, "1 while true"
   end
 
   test "yield" do


### PR DESCRIPTION
This uses the carrots in `config.yml` to specify what locations are expected to be associated with a node.

This brings to light two issues that are obvious because of this change, but should probably be resolved separately,

* `"foo" until true` has a range where the first number is higher then the second since it is `keyword->statement`, would you expect a predicate location to include the statement before it?
* There is a somewhat common pattern of `node->as.blah_node.closing = parser->previous;`, but this breaks the location calculation since it only happens during node creation. Should we always resolve node locations later? I inserted a temporary fix that doesn't not abide by the rules in `config.yml` location precedence, but does always get the right answer.

additionally, it might be worth creating dedicated location tests for things that do not exist in comments today, but it probably isn't a pressing need right now.