### PR TITLE
Only update lex state to BEG if it isn't already kinda BEG

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1214,7 +1214,9 @@ lex_token_type(yp_parser_t *parser) {
         }
 
         case '\n':
-          parser->lex_state = YP_LEX_STATE_BEG;
+          if (!(parser->lex_state & YP_LEX_STATE_BEG)) {
+            parser->lex_state = YP_LEX_STATE_BEG;
+          }
           parser->command_start = true;
           return YP_TOKEN_NEWLINE;
 


### PR DESCRIPTION
I noticed in the example

    {
      foo: hi +
        bar,
    }

that the newline after the trailing comma stays BEG|LABEL in riper, but the trailing newline after BRACE_LEFT does get set to BEG. So it seems we should only worry about setting it if one of the states isn't already BEG.