### PR TITLE
Implements top level constants

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1414,6 +1414,18 @@ nodes:
 
           foo ? bar : baz
           ^^^^^^^^^^^^^^^
+  - name: TopLevelConstantNode
+    child_nodes:
+      - name: delimiter
+        type: token
+      - name: name
+        type: token
+    location: delimiter->name
+    comment: |
+      Represents the use of a top level constant
+
+        ::Foo
+        ^^^^^
   - name: TrueNode
     child_nodes:
       - name: keyword

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3417,6 +3417,11 @@ parse_expression_prefix(yp_parser_t *parser) {
     }
     case YP_TOKEN_SYMBOL_BEGIN:
       return parse_symbol(parser, lex_mode.mode);
+    case YP_TOKEN_COLON_COLON: {
+      yp_token_t delimiter = parser->previous;
+      expect(parser, YP_TOKEN_CONSTANT, "Expected a constant after '::'.");
+      return yp_node_top_level_constant_node_create(parser, &delimiter, &parser->previous);
+    }
     default:
       if (context_recoverable(parser, &parser->previous)) {
         parser->recovering = true;
@@ -3444,6 +3449,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, binding_power_t bin
           return result;
         }
         case YP_NODE_CONSTANT_PATH_NODE:
+        case YP_NODE_TOP_LEVEL_CONSTANT_NODE:
         case YP_NODE_CONSTANT_READ: {
           yp_node_t *value = parse_expression(parser, binding_power, "Expected a value for the constant after =.");
           return yp_node_constant_path_write_node_create(parser, node, &token, value);

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -15,6 +15,11 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expected, "A::$b", ["Expected identifier or constant after '::'"]
   end
 
+  test "top level constant with invalid token after" do
+    expected = TopLevelConstantNode(COLON_COLON("::"), MISSING(""))
+    assert_errors expected, "::foo", ["Expected a constant after '::'."]
+  end
+
   test "module name recoverable" do
     expected = ModuleNode(
       Scope([]),

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -620,6 +620,44 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "A::B = 1"
   end
 
+  test "top level constant" do
+    assert_parses TopLevelConstantNode(COLON_COLON("::"), CONSTANT("A")), "::A"
+  end
+
+  test "top level constant path" do
+    expected = ConstantPathNode(
+      TopLevelConstantNode(COLON_COLON("::"), CONSTANT("A")),
+      COLON_COLON("::"),
+      ConstantRead(CONSTANT("B"))
+    )
+
+    assert_parses expected, "::A::B"
+  end
+
+  test "top level constant write single" do
+    expected = ConstantPathWriteNode(
+      TopLevelConstantNode(COLON_COLON("::"), CONSTANT("A")),
+      EQUAL("="),
+      IntegerLiteral(INTEGER("1"))
+    )
+
+    assert_parses expected, "::A = 1"
+  end
+
+  test "top level constant write multiple" do
+    expected = ConstantPathWriteNode(
+      ConstantPathNode(
+        TopLevelConstantNode(COLON_COLON("::"), CONSTANT("A")),
+        COLON_COLON("::"),
+        ConstantRead(CONSTANT("B"))
+      ),
+      EQUAL("="),
+      IntegerLiteral(INTEGER("1"))
+    )
+
+    assert_parses expected, "::A::B = 1"
+  end
+
   test "def without parentheses" do
     expected = DefNode(
       KEYWORD_DEF("def"),


### PR DESCRIPTION
Ended up using a new node for top level constants as it seems that was MRI does as well.

Closes #146 