### PR TITLE
Fix small issue when parsing multiline string addition

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4463,6 +4463,9 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, binding_power_t bin
       yp_token_t rparen = not_provided(parser);
 
       yp_node_t *arguments = yp_arguments_node_create(parser);
+
+      accept(parser, YP_TOKEN_NEWLINE);
+
       yp_node_t *argument = parse_expression(parser, binding_power, "Expected a value after the operator.");
       yp_arguments_node_append(arguments, argument);
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3282,6 +3282,32 @@ class ParseTest < Test::Unit::TestCase
     refute YARP.parse("#encoding: utf8").errors.empty?
   end
 
+  test "multiline string addition" do
+    expected = CallNode(
+      StringNode(
+        STRING_BEGIN("\""),
+        STRING_CONTENT("foo"),
+        STRING_END("\""),
+        "foo"
+      ),
+      nil,
+      PLUS("+"),
+      nil,
+      ArgumentsNode(
+        [StringNode(
+           STRING_BEGIN("\""),
+           STRING_CONTENT("bar"),
+           STRING_END("\""),
+           "bar"
+         )]
+      ),
+      nil,
+      "+"
+    )
+
+    assert_parses expected, "\"foo\" +\n\"bar\""
+  end
+
   private
 
   def assert_serializes(expected, source)


### PR DESCRIPTION
I ran into an example like,

```
{ foo: "bar" +
    "baz"
}
```

which fails looking for the argument after the `+`. 

I believe all of these operators are fine with whitespace here, but I didn't test all of them.