### PR TITLE
Fix memory leaks

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -916,6 +916,8 @@ nodes:
           end
   - name: LambdaNode
     child_nodes:
+      - name: scope
+        type: node
       - name: lparen
         type: token?
       - name: parameters

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1337,6 +1337,11 @@ class ParseTest < Test::Unit::TestCase
           HashNode(
             nil,
             [
+              AssocNode(
+                SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("there"), nil),
+                SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("friend"), nil),
+                EQUAL_GREATER("=>")
+              ),
               AssocSplatNode(
                 HashNode(BRACE_LEFT("{"), [], BRACE_RIGHT("}")),
                 Location(22, 24)
@@ -1370,6 +1375,11 @@ class ParseTest < Test::Unit::TestCase
           HashNode(
             nil,
             [
+              AssocNode(
+                SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("there"), nil),
+                SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("friend"), nil),
+                EQUAL_GREATER("=>")
+              ),
               AssocSplatNode(
                 HashNode(BRACE_LEFT("{"), [], BRACE_RIGHT("}")),
                 Location(22, 24)
@@ -4823,6 +4833,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "simple stabby lambda with braces" do
     expected = LambdaNode(
+      Scope([]),
       nil,
       BlockVarNode(
         ParametersNode([], [], nil, [], nil, nil),
@@ -4837,6 +4848,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "simple stabby lambda with do...end" do
     expected = LambdaNode(
+      Scope([]),
       nil,
       BlockVarNode(
         ParametersNode([], [], nil, [], nil, nil),
@@ -4851,6 +4863,15 @@ class ParseTest < Test::Unit::TestCase
 
   test "stabby lambda with parameters with braces" do
     expected = LambdaNode(
+      Scope([
+        IDENTIFIER("a"),
+        IDENTIFIER("b"),
+        LABEL("c"),
+        LABEL("d"),
+        IDENTIFIER("e"),
+        IDENTIFIER("f"),
+        IDENTIFIER("g")
+      ]),
       PARENTHESIS_LEFT("("),
       BlockVarNode(
         ParametersNode(
@@ -4876,6 +4897,13 @@ class ParseTest < Test::Unit::TestCase
 
   test "stabby lambda with non-parenthesised parameters with braces" do
     expected = LambdaNode(
+      Scope([
+        IDENTIFIER("a"),
+        IDENTIFIER("b"),
+        LABEL("c"),
+        LABEL("d"),
+        IDENTIFIER("e"),
+      ]),
       nil,
       BlockVarNode(
         ParametersNode(
@@ -4901,6 +4929,15 @@ class ParseTest < Test::Unit::TestCase
 
   test "stabby lambda with parameters with do..end" do
     expected = LambdaNode(
+      Scope([
+        IDENTIFIER("a"),
+        IDENTIFIER("b"),
+        LABEL("c"),
+        LABEL("d"),
+        IDENTIFIER("e"),
+        IDENTIFIER("f"),
+        IDENTIFIER("g")
+      ]),
       PARENTHESIS_LEFT("("),
       BlockVarNode(
         ParametersNode(
@@ -4926,6 +4963,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "nested lambdas" do
     expected = LambdaNode(
+      Scope([IDENTIFIER("a")]),
       PARENTHESIS_LEFT("("),
       BlockVarNode(
         ParametersNode(
@@ -4941,6 +4979,7 @@ class ParseTest < Test::Unit::TestCase
       PARENTHESIS_RIGHT(")"),
       Statements(
         [LambdaNode(
+          Scope([IDENTIFIER("b")]),
           nil,
           BlockVarNode(
             ParametersNode(
@@ -4973,6 +5012,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "lambdas with block locals" do
     expected = LambdaNode(
+      Scope([IDENTIFIER("a"), IDENTIFIER("b"), IDENTIFIER("c"), IDENTIFIER("d")]),
       PARENTHESIS_LEFT("("),
       BlockVarNode(
         ParametersNode(


### PR DESCRIPTION
This commit fixes a couple of memory leaks in YARP. They include:

* The LambdaNode type parses its scope using a Scope node, but does not retain a pointer to it. As such, the scope gets allocated but never deallocated. Instead, we now hold onto it and release it when the overall tree is deallocated.
* When parsing bare hashes as arguments, the first association in the hash was always being dropped. This is now fixed, the tests are fixed, and the memory leak is fixed.
* When creating a rescue node, the statements was being allocated on its own and then immediately discarded without deallocating. We now manually deallocate it, but this is something that we need to fix in a future PR because there's no reason to create one in the first place.
* ForNode nodes were parsing their locals with a separate scope, but then discarding the scope. They actually shouldn't parse using a separate scope at all, so all of that is now dropped.