### PR TITLE
Implement calling with unnamed rest parameter 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1218,8 +1218,8 @@ nodes:
       - name: operator
         type: token
       - name: expression
-        type: node
-    location: operator->expression
+        type: node?
+    location: operator->expression|operator
     comment: |
       Represents array splats.
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2050,9 +2050,9 @@ parse_argument(yp_parser_t *parser, yp_node_t *arguments) {
   if (accept(parser, YP_TOKEN_STAR)) {
     yp_token_t previous = parser->previous;
     if (*parser->current.start == ',' || *parser->current.start == ')') {
-      // if (!yp_token_list_includes(&parser->current_scope->as.scope.locals, &parser->previous)) {
-      //   yp_error_list_append(&parser->error_list, "unexpected ... when parent method is not forwarding.", parser->previous.start - parser->start);
-      // } 
+      if (!yp_token_list_includes(&parser->current_scope->as.scope.locals, &parser->previous)) {
+        yp_error_list_append(&parser->error_list, "unexpected * when parent method is not forwarding.", parser->previous.start - parser->start);
+      }
       return yp_node_star_node_create(parser, &previous, NULL);
     }
     yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected an expression after '*' in argument.");

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2048,8 +2048,15 @@ parse_argument(yp_parser_t *parser, yp_node_t *arguments) {
   }
 
   if (accept(parser, YP_TOKEN_STAR)) {
-      yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected an expression after '*' in argument.");
-      return yp_node_star_node_create(parser, &parser->previous, expression);
+    yp_token_t previous = parser->previous;
+    if (*parser->current.start == ',' || *parser->current.start == ')') {
+      // if (!yp_token_list_includes(&parser->current_scope->as.scope.locals, &parser->previous)) {
+      //   yp_error_list_append(&parser->error_list, "unexpected ... when parent method is not forwarding.", parser->previous.start - parser->start);
+      // } 
+      return yp_node_star_node_create(parser, &previous, NULL);
+    }
+    yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected an expression after '*' in argument.");
+    return yp_node_star_node_create(parser, &parser->previous, expression);
   }
   
   return parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an argument.");
@@ -2232,6 +2239,7 @@ parse_parameters(yp_parser_t *parser) {
           name = parser->previous;
           yp_token_list_append(&parser->current_scope->as.scope.locals, &name);
         } else {
+          yp_token_list_append(&parser->current_scope->as.scope.locals, &operator);
           name = not_provided(parser);
         }
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2049,7 +2049,7 @@ parse_argument(yp_parser_t *parser, yp_node_t *arguments) {
 
   if (accept(parser, YP_TOKEN_STAR)) {
     yp_token_t previous = parser->previous;
-    if (*parser->current.start == ',' || *parser->current.start == ')') {
+    if (parser->current.type == YP_TOKEN_PARENTHESIS_RIGHT || parser->current.type == YP_TOKEN_COMMA) {
       if (!yp_token_list_includes(&parser->current_scope->as.scope.locals, &parser->previous)) {
         yp_error_list_append(&parser->error_list, "unexpected * when parent method is not forwarding.", parser->previous.start - parser->start);
       }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2058,7 +2058,7 @@ parse_argument(yp_parser_t *parser, yp_node_t *arguments) {
     yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected an expression after '*' in argument.");
     return yp_node_star_node_create(parser, &parser->previous, expression);
   }
-  
+
   return parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an argument.");
 }
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2040,18 +2040,19 @@ parse_statements(yp_parser_t *parser, yp_context_t context) {
 // Parse an individual argument.
 static yp_node_t *
 parse_argument(yp_parser_t *parser, yp_node_t *arguments) {
-  yp_node_t *argument;
-
   if (accept(parser, YP_TOKEN_DOT_DOT_DOT)) {
     if (!yp_token_list_includes(&parser->current_scope->as.scope.locals, &parser->previous)) {
       yp_error_list_append(&parser->error_list, "unexpected ... when parent method is not forwarding.", parser->previous.start - parser->start);
     }
-    argument = yp_node_forwarding_arguments_node_create(parser, &parser->previous);
-  } else {
-    argument = parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an argument.");
+    return yp_node_forwarding_arguments_node_create(parser, &parser->previous);
   }
 
-  return argument;
+  if (accept(parser, YP_TOKEN_STAR)) {
+      yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected an expression after '*' in argument.");
+      return yp_node_star_node_create(parser, &parser->previous, expression);
+  }
+  
+  return parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an argument.");
 }
 
 // Parse a list of arguments.

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -886,7 +886,7 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([STAR("*")])
     )
 
     assert_parses expected, "def a *\nend"
@@ -1123,6 +1123,32 @@ class ParseTest < Test::Unit::TestCase
       "foo"
     )
     assert_parses expected, "foo(*rest)"
+  end
+
+  test "method call with *" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("a"),
+      PARENTHESIS_LEFT("("),
+      ParametersNode([], [], RestParameterNode(STAR("*"), nil), [], nil, nil),
+      PARENTHESIS_RIGHT(")"),
+      nil,
+      Statements(
+        [CallNode(
+          nil,
+          nil,
+          IDENTIFIER("b"),
+          PARENTHESIS_LEFT("("),
+          ArgumentsNode([StarNode(STAR("*"), nil)]),
+          PARENTHESIS_RIGHT(")"),
+          "b"
+         )]
+      ),
+      KEYWORD_END("end"),
+      Scope([STAR("*")])
+    )
+
+    assert_parses expected, "def a(*); b(*); end"
   end
 
   test "defined? without parentheses" do

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1110,6 +1110,21 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "def a(...); \"foo\#{b(...)}\"; end"
   end
 
+  test "method call with *rest" do
+    expected = CallNode(
+      nil,
+      nil,
+      IDENTIFIER("foo"),
+      PARENTHESIS_LEFT("("),
+      ArgumentsNode(
+        [StarNode(IDENTIFIER("rest"), CallNode(nil, nil, IDENTIFIER("rest"), nil, nil, nil, "rest"))]
+      ),
+      PARENTHESIS_RIGHT(")"),
+      "foo"
+    )
+    assert_parses expected, "foo(*rest)"
+  end
+
   test "defined? without parentheses" do
     assert_parses DefinedNode(KEYWORD_DEFINED("defined?"), nil, expression("1"), nil), "defined? 1"
   end


### PR DESCRIPTION
This PR contains implementation for calling a method with unnamed rest parameter.

```ruby
def foo(*)
  bar(*)
end
```

The behavior is very similar to the forwarding parameter `...`.