### PR TITLE
Parse optional keyword parameters

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -848,12 +848,18 @@ nodes:
     child_nodes:
       - name: name
         type: token
+      - name: value
+        type: node?
     location: name
     comment: |
-      Represents an required keyword parameter to a method, block, or lambda definition.
+      Represents a keyword parameter to a method, block, or lambda definition.
 
           def a(b:)
                 ^^
+          end
+
+          def a(b: 1)
+                ^^^^
           end
   - name: KeywordRestParameterNode
     child_nodes:

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -806,6 +806,38 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "def a b\nend"
   end
 
+  test "def with keyword parameter (no parenthesis)" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("a"),
+      nil,
+      ParametersNode([], [], nil, [KeywordParameterNode(LABEL("b:"), nil)], nil, nil),
+      nil,
+      nil,
+      Statements([]),
+      KEYWORD_END("end"),
+      Scope([LABEL("b")])
+    )
+
+    assert_parses expected, "def a b:\nend"
+  end
+
+  test "def with keyword parameter (parenthesis)" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("a"),
+      PARENTHESIS_LEFT("("),
+      ParametersNode([], [], nil, [KeywordParameterNode(LABEL("b:"), nil)], nil, nil),
+      PARENTHESIS_RIGHT(")"),
+      nil,
+      Statements([]),
+      KEYWORD_END("end"),
+      Scope([LABEL("b")])
+    )
+
+    assert_parses expected, "def a(b:)\nend"
+  end
+
   test "def with multiple required parameters" do
     expected = DefNode(
       KEYWORD_DEF("def"),
@@ -880,6 +912,79 @@ class ParseTest < Test::Unit::TestCase
     )
 
     assert_parses expected, "def a b = 1, c = 2\nend"
+  end
+
+  test "def with optional keyword parameters (no parenthesis)" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("a"),
+      nil,
+      ParametersNode(
+        [],
+        [KeywordParameterNode(LABEL("c:"), expression("1"))],
+        nil,
+        [KeywordParameterNode(LABEL("b:"), nil)],
+        nil,
+        nil
+      ),
+      nil,
+      nil,
+      Statements([]),
+      KEYWORD_END("end"),
+      Scope([LABEL("b"), LABEL("c")])
+    )
+
+    assert_parses expected, "def a b:, c: 1 \nend"
+  end
+
+  test "def with optional keyword parameters (parenthesis)" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("a"),
+      PARENTHESIS_LEFT("("),
+      ParametersNode(
+        [],
+        [KeywordParameterNode(LABEL("c:"), expression("1"))],
+        nil,
+        [KeywordParameterNode(LABEL("b:"), nil)],
+        nil,
+        nil
+      ),
+      PARENTHESIS_RIGHT(")"),
+      nil,
+      Statements([]),
+      KEYWORD_END("end"),
+      Scope([LABEL("b"), LABEL("c")])
+    )
+
+    assert_parses expected, "def a(b:, c: 1)\nend"
+  end
+
+  test "def with optional keyword parameters and line break" do
+    expected = DefNode(
+      KEYWORD_DEF("def"),
+      IDENTIFIER("a"),
+      PARENTHESIS_LEFT("("),
+      ParametersNode(
+        [],
+        [KeywordParameterNode(LABEL("b:"), expression("1"))],
+        nil,
+        [KeywordParameterNode(LABEL("c:"), nil)],
+        nil,
+        nil
+      ),
+      PARENTHESIS_RIGHT(")"),
+      nil,
+      Statements([]),
+      KEYWORD_END("end"),
+      Scope([LABEL("b"), LABEL("c")])
+    )
+
+    assert_parses expected, <<~RUBY
+      def a(b:
+        1, c:)
+      end
+    RUBY
   end
 
   test "def with rest parameter" do
@@ -1003,7 +1108,7 @@ class ParseTest < Test::Unit::TestCase
         [RequiredParameterNode(IDENTIFIER("a"))],
         [],
         nil,
-        [KeywordParameterNode(LABEL("b:"))],
+        [KeywordParameterNode(LABEL("b:"), nil)],
         NoKeywordsParameterNode(KEYWORD_NIL("nil")),
         nil
       ),


### PR DESCRIPTION
Parse optional keyword parameters. This is a little bit more tricky than parsing optional default parameters because there is no straight forward way to tell if a keyword parameter is optional or not and the behaviour also differs depending on wether the method parameters are defined with or without parenthesis. For more context see https://github.com/Shopify/yarp/pull/239.