### PR TITLE
Support symbol to proc

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -668,6 +668,18 @@ nodes:
             bar(...)
             ^^^^^^^^
           end
+  - name: SymbolToProcNode
+    child_nodes:
+      - name: operator
+        type: token
+      - name: body
+        type: node
+    location: operator->body
+    comment: |
+      Represents symbol to proc node
+
+          map(&:call)
+              ^^^^^^
   - name: ForwardingParameterNode
     child_nodes:
       - name: operator

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2624,6 +2624,12 @@ parse_argument(yp_parser_t *parser, yp_node_t *arguments) {
     return yp_node_star_node_create(parser, &parser->previous, expression);
   }
 
+  if (accept(parser, YP_TOKEN_AMPERSAND)) {
+    yp_token_t operator = parser->previous;
+    yp_node_t *expr = parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an argument.");
+    return yp_node_symbol_to_proc_node_create(parser, &operator, expr);
+  }
+
   return parse_expression(parser, BINDING_POWER_NONE, "Expected to be able to parse an argument.");
 }
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3290,6 +3290,25 @@ class ParseTest < Test::Unit::TestCase
     refute YARP.parse("#encoding: utf8").errors.empty?
   end
 
+  test "symbol to proc argument" do
+    expected = CallNode(
+      nil,
+      nil,
+      IDENTIFIER("foo"),
+      PARENTHESIS_LEFT("("),
+      ArgumentsNode(
+        [SymbolToProcNode(
+           AMPERSAND("&"),
+           SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("hi"), nil)
+         )]
+      ),
+      PARENTHESIS_RIGHT(")"),
+      "foo"
+    )
+
+    assert_parses expected, "foo(&:hi)"
+  end
+
   private
 
   def assert_serializes(expected, source)


### PR DESCRIPTION
    foo(&:hi)

Should parse now. Things like

    foo(&hi.to_sym)

also works, just like in Ruby. There are probably some things that this supports that are invalid, but this is a start.