### PR TITLE
Heredoc beginnings

### DIFF
--- a/bin/template.rb
+++ b/bin/template.rb
@@ -64,6 +64,13 @@ class LocationParam < Struct.new(:name)
   def java_type = "Location"
 end
 
+# This represents an integer parameter.
+class IntegerParam < Struct.new(:name)
+  def param = "int #{name}"
+  def rbs_class = "Integer"
+  def java_type = "int"
+end
+
 # This class represents a node in the tree, configured by the config.yml file in
 # YAML format. It contains information about the name of the node, the various
 # child nodes it contains, and how to obtain the location of the node in the
@@ -99,6 +106,8 @@ class NodeType
           TokenListParam.new(name)
         when "location"
           LocationParam.new(name)
+        when "integer"
+          IntegerParam.new(name)
         else
           raise "Unknown param type: #{param["type"].inspect}"
         end

--- a/bin/templates/ext/yarp/node.c.erb
+++ b/bin/templates/ext/yarp/node.c.erb
@@ -71,6 +71,8 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node) {
       }
       <%- when LocationParam -%>
       argv[<%= index %>] = location_new(parser, node->as.<%= node.human %>.<%= param.name %>.start, node->as.<%= node.human %>.<%= param.name %>.end);
+      <%- when IntegerParam -%>
+      argv[<%= index %>] = INT2FIX(node->as.<%= node.human %>.<%= param.name %>);
       <%- else -%>
       <%- raise -%>
       <%- end -%>

--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -87,6 +87,10 @@ public class Loader {
         return new Nodes.Location(startOffset, endOffset);
     }
 
+    private int loadInteger() {
+        return buffer.getInt();
+    }
+
     private Nodes.Node loadNode() {
         int type = buffer.get() & 0xFF;
         int length = buffer.getInt();
@@ -106,6 +110,7 @@ public class Loader {
                     when TokenListParam then "loadTokens()"
                     when OptionalTokenParam then "loadOptionalToken()"
                     when LocationParam then "loadLocation()"
+                    when IntegerParam then "loadInteger()"
                     else raise
                     end
             } + ["startOffset", "endOffset"]).join(", ") -%>);

--- a/bin/templates/lib/yarp/serialize.rb.erb
+++ b/bin/templates/lib/yarp/serialize.rb.erb
@@ -83,6 +83,7 @@ module YARP
           when TokenListParam then "io.read(4).unpack1(\"L\").times.map { load_token }"
           when OptionalTokenParam then "load_optional_token"
           when LocationParam then "load_location"
+          when IntegerParam then "io.read(4).unpack1(\"L\")"
           else raise
           end
         } + ["location"]).join(", ") -%>)

--- a/bin/templates/src/ast.h.erb
+++ b/bin/templates/src/ast.h.erb
@@ -80,6 +80,7 @@ typedef struct yp_node {
       in TokenListParam then "yp_token_list_t #{param.name}"
       in StringParam then "yp_string_t #{param.name}"
       in LocationParam then "yp_location_t #{param.name}"
+      in IntegerParam then "int #{param.name}"
       end
       %>;
     <%- end -%>

--- a/bin/templates/src/node.c.erb
+++ b/bin/templates/src/node.c.erb
@@ -111,7 +111,7 @@ yp_node_list_free(yp_parser_t *parser, yp_node_list_t *list) {
 yp_node_t *
 <%- assigns = node.params.map { |param| 
   case param
-  in NodeParam | OptionalNodeParam then ".#{param.name} = #{param.name}"
+  in NodeParam | OptionalNodeParam | IntegerParam then ".#{param.name} = #{param.name}"
   in TokenParam | OptionalTokenParam then ".#{param.name} = *#{param.name}"
   in LocationParam then ".#{param.name} = *#{param.name}"
   in StringParam | NodeListParam | TokenListParam then nil
@@ -142,7 +142,7 @@ yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
     case <%= node.type %>:
       <%- node.params.each do |param| -%>
       <%- case param -%>
-      <%- when TokenParam, OptionalTokenParam, LocationParam -%>
+      <%- when TokenParam, OptionalTokenParam, LocationParam, IntegerParam -%>
       <%- when NodeParam -%>
       yp_node_destroy(parser, node->as.<%= node.human %>.<%= param.name %>);
       <%- when OptionalNodeParam -%>
@@ -190,6 +190,8 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
       memsize->memsize += yp_token_list_memsize(&node->as.<%= node.human %>.<%= param.name %>);
       <%- when LocationParam -%>
       memsize->memsize += sizeof(yp_location_t);
+      <%- when IntegerParam -%>
+      memsize->memsize += sizeof(int);
       <%- else -%>
       <%- raise -%>
       <%- end -%>

--- a/bin/templates/src/prettyprint.c.erb
+++ b/bin/templates/src/prettyprint.c.erb
@@ -63,6 +63,13 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
       }
       <%- when LocationParam -%>
       prettyprint_location(buffer, parser, &node->as.<%= node.human %>.<%= param.name %>);
+      <%- when IntegerParam -%>
+      char <%= param.name %>_buffer[12];
+      snprintf(<%= param.name %>_buffer, 12, "+%d", node->as.<%= node.human %>.<%= param.name %>);
+      if (node->as.<%= node.human %>.<%= param.name %> < 0) {
+        <%= param.name %>_buffer[0] = '-';
+      }
+      yp_buffer_append_str(buffer, <%= param.name %>_buffer, strlen(<%= param.name %>_buffer));
       <%- else -%>
       <%- raise -%>
       <%- end -%>

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -69,6 +69,8 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
       }
       <%- when LocationParam -%>
       serialize_location(parser, &node->as.<%= node.human %>.<%= param.name %>, buffer);
+      <%- when IntegerParam -%>
+      yp_buffer_append_int(buffer, node->as.<%= node.human %>.<%= param.name %>);
       <%- else -%>
       <%- raise -%>
       <%- end -%>

--- a/config.yml
+++ b/config.yml
@@ -743,6 +743,24 @@ nodes:
 
           { a => b }
           ^^^^^^^^^^
+  - name: HeredocNode
+    child_nodes:
+      - name: opening
+        type: token
+      - name: parts
+        type: node[]
+      - name: closing
+        type: token
+      - name: dedent
+        type: integer
+    location: opening->closing
+    comment: |
+      Represents the use of a heredoc.
+
+          <<~HERE
+            Content.
+          HERE
+          ^^^^^^^^^^
   - name: IfNode
     child_nodes:
       - name: if_keyword

--- a/config.yml
+++ b/config.yml
@@ -100,6 +100,10 @@ tokens:
     comment: ">>="
   - name: GLOBAL_VARIABLE
     comment: "a global variable"
+  - name: HEREDOC_END
+    comment: "the end of a heredoc"
+  - name: HEREDOC_START
+    comment: "the start of a heredoc"
   - name: IDENTIFIER
     comment: "an identifier"
   - name: IMAGINARY_NUMBER

--- a/docs/heredocs.md
+++ b/docs/heredocs.md
@@ -12,6 +12,8 @@ When a heredoc identifier is encountered in the regular process of lexing, we pu
 
 We also set the special `parser.next_start` field which is a pointer to the place in the source where we should start lexing the next token. This is set to the pointer of the character immediately following the next newline.
 
+Note that if the `parser.heredoc_end` field is already set, then it means we have already encountered a heredoc on this line. In that case the `parser.next_start` field will be set to the `parser.heredoc_end` field. This is because we want to skip past the heredoc previous heredocs on this line and instead lex the body of this heredoc.
+
 ## 2. Lexing the body
 
 The next time the lexer is asked for a token, it will be in the `YP_LEX_HEREDOC` mode. In this mode we are lexing the body of the heredoc. It will start by checking if the `next_start` field is set. If it is, then this is the first token within the body of the heredoc so we'll start lexing from there. Otherwise we'll start lexing from the end of the previous token.
@@ -27,4 +29,4 @@ On every newline within the body of a heredoc, we check to see if it matches the
 
 ## 4. Lexing the rest of the line
 
-Once the heredoc has been lexed, the lexer will resume lexing from the `next_start` field.
+Once the heredoc has been lexed, the lexer will resume lexing from the `next_start` field. Lexing will continue until the next newline character. When the next newline character is found, it will check to see if the `heredoc_end` field is set. If it is it will skip to that point, unset the field, and continue lexing.

--- a/docs/heredocs.md
+++ b/docs/heredocs.md
@@ -30,3 +30,7 @@ On every newline within the body of a heredoc, we check to see if it matches the
 ## 4. Lexing the rest of the line
 
 Once the heredoc has been lexed, the lexer will resume lexing from the `next_start` field. Lexing will continue until the next newline character. When the next newline character is found, it will check to see if the `heredoc_end` field is set. If it is it will skip to that point, unset the field, and continue lexing.
+
+## Compatibility with Ripper
+
+The order in which tokens are emitted is different from that of Ripper. Ripper emits each token in the file in the order in which it appears. YARP instead will emit the tokens that makes the most sense for the lexer, using the process described above. Therefore to line things up, `YARP.lex_compat` will shuffle the tokens around to match Ripper's output.

--- a/docs/heredocs.md
+++ b/docs/heredocs.md
@@ -1,0 +1,30 @@
+# Heredocs
+
+Heredocs are one of the most complicated pieces of this parser. There are many different forms, there can be multiple open at the same time, and they can be nested. In order to support parsing them, we keep track of a lot of metadata. Below is a basic overview of how it works.
+
+## 1. Lexing the identifier
+
+When a heredoc identifier is encountered in the regular process of lexing, we push the `YP_LEX_HEREDOC` mode onto the stack with the following metadata:
+
+* `ident_start`: A pointer to the start of the identifier for the heredoc. We need this to match against the end of the heredoc.
+* `ident_length`: The length of the identifier for the heredoc. We also need this to match.
+* `next_start`: A pointer to the place in source that the parser should resume lexing once it has completed this heredoc.
+
+We also set the special `parser.next_start` field which is a pointer to the place in the source where we should start lexing the next token. This is set to the pointer of the character immediately following the next newline.
+
+## 2. Lexing the body
+
+The next time the lexer is asked for a token, it will be in the `YP_LEX_HEREDOC` mode. In this mode we are lexing the body of the heredoc. It will start by checking if the `next_start` field is set. If it is, then this is the first token within the body of the heredoc so we'll start lexing from there. Otherwise we'll start lexing from the end of the previous token.
+
+Lexing these fields is extremely similar to lexing an interpolated string. The only difference is that we also do an additional check at the beginning of each line to check if we have hit the terminator.
+
+## 3. Lexing the terminator
+
+On every newline within the body of a heredoc, we check to see if it matches the terminator followed by a newline or a carriage return and a newline. If it does, then we pop the lex mode off the stack and set a couple of fields on the parser:
+
+* `next_start`: This is set to the value that we previously stored on the heredoc to indicate where the lexer should resume lexing when it is done with this heredoc.
+* `next_newline`: This is set to the end of the heredoc. When a newline character is found, this indicates that the lexer should skip past to this next point.
+
+## 4. Lexing the rest of the line
+
+Once the heredoc has been lexed, the lexer will resume lexing from the `next_start` field.

--- a/docs/heredocs.md
+++ b/docs/heredocs.md
@@ -23,7 +23,7 @@ Lexing these fields is extremely similar to lexing an interpolated string. The o
 On every newline within the body of a heredoc, we check to see if it matches the terminator followed by a newline or a carriage return and a newline. If it does, then we pop the lex mode off the stack and set a couple of fields on the parser:
 
 * `next_start`: This is set to the value that we previously stored on the heredoc to indicate where the lexer should resume lexing when it is done with this heredoc.
-* `next_newline`: This is set to the end of the heredoc. When a newline character is found, this indicates that the lexer should skip past to this next point.
+* `heredoc_end`: This is set to the end of the heredoc. When a newline character is found, this indicates that the lexer should skip past to this next point.
 
 ## 4. Lexing the rest of the line
 

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -370,17 +370,28 @@ module YARP
         case state
         when :default
           tokens << token
-          state = :heredoc_opened if event == :on_heredoc_beg
+
+          if event == :on_heredoc_beg
+            state = :heredoc_opened
+            heredoc << []
+          end
         when :heredoc_opened
-          heredoc << token
+          heredoc.last << token
           state = :heredoc_closed if event == :on_heredoc_end
         when :heredoc_closed
           tokens << token
 
-          if event == :on_nl
-            tokens.concat(heredoc)
+          case event
+          when :on_nl
+            heredoc.each do |heredoc_tokens|
+              tokens.concat(heredoc_tokens)
+            end
+
             heredoc.clear
             state = :default
+          when :on_heredoc_beg
+            state = :heredoc_opened
+            heredoc << []
           end
         end
       end

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -277,6 +277,8 @@ module YARP
     GREATER_GREATER: :on_op,
     GREATER_GREATER_EQUAL: :on_op,
     GLOBAL_VARIABLE: :on_gvar,
+    HEREDOC_END: :on_heredoc_end,
+    HEREDOC_START: :on_heredoc_beg,
     IDENTIFIER: :on_ident,
     IMAGINARY_NUMBER: :on_imaginary,
     INTEGER: :on_int,

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -177,206 +177,263 @@ module YARP
     end
   end
 
+  # This class is responsible for lexing the source using YARP and then
+  # converting those tokens to be compatible with Ripper.
+  class LexCompat
+    RIPPER = {
+      AMPERSAND: :on_op,
+      AMPERSAND_AMPERSAND: :on_op,
+      AMPERSAND_AMPERSAND_EQUAL: :on_op,
+      AMPERSAND_DOT: :on_op,
+      AMPERSAND_EQUAL: :on_op,
+      BACK_REFERENCE: :on_backref,
+      BACKTICK: :on_backtick,
+      BANG: :on_op,
+      BANG_AT: :on_op,
+      BANG_EQUAL: :on_op,
+      BANG_TILDE: :on_op,
+      BRACE_LEFT: :on_lbrace,
+      BRACE_RIGHT: :on_rbrace,
+      BRACKET_LEFT: :on_lbracket,
+      BRACKET_LEFT_RIGHT: :on_op,
+      BRACKET_LEFT_RIGHT_EQUAL: :on_op,
+      BRACKET_RIGHT: :on_rbracket,
+      CARET: :on_op,
+      CARET_EQUAL: :on_op,
+      CHARACTER_LITERAL: :on_CHAR,
+      CLASS_VARIABLE: :on_cvar,
+      COLON: :on_op,
+      COLON_COLON: :on_op,
+      COMMA: :on_comma,
+      COMMENT: :on_comment,
+      CONSTANT: :on_const,
+      DOT: :on_period,
+      DOT_DOT: :on_op,
+      DOT_DOT_DOT: :on_op,
+      EMBDOC_BEGIN: :on_embdoc_beg,
+      EMBDOC_END: :on_embdoc_end,
+      EMBDOC_LINE: :on_embdoc,
+      EMBEXPR_BEGIN: :on_embexpr_beg,
+      EMBEXPR_END: :on_embexpr_end,
+      EMBVAR: :on_embvar,
+      EOF: :on_eof,
+      EQUAL: :on_op,
+      EQUAL_EQUAL: :on_op,
+      EQUAL_EQUAL_EQUAL: :on_op,
+      EQUAL_GREATER: :on_op,
+      EQUAL_TILDE: :on_op,
+      FLOAT: :on_float,
+      GREATER: :on_op,
+      GREATER_EQUAL: :on_op,
+      GREATER_GREATER: :on_op,
+      GREATER_GREATER_EQUAL: :on_op,
+      GLOBAL_VARIABLE: :on_gvar,
+      HEREDOC_END: :on_heredoc_end,
+      HEREDOC_START: :on_heredoc_beg,
+      IDENTIFIER: :on_ident,
+      IMAGINARY_NUMBER: :on_imaginary,
+      INTEGER: :on_int,
+      INSTANCE_VARIABLE: :on_ivar,
+      INVALID: :INVALID,
+      KEYWORD___ENCODING__: :on_kw,
+      KEYWORD___LINE__: :on_kw,
+      KEYWORD___FILE__: :on_kw,
+      KEYWORD_ALIAS: :on_kw,
+      KEYWORD_AND: :on_kw,
+      KEYWORD_BEGIN: :on_kw,
+      KEYWORD_BEGIN_UPCASE: :on_kw,
+      KEYWORD_BREAK: :on_kw,
+      KEYWORD_CASE: :on_kw,
+      KEYWORD_CLASS: :on_kw,
+      KEYWORD_DEF: :on_kw,
+      KEYWORD_DEFINED: :on_kw,
+      KEYWORD_DO: :on_kw,
+      KEYWORD_DO_LOOP: :on_kw,
+      KEYWORD_ELSE: :on_kw,
+      KEYWORD_ELSIF: :on_kw,
+      KEYWORD_END: :on_kw,
+      KEYWORD_END_UPCASE: :on_kw,
+      KEYWORD_ENSURE: :on_kw,
+      KEYWORD_FALSE: :on_kw,
+      KEYWORD_FOR: :on_kw,
+      KEYWORD_IF: :on_kw,
+      KEYWORD_IN: :on_kw,
+      KEYWORD_MODULE: :on_kw,
+      KEYWORD_NEXT: :on_kw,
+      KEYWORD_NIL: :on_kw,
+      KEYWORD_NOT: :on_kw,
+      KEYWORD_OR: :on_kw,
+      KEYWORD_REDO: :on_kw,
+      KEYWORD_RESCUE: :on_kw,
+      KEYWORD_RETRY: :on_kw,
+      KEYWORD_RETURN: :on_kw,
+      KEYWORD_SELF: :on_kw,
+      KEYWORD_SUPER: :on_kw,
+      KEYWORD_THEN: :on_kw,
+      KEYWORD_TRUE: :on_kw,
+      KEYWORD_UNDEF: :on_kw,
+      KEYWORD_UNLESS: :on_kw,
+      KEYWORD_UNTIL: :on_kw,
+      KEYWORD_WHEN: :on_kw,
+      KEYWORD_WHILE: :on_kw,
+      KEYWORD_YIELD: :on_kw,
+      LABEL: :on_label,
+      LAMBDA_BEGIN: :on_tlambeg,
+      LESS: :on_op,
+      LESS_EQUAL: :on_op,
+      LESS_EQUAL_GREATER: :on_op,
+      LESS_LESS: :on_op,
+      LESS_LESS_EQUAL: :on_op,
+      MINUS: :on_op,
+      MINUS_AT: :on_op,
+      MINUS_EQUAL: :on_op,
+      MINUS_GREATER: :on_tlambda,
+      NEWLINE: :on_nl,
+      NTH_REFERENCE: :on_backref,
+      PARENTHESIS_LEFT: :on_lparen,
+      PARENTHESIS_RIGHT: :on_rparen,
+      PERCENT: :on_op,
+      PERCENT_EQUAL: :on_op,
+      PERCENT_LOWER_I: :on_qsymbols_beg,
+      PERCENT_LOWER_W: :on_qwords_beg,
+      PERCENT_LOWER_X: :on_backtick,
+      PERCENT_UPPER_I: :on_symbols_beg,
+      PERCENT_UPPER_W: :on_words_beg,
+      PIPE: :on_op,
+      PIPE_EQUAL: :on_op,
+      PIPE_PIPE: :on_op,
+      PIPE_PIPE_EQUAL: :on_op,
+      PLUS: :on_op,
+      PLUS_AT: :on_op,
+      PLUS_EQUAL: :on_op,
+      QUESTION_MARK: :on_op,
+      RATIONAL_NUMBER: :on_rational,
+      REGEXP_BEGIN: :on_regexp_beg,
+      REGEXP_END: :on_regexp_end,
+      SEMICOLON: :on_semicolon,
+      SLASH: :on_op,
+      SLASH_EQUAL: :on_op,
+      STAR: :on_op,
+      STAR_EQUAL: :on_op,
+      STAR_STAR: :on_op,
+      STAR_STAR_EQUAL: :on_op,
+      STRING_BEGIN: :on_tstring_beg,
+      STRING_CONTENT: :on_tstring_content,
+      STRING_END: :on_tstring_end,
+      SYMBOL_BEGIN: :on_symbeg,
+      TILDE: :on_op,
+      TILDE_AT: :on_op,
+      WORDS_SEP: :on_words_sep,
+      __END__: :on___end__
+    }.freeze
+
+    private_constant :RIPPER
+
+    attr_reader :source, :offsets
+
+    def initialize(source)
+      @source = source
+
+      @offsets = [0]
+      last_offset = 0
+
+      source.each_line do |line|
+        last_offset += line.bytesize
+        @offsets << last_offset
+      end
+    end
+
+    def tokens
+      tokens = []
+
+      state = :default
+      heredoc = []
+
+      YARP.lex(source).each do |(token, lex_state)|
+        event = RIPPER.fetch(token.type)
+        token = [
+          location_for(token.location.start_offset),
+          event,
+          value_for(event, token.value),
+          Ripper::Lexer::State.new(lex_state)
+        ]
+
+        # The order in which tokens appear in our lexer is different from the
+        # order that they appear in Ripper. When we hit the declaration of a
+        # heredoc in YARP, we skip forward and lex the rest of the content of
+        # the heredoc before going back and lexing at the end of the heredoc
+        # identifier.
+        #
+        # To match up to ripper, we keep a small state variable around here to
+        # track whether we're in the middle of a heredoc or not. In this way we
+        # can shuffle around the token to match Ripper's output.
+        case state
+        when :default
+          tokens << token
+          state = :heredoc_opened if event == :on_heredoc_beg
+        when :heredoc_opened
+          heredoc << token
+          state = :heredoc_closed if event == :on_heredoc_end
+        when :heredoc_closed
+          tokens << token
+
+          if event == :on_nl
+            tokens.concat(heredoc)
+            heredoc.clear
+            state = :default
+          end
+        end
+      end
+
+      tokens[0...-1]
+    end
+
+    private
+
+    def location_for(start_offset)
+      line_number, line_offset =
+        offsets.each_with_index.detect do |(offset, line)|
+          break [line, offsets[line - 1]] if start_offset < offset
+        end
+
+      [
+        line_number || offsets.length - 1,
+        start_offset - (line_offset || offsets.last)
+      ]
+    end
+
+    def value_for(event, value)
+      case event
+      when :on_comment, :on_tstring_content
+        # Ripper unescapes string content and comments, so we need to do the
+        # same here. We're going to attempt to force it into UTF-8, but if
+        # that doesn't work we'll just use the plain value.
+        begin
+          value.force_encoding("UTF-8").unicode_normalize
+        rescue ArgumentError
+          value
+        end
+      when :on___end__
+        # Ripper doesn't include the rest of the token in the event, so we
+        # need to trim it down to just the first newline.
+        value[0..value.index("\n")]
+      else
+        value
+      end
+    end
+  end
+
   # Returns an array of tokens that closely resembles that of the Ripper lexer.
   # The only difference is that since we don't keep track of lexer state in the
   # same way, it's going to always return the NONE state.
   def self.lex_compat(source)
-    offsets = [0]
-    source.each_line { |line| offsets << offsets.last + line.bytesize }
-
-    tokens = []
-    lex(source).each do |(token, state)|
-      line_number, line_offset =
-        offsets.each_with_index.detect do |(offset, line)|
-          break [line, offsets[line - 1]] if token.location.start_offset < offset
-        end
-
-      line_number ||= offsets.length + 1
-      line_offset ||= offsets.last
-
-      line_byte = token.location.start_offset - line_offset
-      event = RIPPER.fetch(token.type)
-
-      value = token.value
-      normalized =
-        case event
-        when :on_comment, :on_tstring_content
-          # Ripper unescapes string content and comments, so we need to do the
-          # same here. We're going to attempt to force it into UTF-8, but if
-          # that doesn't work we'll just use the plain value.
-          begin
-            value.force_encoding("UTF-8").unicode_normalize
-          rescue ArgumentError
-            value
-          end
-        when :on___end__
-          # Ripper doesn't include the rest of the token in the event, so we
-          # need to trim it down to just the first newline.
-          value[0..value.index("\n")]
-        else
-          value
-        end
-
-      lexer_state = Ripper::Lexer::State.new(state)
-      tokens << [[line_number, line_byte], event, normalized, lexer_state]
-    end
-
-    tokens[0...-1]
+    LexCompat.new(source).tokens
   end
 
   # Load the serialized AST using the source as a reference into a tree.
   def self.load(source, serialized)
     Serialize.load(source, serialized)
   end
-
-  RIPPER = {
-    AMPERSAND: :on_op,
-    AMPERSAND_AMPERSAND: :on_op,
-    AMPERSAND_AMPERSAND_EQUAL: :on_op,
-    AMPERSAND_DOT: :on_op,
-    AMPERSAND_EQUAL: :on_op,
-    BACK_REFERENCE: :on_backref,
-    BACKTICK: :on_backtick,
-    BANG: :on_op,
-    BANG_AT: :on_op,
-    BANG_EQUAL: :on_op,
-    BANG_TILDE: :on_op,
-    BRACE_LEFT: :on_lbrace,
-    BRACE_RIGHT: :on_rbrace,
-    BRACKET_LEFT: :on_lbracket,
-    BRACKET_LEFT_RIGHT: :on_op,
-    BRACKET_LEFT_RIGHT_EQUAL: :on_op,
-    BRACKET_RIGHT: :on_rbracket,
-    CARET: :on_op,
-    CARET_EQUAL: :on_op,
-    CHARACTER_LITERAL: :on_CHAR,
-    CLASS_VARIABLE: :on_cvar,
-    COLON: :on_op,
-    COLON_COLON: :on_op,
-    COMMA: :on_comma,
-    COMMENT: :on_comment,
-    CONSTANT: :on_const,
-    DOT: :on_period,
-    DOT_DOT: :on_op,
-    DOT_DOT_DOT: :on_op,
-    EMBDOC_BEGIN: :on_embdoc_beg,
-    EMBDOC_END: :on_embdoc_end,
-    EMBDOC_LINE: :on_embdoc,
-    EMBEXPR_BEGIN: :on_embexpr_beg,
-    EMBEXPR_END: :on_embexpr_end,
-    EMBVAR: :on_embvar,
-    EOF: :on_eof,
-    EQUAL: :on_op,
-    EQUAL_EQUAL: :on_op,
-    EQUAL_EQUAL_EQUAL: :on_op,
-    EQUAL_GREATER: :on_op,
-    EQUAL_TILDE: :on_op,
-    FLOAT: :on_float,
-    GREATER: :on_op,
-    GREATER_EQUAL: :on_op,
-    GREATER_GREATER: :on_op,
-    GREATER_GREATER_EQUAL: :on_op,
-    GLOBAL_VARIABLE: :on_gvar,
-    HEREDOC_END: :on_heredoc_end,
-    HEREDOC_START: :on_heredoc_beg,
-    IDENTIFIER: :on_ident,
-    IMAGINARY_NUMBER: :on_imaginary,
-    INTEGER: :on_int,
-    INSTANCE_VARIABLE: :on_ivar,
-    INVALID: :INVALID,
-    KEYWORD___ENCODING__: :on_kw,
-    KEYWORD___LINE__: :on_kw,
-    KEYWORD___FILE__: :on_kw,
-    KEYWORD_ALIAS: :on_kw,
-    KEYWORD_AND: :on_kw,
-    KEYWORD_BEGIN: :on_kw,
-    KEYWORD_BEGIN_UPCASE: :on_kw,
-    KEYWORD_BREAK: :on_kw,
-    KEYWORD_CASE: :on_kw,
-    KEYWORD_CLASS: :on_kw,
-    KEYWORD_DEF: :on_kw,
-    KEYWORD_DEFINED: :on_kw,
-    KEYWORD_DO: :on_kw,
-    KEYWORD_DO_LOOP: :on_kw,
-    KEYWORD_ELSE: :on_kw,
-    KEYWORD_ELSIF: :on_kw,
-    KEYWORD_END: :on_kw,
-    KEYWORD_END_UPCASE: :on_kw,
-    KEYWORD_ENSURE: :on_kw,
-    KEYWORD_FALSE: :on_kw,
-    KEYWORD_FOR: :on_kw,
-    KEYWORD_IF: :on_kw,
-    KEYWORD_IN: :on_kw,
-    KEYWORD_MODULE: :on_kw,
-    KEYWORD_NEXT: :on_kw,
-    KEYWORD_NIL: :on_kw,
-    KEYWORD_NOT: :on_kw,
-    KEYWORD_OR: :on_kw,
-    KEYWORD_REDO: :on_kw,
-    KEYWORD_RESCUE: :on_kw,
-    KEYWORD_RETRY: :on_kw,
-    KEYWORD_RETURN: :on_kw,
-    KEYWORD_SELF: :on_kw,
-    KEYWORD_SUPER: :on_kw,
-    KEYWORD_THEN: :on_kw,
-    KEYWORD_TRUE: :on_kw,
-    KEYWORD_UNDEF: :on_kw,
-    KEYWORD_UNLESS: :on_kw,
-    KEYWORD_UNTIL: :on_kw,
-    KEYWORD_WHEN: :on_kw,
-    KEYWORD_WHILE: :on_kw,
-    KEYWORD_YIELD: :on_kw,
-    LABEL: :on_label,
-    LAMBDA_BEGIN: :on_tlambeg,
-    LESS: :on_op,
-    LESS_EQUAL: :on_op,
-    LESS_EQUAL_GREATER: :on_op,
-    LESS_LESS: :on_op,
-    LESS_LESS_EQUAL: :on_op,
-    MINUS: :on_op,
-    MINUS_AT: :on_op,
-    MINUS_EQUAL: :on_op,
-    MINUS_GREATER: :on_tlambda,
-    NEWLINE: :on_nl,
-    NTH_REFERENCE: :on_backref,
-    PARENTHESIS_LEFT: :on_lparen,
-    PARENTHESIS_RIGHT: :on_rparen,
-    PERCENT: :on_op,
-    PERCENT_EQUAL: :on_op,
-    PERCENT_LOWER_I: :on_qsymbols_beg,
-    PERCENT_LOWER_W: :on_qwords_beg,
-    PERCENT_LOWER_X: :on_backtick,
-    PERCENT_UPPER_I: :on_symbols_beg,
-    PERCENT_UPPER_W: :on_words_beg,
-    PIPE: :on_op,
-    PIPE_EQUAL: :on_op,
-    PIPE_PIPE: :on_op,
-    PIPE_PIPE_EQUAL: :on_op,
-    PLUS: :on_op,
-    PLUS_AT: :on_op,
-    PLUS_EQUAL: :on_op,
-    QUESTION_MARK: :on_op,
-    RATIONAL_NUMBER: :on_rational,
-    REGEXP_BEGIN: :on_regexp_beg,
-    REGEXP_END: :on_regexp_end,
-    SEMICOLON: :on_semicolon,
-    SLASH: :on_op,
-    SLASH_EQUAL: :on_op,
-    STAR: :on_op,
-    STAR_EQUAL: :on_op,
-    STAR_STAR: :on_op,
-    STAR_STAR_EQUAL: :on_op,
-    STRING_BEGIN: :on_tstring_beg,
-    STRING_CONTENT: :on_tstring_content,
-    STRING_END: :on_tstring_end,
-    SYMBOL_BEGIN: :on_symbeg,
-    TILDE: :on_op,
-    TILDE_AT: :on_op,
-    WORDS_SEP: :on_words_sep,
-    __END__: :on___end__
-  }.freeze
-
-  private_constant :RIPPER
 end
 
 require_relative "yarp/node"

--- a/src/parser.h
+++ b/src/parser.h
@@ -258,6 +258,10 @@ struct yp_parser {
   // This is an optional callback that can be attached to the parser that will
   // be called whenever a new token is lexed by the parser.
   yp_lex_callback_t *lex_callback;
+
+  // This is the current heredoc where we have found the declaration but have
+  // not yet parsed the body.
+  yp_node_t *current_heredoc;
 };
 
 #endif // YARP_PARSER_H

--- a/src/parser.h
+++ b/src/parser.h
@@ -119,6 +119,11 @@ typedef struct yp_lex_mode {
       // Whether or not interpolation is allowed in this symbol.
       bool interpolation;
     } symbol;
+
+    struct {
+      // This is the heredoc node that we are currently filling in.
+      yp_node_t *node;
+    } heredoc;
   } as;
 
   // The previous lex state so that it knows how to pop.

--- a/src/parser.h
+++ b/src/parser.h
@@ -69,6 +69,9 @@ typedef struct yp_lex_mode {
     // inside of a string with the # shorthand.
     YP_LEX_EMBVAR,
 
+    // This state is used when you are inside the content of a heredoc.
+    YP_LEX_HEREDOC,
+
     // This state is used when we are lexing a list of tokens, as in a %w word
     // list literal or a %i symbol list literal.
     YP_LEX_LIST,

--- a/src/parser.h
+++ b/src/parser.h
@@ -248,11 +248,16 @@ struct yp_parser {
   yp_token_t previous; // the previous token we were considering
   yp_token_t current;  // the current token we're considering
 
-  // When we hit a newline, we need to check this point to see if it is set. If
-  // it is, then we need to jump to this point and continue lexing from there.
-  // This is to accommodate heredocs.
+  // This is a special field set on the parser when we need the parser to jump
+  // to a specific location when lexing the next token, as opposed to just using
+  // the end of the previous token. Normally this is NULL.
   const char *next_start;
-  const char *next_newline;
+
+  // This field indicates the end of a heredoc whose identifier was found on the
+  // current line. If another heredoc is found on the same line, then this will
+  // be moved forward to the end of that heredoc. If no heredocs are found on a
+  // line then this is NULL.
+  const char *heredoc_end;
 
   yp_list_t comment_list;             // the list of comments that have been found while parsing
   yp_list_t warning_list;             // the list of warnings that have been found while parsing

--- a/src/util/yp_buffer.c
+++ b/src/util/yp_buffer.c
@@ -62,6 +62,13 @@ yp_buffer_append_u64(yp_buffer_t *buffer, uint64_t value) {
   yp_buffer_append(buffer, source, sizeof(uint64_t));
 }
 
+// Append an integer to the buffer.
+void
+yp_buffer_append_int(yp_buffer_t *buffer, int value) {
+  const void *source = &value;
+  yp_buffer_append(buffer, source, sizeof(int));
+}
+
 // Free the memory associated with the buffer.
 void
 yp_buffer_free(yp_buffer_t *buffer) {

--- a/src/util/yp_buffer.h
+++ b/src/util/yp_buffer.h
@@ -42,6 +42,10 @@ yp_buffer_append_u32(yp_buffer_t *buffer, uint32_t value);
 void
 yp_buffer_append_u64(yp_buffer_t *buffer, uint64_t value);
 
+// Append an integer to the buffer.
+void
+yp_buffer_append_int(yp_buffer_t *buffer, int value);
+
 // Free the memory associated with the buffer.
 __attribute__ ((__visibility__("default"))) extern void
 yp_buffer_free(yp_buffer_t *buffer);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1511,7 +1511,7 @@ lex_token_type(yp_parser_t *parser) {
             ) {
               const char *end = parser->current.end;
 
-              match(parser, '-') || match(parser, '~');
+              (void) (match(parser, '-') || match(parser, '~'));
               const char *ident_start = parser->current.end;
 
               size_t width = char_is_identifier(parser, parser->current.end);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1,6 +1,4 @@
 #include "yarp.h"
-#include "ast.h"
-#include "node.h"
 
 #define STRINGIZE0(expr) #expr
 #define STRINGIZE(expr) STRINGIZE0(expr)

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1354,10 +1354,10 @@ lex_token_type(yp_parser_t *parser) {
           parser->command_start = true;
 
           // If the special resume flag is set, then we need to jump ahead.
-          if (parser->next_newline != NULL) {
-            assert(parser->next_newline <= parser->end);
-            parser->next_start = parser->next_newline;
-            parser->next_newline = NULL;
+          if (parser->heredoc_end != NULL) {
+            assert(parser->heredoc_end <= parser->end);
+            parser->next_start = parser->heredoc_end;
+            parser->heredoc_end = NULL;
           }
 
           return YP_TOKEN_NEWLINE;
@@ -1524,7 +1524,7 @@ lex_token_type(yp_parser_t *parser) {
                 }
               });
 
-              if (parser->next_newline == NULL) {
+              if (parser->heredoc_end == NULL) {
                 const char *body_start = (const char *) memchr(parser->current.end, '\n', parser->end - parser->current.end);
 
                 if (body_start == NULL) {
@@ -1535,7 +1535,7 @@ lex_token_type(yp_parser_t *parser) {
 
                 parser->next_start = body_start + 1;
               } else {
-                parser->next_start = parser->next_newline;
+                parser->next_start = parser->heredoc_end;
               }
 
               return YP_TOKEN_HEREDOC_START;
@@ -2300,7 +2300,7 @@ lex_token_type(yp_parser_t *parser) {
 
         if (matched) {
           parser->next_start = parser->lex_modes.current->as.heredoc.next_start;
-          parser->next_newline = parser->current.end;
+          parser->heredoc_end = parser->current.end;
 
           lex_mode_pop(parser);
           return YP_TOKEN_HEREDOC_END;
@@ -5301,7 +5301,7 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size) {
     .end = source + size,
     .current = { .start = source, .end = source },
     .next_start = NULL,
-    .next_newline = NULL,
+    .heredoc_end = NULL,
     .current_scope = NULL,
     .current_context = NULL,
     .recovering = false,

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -360,6 +360,7 @@ debug_lex_mode(yp_parser_t *parser) {
     case YP_LEX_EMBDOC: fprintf(stderr, "lexing in EMBDOC mode\n"); return;
     case YP_LEX_EMBEXPR: fprintf(stderr, "lexing in EMBEXPR mode\n"); return;
     case YP_LEX_EMBVAR: fprintf(stderr, "lexing in EMBVAR mode\n"); return;
+    case YP_LEX_HEREDOC: fprintf(stderr, "lexing in HEREDOC mode\n"); return;
     case YP_LEX_LIST: fprintf(stderr, "lexing in LIST mode (terminator=%c, interpolation=%d)\n", lex_mode->as.list.terminator, lex_mode->as.list.interpolation); return;
     case YP_LEX_REGEXP: fprintf(stderr, "lexing in REGEXP mode (terminator=%c)\n", lex_mode->as.regexp.terminator); return;
     case YP_LEX_STRING: fprintf(stderr, "lexing in STRING mode (terminator=%c, interpolation=%d)\n", lex_mode->as.string.terminator, lex_mode->as.string.interpolation); return;
@@ -2177,13 +2178,16 @@ lex_token_type(yp_parser_t *parser) {
 
       // These are the places where we need to split up the content of the
       // string. We'll use strpbrk to find the first of these characters.
-      char breakpoints[] = " \\\0";
+      char breakpoints[3];
       breakpoints[0] = parser->lex_modes.current->as.string.terminator;
+      breakpoints[1] = '\\';
 
       // If interpolation is allowed, then we're going to check for the #
       // character. Otherwise we'll only look for escapes and the terminator.
       if (parser->lex_modes.current->as.string.interpolation) {
         breakpoints[2] = '#';
+      } else {
+        breakpoints[2] = '\0';
       }
 
       char *breakpoint = strpbrk(parser->current.end, breakpoints);
@@ -2233,6 +2237,9 @@ lex_token_type(yp_parser_t *parser) {
       parser->current.end = parser->end;
       return YP_TOKEN_EOF;
     }
+    case YP_LEX_HEREDOC:
+      assert(0);
+      break;
     case YP_LEX_SYMBOL: {
       // First, we'll set to start of this token to be the current end.
       parser->current.start = parser->current.end;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3932,13 +3932,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       return parse_identifier(parser);
     case YP_TOKEN_HEREDOC_START: {
       yp_node_t *node = yp_node_heredoc_node_create(parser, &parser->previous, &parser->previous, 0);
-
-      expect(parser, YP_TOKEN_STRING_CONTENT, "Expected string content for heredoc.");
-      yp_token_t content_start = not_provided(parser);
-      yp_token_t content_end = not_provided(parser);
-
-      yp_node_t *content = yp_node_string_node_create_and_unescape(parser, &content_start, &parser->previous, &content_end, YP_UNESCAPE_ALL);
-      yp_node_list_append(parser, node, &node->as.heredoc_node.parts, content);
+      parse_interpolated_string_parts(parser, YP_TOKEN_HEREDOC_END, node, &node->as.heredoc_node.parts);
 
       expect(parser, YP_TOKEN_HEREDOC_END, "Expected a closing delimiter for heredoc.");
       node->as.heredoc_node.closing = parser->previous;

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1920,7 +1920,7 @@ class ParseTest < Test::Unit::TestCase
       0
     )
 
-    assert_parses nil, "<<-EOF\n  a\nEOF"
+    assert_parses expected, "<<-EOF\n  a\nEOF"
   end
 
   test "identifier" do

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1915,12 +1915,12 @@ class ParseTest < Test::Unit::TestCase
   test "heredocs" do
     expected = HeredocNode(
       HEREDOC_START("<<-EOF"),
-      [STRING_CONTENT("  a\n")],
-      HEREDOC_END("EOF"),
+      [StringNode(nil, STRING_CONTENT("  a\n"), nil, "  a\n")],
+      HEREDOC_END("EOF\n"),
       0
     )
 
-    assert_parses expected, "<<-EOF\n  a\nEOF"
+    assert_parses expected, "<<-EOF\n  a\nEOF\n"
   end
 
   test "identifier" do

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1923,6 +1923,62 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "<<-EOF\n  a\nEOF\n"
   end
 
+  test "heredocs with multiple lines" do
+    expected = HeredocNode(
+      HEREDOC_START("<<-EOF"),
+      [StringNode(nil, STRING_CONTENT("  a\n  b\n"), nil, "  a\n  b\n")],
+      HEREDOC_END("EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<-EOF\n  a\n  b\nEOF\n"
+  end
+
+  test "heredocs with interpolation" do
+    expected = HeredocNode(
+      HEREDOC_START("<<-EOF"),
+      [
+        StringNode(nil, STRING_CONTENT("  a\n"), nil, "  a\n"),
+        StringInterpolatedNode(
+          EMBEXPR_BEGIN("\#{"),
+          Statements([CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, "b")]),
+          EMBEXPR_END("}")
+        ),
+        StringNode(nil, STRING_CONTENT("\n"), nil, "\n")
+      ],
+      HEREDOC_END("EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<-EOF\n  a\n\#{b}\nEOF\n"
+  end
+
+  test "heredocs on the same line" do
+    expected = CallNode(
+      HeredocNode(
+        HEREDOC_START("<<-FIRST"),
+        [StringNode(nil, STRING_CONTENT("  a\n"), nil, "  a\n")],
+        HEREDOC_END("FIRST\n"),
+        0
+      ),
+      nil,
+      PLUS("+"),
+      nil,
+      ArgumentsNode(
+        [HeredocNode(
+           HEREDOC_START("<<-SECOND"),
+           [StringNode(nil, STRING_CONTENT("  b\n"), nil, "  b\n")],
+           HEREDOC_END("SECOND\n"),
+           0
+         )]
+      ),
+      nil,
+      "+"
+    )
+
+    assert_parses expected, "<<-FIRST + <<-SECOND\n  a\nFIRST\n  b\nSECOND\n"
+  end
+
   test "identifier" do
     assert_parses CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a"), "a"
   end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1912,6 +1912,17 @@ class ParseTest < Test::Unit::TestCase
     assert_parses GlobalVariableWrite(GLOBAL_VARIABLE("$abc"), EQUAL("="), expression("1")), "$abc = 1"
   end
 
+  test "heredocs" do
+    expected = HeredocNode(
+      HEREDOC_START("<<-EOF"),
+      [STRING_CONTENT("  a\n")],
+      HEREDOC_END("EOF"),
+      0
+    )
+
+    assert_parses nil, "<<-EOF\n  a\nEOF"
+  end
+
   test "identifier" do
     assert_parses CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, "a"), "a"
   end


### PR DESCRIPTION
This PR introduces the concept of parsing heredocs. It specifically _doesn't_ handle a couple of cases, including:

* Nested heredocs (i.e., a heredoc interpolated into another heredoc)
* Heredocs with quotes on their declarations (e.g., ``<<-`FOO` ``, `<<-'FOO'`, and `<<-"FOO"`)
* Dedenting heredocs (e.g., `<<~FOO`)
* Heredocs that don't start at the beginning of the line