### PR TITLE
Improve whitespace handling in hash literals

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3229,14 +3229,14 @@ parse_expression_prefix(yp_parser_t *parser) {
       yp_token_t opening = parser->previous;
       yp_node_t *array = yp_array_node_create(parser, &opening, &opening);
 
+      while (accept(parser, YP_TOKEN_NEWLINE));
       while (!match_any_type_p(parser, 2, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_EOF)) {
-        while (accept(parser, YP_TOKEN_NEWLINE));
-
         if (yp_array_node_size(array) != 0) {
           expect(parser, YP_TOKEN_COMMA, "Expected a separator for the elements in an array.");
+          while (accept(parser, YP_TOKEN_NEWLINE));
         }
 
-        while (accept(parser, YP_TOKEN_NEWLINE));
+
         yp_node_t *element;
 
         if (accept(parser, YP_TOKEN_STAR)) {
@@ -3284,7 +3284,6 @@ parse_expression_prefix(yp_parser_t *parser) {
           expect(parser, YP_TOKEN_COMMA, "expected a comma between hash entries.");
           while (accept(parser, YP_TOKEN_NEWLINE));
         }
-
 
         yp_node_t *element;
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3278,14 +3278,14 @@ parse_expression_prefix(yp_parser_t *parser) {
       yp_token_t opening = parser->previous;
       yp_node_t *node = yp_node_hash_node_create(parser, &opening, &opening);
 
+      while (accept(parser, YP_TOKEN_NEWLINE));
       while (!match_any_type_p(parser, 2, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_EOF)) {
-        while (accept(parser, YP_TOKEN_NEWLINE));
-
         if (node->as.hash_node.elements.size != 0) {
           expect(parser, YP_TOKEN_COMMA, "expected a comma between hash entries.");
+          while (accept(parser, YP_TOKEN_NEWLINE));
         }
 
-        while (accept(parser, YP_TOKEN_NEWLINE));
+
         yp_node_t *element;
 
         switch (parser->current.type) {

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -112,6 +112,10 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "[*a]"
   end
 
+  test "empty array literal" do
+    assert_parses ArrayNode(BRACKET_LEFT("["), [], BRACKET_RIGHT("]")), "[\n]\n"
+  end
+
   test "empty parenteses" do
     assert_parses ParenthesesNode(PARENTHESIS_LEFT("("), Statements([]), PARENTHESIS_RIGHT(")")), "()"
   end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3126,6 +3126,10 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "{ a => b, **c }"
   end
 
+  test "parses empty hash with statements after it" do
+    assert_parses HashNode(BRACE_LEFT("{"), [], BRACE_RIGHT("}")), "{\n}\n"
+  end
+
   test "begin with rescue and ensure statements" do
     expected = BeginNode(
       KEYWORD_BEGIN("begin"),


### PR DESCRIPTION
    {
    }

and

    [
    ]

previously the above parsed as a missing key, instead this should now successfully return an empty hash node.

