### PR TITLE
Add support for rescue else syntax

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -374,6 +374,8 @@ nodes:
         type: node
       - name: rescue_clause
         type: node?
+      - name: rescue_else_clause
+        type: node?
       - name: ensure_clause
         type: node?
       - name: end_keyword

--- a/src/parser.h
+++ b/src/parser.h
@@ -112,6 +112,7 @@ typedef enum {
   YP_CONTEXT_PARENS,   // a parenthesized expression
   YP_CONTEXT_ENSURE,   // an ensure statement
   YP_CONTEXT_RESCUE,   // a rescue statement
+  YP_CONTEXT_RESCUE_ELSE,   // a rescue else statement
 } yp_context_t;
 
 // This is a node in a linked list of contexts.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -30,6 +30,7 @@ debug_context(yp_context_t context) {
     case YP_CONTEXT_POSTEXE: return "POSTEXE";
     case YP_CONTEXT_PREEXE: return "PREEXE";
     case YP_CONTEXT_RESCUE: return "RESCUE";
+    case YP_CONTEXT_RESCUE_ELSE: return "RESCUE ELSE";
     case YP_CONTEXT_SCLASS: return "SCLASS";
     case YP_CONTEXT_UNLESS: return "UNLESS";
     case YP_CONTEXT_UNTIL: return "UNTIL";
@@ -1664,7 +1665,9 @@ context_terminator(yp_context_t context, yp_token_t *token) {
       return token->type == YP_TOKEN_PARENTHESIS_RIGHT;
     case YP_CONTEXT_BEGIN:
     case YP_CONTEXT_RESCUE:
-      return token->type == YP_TOKEN_KEYWORD_ENSURE || token->type == YP_TOKEN_KEYWORD_RESCUE || token->type == YP_TOKEN_KEYWORD_END;
+      return token->type == YP_TOKEN_KEYWORD_ENSURE || token->type == YP_TOKEN_KEYWORD_RESCUE || token->type == YP_TOKEN_KEYWORD_ELSE || token->type == YP_TOKEN_KEYWORD_END;
+    case YP_CONTEXT_RESCUE_ELSE:
+      return token->type == YP_TOKEN_KEYWORD_ENSURE || token->type == YP_TOKEN_KEYWORD_END;
   }
 
   return false;
@@ -2676,7 +2679,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       yp_token_t end_keyword;
       not_provided(&end_keyword, parser->previous.end);
 
-      yp_node_t *begin_node = yp_node_begin_node_create(parser, &begin_keyword, begin_statements, NULL, NULL, &end_keyword);
+      yp_node_t *begin_node = yp_node_begin_node_create(parser, &begin_keyword, begin_statements, NULL, NULL, NULL, &end_keyword);
       yp_node_t *current = NULL;
 
       // Parse any number of rescue clauses. This will form a linked list of if
@@ -2721,6 +2724,15 @@ parse_expression_prefix(yp_parser_t *parser) {
           current->as.rescue_node.consequent = rescue;
         }
         current = rescue;
+      }
+
+      if (accept(parser, YP_TOKEN_KEYWORD_ELSE)) {
+        yp_token_t else_keyword = parser->previous;
+        accept_any(parser, 2, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+        yp_node_t *rescue_else_statements = parse_statements(parser, YP_CONTEXT_RESCUE_ELSE);
+        accept_any(parser, 2, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+        yp_node_t *else_node = yp_node_else_node_create(parser, &else_keyword, rescue_else_statements, &parser->previous);
+        begin_node->as.begin_node.rescue_else_clause = else_node;
       }
 
       if (accept(parser, YP_TOKEN_KEYWORD_ENSURE)) {

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2054,6 +2054,7 @@ class ParseTest < Test::Unit::TestCase
       Statements([expression("a")]),
       nil,
       nil,
+      nil,
       KEYWORD_END("end"),
     )
 
@@ -2062,6 +2063,60 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "begin a\n end"
     assert_parses expected, "begin a; end"
   end
+
+
+  test "begin rescue, else" do
+    expected = BeginNode(
+      KEYWORD_BEGIN("begin"),
+      Statements([CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a")]),
+      RescueNode(
+        KEYWORD_RESCUE("rescue"),
+        [],
+        nil,
+        nil,
+        Statements([CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, "b")]),
+        nil
+      ),
+      ElseNode(
+        KEYWORD_ELSE("else"),
+        Statements([CallNode(nil, nil, IDENTIFIER("c"), nil, nil, nil, "c")]),
+        SEMICOLON(";")
+      ),
+      nil,
+      KEYWORD_END("end")
+    )
+
+    assert_parses expected, "begin; a; rescue; b; else; c; end"
+  end
+
+  test "begin rescue, else and ensure" do
+    expected = BeginNode(
+      KEYWORD_BEGIN("begin"),
+      Statements([CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a")]),
+      RescueNode(
+        KEYWORD_RESCUE("rescue"),
+        [],
+        nil,
+        nil,
+        Statements([CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, "b")]),
+        nil
+      ),
+      ElseNode(
+        KEYWORD_ELSE("else"),
+        Statements([CallNode(nil, nil, IDENTIFIER("c"), nil, nil, nil, "c")]),
+        SEMICOLON(";")
+      ),
+      EnsureNode(
+        KEYWORD_ENSURE("ensure"),
+        Statements([CallNode(nil, nil, IDENTIFIER("d"), nil, nil, nil, "d")]),
+        KEYWORD_END("end")
+      ),
+      nil
+    )
+
+    assert_parses expected, "begin; a; rescue; b; else; c; ensure; d; end"
+  end
+
 
   test "endless method definition without arguments" do
     expected = DefNode(
@@ -2296,6 +2351,7 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
+      nil,
       KEYWORD_END("end"),
     )
 
@@ -2317,6 +2373,7 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
+      nil,
       KEYWORD_END("end"),
     )
 
@@ -2333,8 +2390,9 @@ class ParseTest < Test::Unit::TestCase
         EQUAL_GREATER("=>"),
         IDENTIFIER("ex"),
         Statements([expression("b")]),
-        nil
+        nil,
       ),
+      nil,
       nil,
       KEYWORD_END("end"),
     )
@@ -2355,6 +2413,7 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
+      nil,
       KEYWORD_END("end"),
     )
 
@@ -2373,6 +2432,7 @@ class ParseTest < Test::Unit::TestCase
         Statements([expression("b")]),
         nil
       ),
+      nil,
       nil,
       KEYWORD_END("end"),
     )
@@ -2407,6 +2467,7 @@ class ParseTest < Test::Unit::TestCase
         )
       ),
       nil,
+      nil,
       KEYWORD_END("end"),
     )
 
@@ -2433,6 +2494,7 @@ class ParseTest < Test::Unit::TestCase
         )
       ),
       nil,
+      nil,
       KEYWORD_END("end"),
     )
 
@@ -2444,12 +2506,13 @@ class ParseTest < Test::Unit::TestCase
       KEYWORD_BEGIN("begin"),
       Statements([expression("a")]),
       nil,
+      nil,
       EnsureNode(
         KEYWORD_ENSURE("ensure"),
         Statements([expression("b")]),
         KEYWORD_END("end"),
       ),
-      nil,
+      nil
     )
 
     assert_parses expected, "begin\na\nensure\nb\nend"
@@ -2526,6 +2589,7 @@ class ParseTest < Test::Unit::TestCase
         Statements([expression("b")]),
         nil
       ),
+      nil,
       EnsureNode(
         KEYWORD_ENSURE("ensure"),
         Statements([expression("b")]),


### PR DESCRIPTION
Fixes: https://github.com/Shopify/yarp/issues/209

```
begin; a; rescue; b; else; c; ensure; d; end
```

becomes,

```
BeginNode(
  KEYWORD_BEGIN("begin"),
  Statements([CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a")]),
  RescueNode(
    KEYWORD_RESCUE("rescue"),
    [],
    nil,
    nil,
    Statements([CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, "b")]),
    nil
  ),
  ElseNode(
    KEYWORD_ELSE("else"),
    Statements([CallNode(nil, nil, IDENTIFIER("c"), nil, nil, nil, "c")]),
    SEMICOLON(";")
  ),
  EnsureNode(
    KEYWORD_ENSURE("ensure"),
    Statements([CallNode(nil, nil, IDENTIFIER("d"), nil, nil, nil, "d")]),
    KEYWORD_END("end")
  ),
  nil
)
```