### PR TITLE
Support block with braces

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -448,6 +448,22 @@ nodes:
 
           foo.bar
           ^^^^^^^
+  - name: BlockNode
+    child_nodes:
+      - name: start_keyword
+        type: token
+      - name: arguments
+        type: node?
+      - name: statements
+        type: node?
+      - name: end_keyword
+        type: token
+    location: start_keyword->end_keyword
+    comment: |
+      represents a block of ruby code
+
+      [1,2, 3].each { |i| puts x }
+                    ^^^^^^^^^^^^^^
   - name: ClassNode
     child_nodes:
       - name: scope

--- a/src/parser.h
+++ b/src/parser.h
@@ -148,6 +148,7 @@ typedef enum {
   YP_CONTEXT_WHILE,       // a while statement
   YP_CONTEXT_UNTIL,       // an until statement
   YP_CONTEXT_EMBEXPR,     // an interpolated expression
+  YP_CONTEXT_BLOCK_BRACES,      // expressions in block arguments using braces
   YP_CONTEXT_BEGIN,       // a begin statement
   YP_CONTEXT_SCLASS,      // a singleton class definition
   YP_CONTEXT_FOR,         // a for loop

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -229,6 +229,27 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expression("def ().a; end"), "def ().a; end", ["Expected to be able to parse receiver."]
   end
 
+  test "block beginning with '{' and ending with 'end'" do
+    expected = CallNode(
+      CallNode(nil, nil, IDENTIFIER("x"), nil, nil, nil, "x"),
+      DOT("."),
+      IDENTIFIER("each"),
+      nil,
+      ArgumentsNode(
+        [BlockNode(
+           BRACE_LEFT("{"),
+           nil,
+           Statements([CallNode(nil, nil, IDENTIFIER("x"), nil, nil, nil, "x")]),
+           MISSING("")
+         )]
+      ),
+      nil,
+      "each"
+    )
+
+    assert_errors expected, "x.each { x end", ["expected block beginning with '{' to end with '}'."]
+  end
+
   private
 
   def assert_errors(expected, source, errors)


### PR DESCRIPTION
This adds support for block arguments syntax. Focusing on `do/end` and `{/}` blocks with `|` variables.