### PR TITLE
Enforce method parameters order

### DIFF
--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -840,6 +840,29 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "def a ...\nend"
   end
 
+  test "def with named parameter and forwarding parameter" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("foo"),
+      nil,
+      ParametersNode(
+        [RequiredParameterNode(IDENTIFIER("a"))],
+        [],
+        nil,
+        [],
+        ForwardingParameterNode(DOT_DOT_DOT("...")),
+        nil
+      ),
+      nil,
+      nil,
+      Statements([]),
+      KEYWORD_END("end"),
+      Scope([IDENTIFIER("a"), DOT_DOT_DOT("...")])
+    )
+
+    assert_parses expected, "def foo a, ...\nend"
+  end
+
   test "def with block parameter" do
     expected = DefNode(
       KEYWORD_DEF("def"),


### PR DESCRIPTION
I tried to tackle #153. The error message is very generic, I don't know if that's you had in mind either with the message or the implementation.

I also added an `assert_errors_only` helper to make the test more readable but let me know if you want me to remove it and use `expression` in those tests instead (I only found that it checks the parser's result is the same twice and had no impact on errors).