### PR TITLE
Optional location params

### DIFF
--- a/bin/memsize
+++ b/bin/memsize
@@ -14,7 +14,7 @@ results =
           4
         when "node", "node?"
           8
-        when "location"
+        when "location", "location?"
           16
         when "node[]", "string", "token", "token?", "token[]"
           24

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -64,6 +64,13 @@ class LocationParam < Struct.new(:name)
   def java_type = "Location"
 end
 
+# This represents a parameter to a node that is a location that is optional.
+class OptionalLocationParam < Struct.new(:name)
+  def param = "const yp_location_t *#{name}"
+  def rbs_class = "Location?"
+  def java_type = "Location"
+end
+
 # This represents an integer parameter.
 class IntegerParam < Struct.new(:name)
   def param = "int #{name}"
@@ -106,6 +113,8 @@ class NodeType
           TokenListParam.new(name)
         when "location"
           LocationParam.new(name)
+        when "location?"
+          OptionalLocationParam.new(name)
         when "integer"
           IntegerParam.new(name)
         else
@@ -142,6 +151,7 @@ class NodeType
     in OptionalTokenParam then "(#{param.name}->type == YP_TOKEN_NOT_PROVIDED ? #{start_location_for(params.drop(1))} : #{param.name}->start)"
     in NodeListParam | TokenListParam then "0"
     in LocationParam then "#{param.name}->start"
+    in OptionalLocationParam then "(#{param.name} == NULL ? #{start_location_for(params.drop(1))} : #{param.name}->start)"
     else
       raise "Unknown param type: #{param.inspect}"
     end
@@ -155,6 +165,7 @@ class NodeType
     in OptionalTokenParam then "(#{param.name}->type == YP_TOKEN_NOT_PROVIDED ? #{end_location_for(params.drop(1))} : #{param.name}->end)"
     in NodeListParam | TokenListParam then "0"
     in LocationParam then "#{param.name}->end"
+    in OptionalLocationParam then "(#{param.name} == NULL ? #{end_location_for(params.drop(1))} : #{param.name}->end)"
     else
       raise "Unknown param type: #{param.inspect}"
     end

--- a/bin/templates/ext/yarp/node.c.erb
+++ b/bin/templates/ext/yarp/node.c.erb
@@ -71,6 +71,8 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node) {
       }
       <%- when LocationParam -%>
       argv[<%= index %>] = location_new(parser, node->as.<%= node.human %>.<%= param.name %>.start, node->as.<%= node.human %>.<%= param.name %>.end);
+      <%- when OptionalLocationParam -%>
+      argv[<%= index %>] = node->as.<%= node.human %>.<%= param.name %>.start == 0 ? Qnil : location_new(parser, node->as.<%= node.human %>.<%= param.name %>.start, node->as.<%= node.human %>.<%= param.name %>.end);
       <%- when IntegerParam -%>
       argv[<%= index %>] = INT2FIX(node->as.<%= node.human %>.<%= param.name %>);
       <%- else -%>

--- a/bin/templates/ext/yarp/node.c.erb
+++ b/bin/templates/ext/yarp/node.c.erb
@@ -72,7 +72,7 @@ yp_node_new(yp_parser_t *parser, yp_node_t *node) {
       <%- when LocationParam -%>
       argv[<%= index %>] = location_new(parser, node->as.<%= node.human %>.<%= param.name %>.start, node->as.<%= node.human %>.<%= param.name %>.end);
       <%- when OptionalLocationParam -%>
-      argv[<%= index %>] = node->as.<%= node.human %>.<%= param.name %>.start == 0 ? Qnil : location_new(parser, node->as.<%= node.human %>.<%= param.name %>.start, node->as.<%= node.human %>.<%= param.name %>.end);
+      argv[<%= index %>] = node->as.<%= node.human %>.<%= param.name %>.start == parser->start ? Qnil : location_new(parser, node->as.<%= node.human %>.<%= param.name %>.start, node->as.<%= node.human %>.<%= param.name %>.end);
       <%- when IntegerParam -%>
       argv[<%= index %>] = INT2FIX(node->as.<%= node.human %>.<%= param.name %>);
       <%- else -%>

--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -87,6 +87,15 @@ public class Loader {
         return new Nodes.Location(startOffset, endOffset);
     }
 
+    private Nodes.Location loadOptionalLocation() {
+        if (buffer.get(buffer.position()) != 0) {
+            return loadLocation();
+        } else {
+            buffer.position(buffer.position() + 1); // continue after the 0 byte
+            return null;
+        }
+    }
+
     private int loadInteger() {
         return buffer.getInt();
     }
@@ -110,6 +119,7 @@ public class Loader {
                     when TokenListParam then "loadTokens()"
                     when OptionalTokenParam then "loadOptionalToken()"
                     when LocationParam then "loadLocation()"
+                    when OptionalLocationParam then "loadOptionalLocation()"
                     when IntegerParam then "loadInteger()"
                     else raise
                     end

--- a/bin/templates/lib/yarp/node.rb.erb
+++ b/bin/templates/lib/yarp/node.rb.erb
@@ -63,10 +63,6 @@ module YARP
   module DSL
     private
 
-    def Location(start_offset, end_offset)
-      Location.new(start_offset, end_offset)
-    end
-
     <%- nodes.each do |node| -%>
 
     # Create a new <%= node.name %> node

--- a/bin/templates/lib/yarp/serialize.rb.erb
+++ b/bin/templates/lib/yarp/serialize.rb.erb
@@ -67,6 +67,13 @@ module YARP
         Location.new(start_offset, end_offset)
       end
 
+      def load_optional_location
+        if io.read(1).unpack1("C") != 0
+          io.pos -= 1
+          load_location
+        end
+      end
+
       def load_node
         type, _length = io.read(5).unpack("CL")
         location = load_location
@@ -83,6 +90,7 @@ module YARP
           when TokenListParam then "io.read(4).unpack1(\"L\").times.map { load_token }"
           when OptionalTokenParam then "load_optional_token"
           when LocationParam then "load_location"
+          when OptionalLocationParam then "load_optional_location"
           when IntegerParam then "io.read(4).unpack1(\"L\")"
           else raise
           end

--- a/bin/templates/src/ast.h.erb
+++ b/bin/templates/src/ast.h.erb
@@ -79,7 +79,7 @@ typedef struct yp_node {
       in TokenParam | OptionalTokenParam then "yp_token_t #{param.name}"
       in TokenListParam then "yp_token_list_t #{param.name}"
       in StringParam then "yp_string_t #{param.name}"
-      in LocationParam then "yp_location_t #{param.name}"
+      in LocationParam | OptionalLocationParam then "yp_location_t #{param.name}"
       in IntegerParam then "int #{param.name}"
       end
       %>;

--- a/bin/templates/src/node.c.erb
+++ b/bin/templates/src/node.c.erb
@@ -113,7 +113,7 @@ yp_node_t *
   case param
   in NodeParam | OptionalNodeParam | IntegerParam then ".#{param.name} = #{param.name}"
   in TokenParam | OptionalTokenParam then ".#{param.name} = *#{param.name}"
-  in LocationParam then ".#{param.name} = *#{param.name}"
+  in LocationParam | OptionalLocationParam then ".#{param.name} = *#{param.name}"
   in StringParam | NodeListParam | TokenListParam then nil
   end
 }.compact.join(", ") -%>
@@ -142,7 +142,7 @@ yp_node_destroy(yp_parser_t *parser, yp_node_t *node) {
     case <%= node.type %>:
       <%- node.params.each do |param| -%>
       <%- case param -%>
-      <%- when TokenParam, OptionalTokenParam, LocationParam, IntegerParam -%>
+      <%- when TokenParam, OptionalTokenParam, LocationParam, OptionalLocationParam, IntegerParam -%>
       <%- when NodeParam -%>
       yp_node_destroy(parser, node->as.<%= node.human %>.<%= param.name %>);
       <%- when OptionalNodeParam -%>

--- a/bin/templates/src/node.c.erb
+++ b/bin/templates/src/node.c.erb
@@ -191,7 +191,7 @@ yp_node_memsize_node(yp_node_t *node, yp_memsize_t *memsize) {
       yp_node_list_memsize(&node->as.<%= node.human %>.<%= param.name %>, memsize);
       <%- when TokenListParam -%>
       memsize->memsize += yp_token_list_memsize(&node->as.<%= node.human %>.<%= param.name %>);
-      <%- when LocationParam -%>
+      <%- when LocationParam, OptionalLocationParam -%>
       memsize->memsize += sizeof(yp_location_t);
       <%- when IntegerParam -%>
       memsize->memsize += sizeof(int);

--- a/bin/templates/src/prettyprint.c.erb
+++ b/bin/templates/src/prettyprint.c.erb
@@ -64,7 +64,7 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
       <%- when LocationParam -%>
       prettyprint_location(buffer, parser, &node->as.<%= node.human %>.<%= param.name %>);
       <%- when OptionalLocationParam -%>
-      if (node->as.<%= node.human %>.<%= param.name %>.start == 0) {
+      if (node->as.<%= node.human %>.<%= param.name %>.start == parser->start) {
         yp_buffer_append_str(buffer, "nil", 3);
       } else {
         prettyprint_location(buffer, parser, &node->as.<%= node.human %>.<%= param.name %>);

--- a/bin/templates/src/prettyprint.c.erb
+++ b/bin/templates/src/prettyprint.c.erb
@@ -63,6 +63,12 @@ prettyprint_node(yp_buffer_t *buffer, yp_parser_t *parser, yp_node_t *node) {
       }
       <%- when LocationParam -%>
       prettyprint_location(buffer, parser, &node->as.<%= node.human %>.<%= param.name %>);
+      <%- when OptionalLocationParam -%>
+      if (node->as.<%= node.human %>.<%= param.name %>.start == 0) {
+        yp_buffer_append_str(buffer, "nil", 3);
+      } else {
+        prettyprint_location(buffer, parser, &node->as.<%= node.human %>.<%= param.name %>);
+      }
       <%- when IntegerParam -%>
       char <%= param.name %>_buffer[12];
       snprintf(<%= param.name %>_buffer, 12, "+%d", node->as.<%= node.human %>.<%= param.name %>);

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -69,6 +69,12 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
       }
       <%- when LocationParam -%>
       serialize_location(parser, &node->as.<%= node.human %>.<%= param.name %>, buffer);
+      <%- when OptionalLocationParam -%>
+      if (node->as.<%= node.human %>.<%= param.name %>.start == 0) {
+        yp_buffer_append_u8(buffer, 0);
+      } else {
+        serialize_location(parser, &node->as.<%= node.human %>.<%= param.name %>, buffer);
+      }
       <%- when IntegerParam -%>
       yp_buffer_append_int(buffer, node->as.<%= node.human %>.<%= param.name %>);
       <%- else -%>

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -70,7 +70,7 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
       <%- when LocationParam -%>
       serialize_location(parser, &node->as.<%= node.human %>.<%= param.name %>, buffer);
       <%- when OptionalLocationParam -%>
-      if (node->as.<%= node.human %>.<%= param.name %>.start == 0) {
+      if (node->as.<%= node.human %>.<%= param.name %>.start == parser->start) {
         yp_buffer_append_u8(buffer, 0);
       } else {
         serialize_location(parser, &node->as.<%= node.human %>.<%= param.name %>, buffer);

--- a/config.yml
+++ b/config.yml
@@ -561,8 +561,6 @@ nodes:
           ^^^
   - name: DefNode
     child_nodes:
-      - name: def_keyword
-        type: token
       - name: receiver
         type: node?
       - name: operator
@@ -583,7 +581,8 @@ nodes:
         type: token?
       - name: scope
         type: node
-    location: def_keyword->end_keyword|statements
+      - name: def_keyword_loc
+        type: location
     comment: |
       Represents a method definition.
 

--- a/config.yml
+++ b/config.yml
@@ -567,12 +567,8 @@ nodes:
         type: token?
       - name: name
         type: token
-      - name: lparen
-        type: token?
       - name: parameters
         type: node
-      - name: rparen
-        type: token?
       - name: equal
         type: token?
       - name: statements
@@ -583,6 +579,10 @@ nodes:
         type: node
       - name: def_keyword_loc
         type: location
+      - name: lparen_loc
+        type: location?
+      - name: rparen_loc
+        type: location?
     comment: |
       Represents a method definition.
 

--- a/config.yml
+++ b/config.yml
@@ -561,27 +561,27 @@ nodes:
           ^^^
   - name: DefNode
     child_nodes:
-      - name: receiver
-        type: node?
-      - name: operator
-        type: token?
       - name: name
         type: token
+      - name: receiver
+        type: node?
       - name: parameters
         type: node
-      - name: equal
-        type: token?
       - name: statements
         type: node
-      - name: end_keyword
-        type: token?
       - name: scope
         type: node
       - name: def_keyword_loc
         type: location
+      - name: operator_loc
+        type: location?
       - name: lparen_loc
         type: location?
       - name: rparen_loc
+        type: location?
+      - name: equal_loc
+        type: location?
+      - name: end_keyword_loc
         type: location?
     comment: |
       Represents a method definition.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -563,6 +563,51 @@ yp_class_variable_write_node_init(yp_parser_t *parser, yp_node_t *node, yp_token
   return node;
 }
 
+// Allocate and initialize a new DefNode node.
+static yp_node_t *
+yp_def_node_create(
+  yp_parser_t *parser,
+  yp_node_t *receiver,
+  const yp_token_t *operator,
+  const yp_token_t *name,
+  const yp_token_t *lparen,
+  yp_node_t *parameters,
+  const yp_token_t *rparen,
+  const yp_token_t *equal,
+  yp_node_t *statements,
+  const yp_token_t *end_keyword,
+  yp_node_t *scope,
+  const yp_token_t *def_keyword
+) {
+  yp_node_t *node = yp_node_alloc(parser);
+
+  *node = (yp_node_t) {
+    .type = YP_NODE_DEF_NODE,
+    .location = {
+      .start = def_keyword->start,
+      .end = (end_keyword->type == YP_TOKEN_NOT_PROVIDED ? statements->location.end : end_keyword->end)
+    },
+    .as.def_node = {
+      .receiver = receiver,
+      .operator = *operator,
+      .name = *name,
+      .lparen = *lparen,
+      .parameters = parameters,
+      .rparen = *rparen,
+      .equal = *equal,
+      .statements = statements,
+      .end_keyword = *end_keyword,
+      .scope = scope,
+      .def_keyword_loc = {
+        .start = def_keyword->start,
+        .end = def_keyword->end
+      },
+    }
+  };
+
+  return node;
+}
+
 // Allocate and initialize a new FalseNode node.
 static yp_node_t *
 yp_false_node_create(yp_parser_t *parser, const yp_token_t *token) {
@@ -5489,7 +5534,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       }
 
       parser->current_scope = parent_scope;
-      return yp_node_def_node_create(parser, &def_keyword, receiver, &operator, &name, &lparen, params, &rparen, &equal, statements, &end_keyword, scope);
+      return yp_def_node_create(parser, receiver, &operator, &name, &lparen, params, &rparen, &equal, statements, &end_keyword, scope, &def_keyword);
     }
     case YP_TOKEN_KEYWORD_DEFINED: {
       parser_lex(parser);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -570,14 +570,14 @@ yp_def_node_create(
   yp_node_t *receiver,
   const yp_token_t *operator,
   const yp_token_t *name,
-  const yp_token_t *lparen,
   yp_node_t *parameters,
-  const yp_token_t *rparen,
   const yp_token_t *equal,
   yp_node_t *statements,
   const yp_token_t *end_keyword,
   yp_node_t *scope,
-  const yp_token_t *def_keyword
+  const yp_token_t *def_keyword,
+  const yp_token_t *lparen,
+  const yp_token_t *rparen
 ) {
   yp_node_t *node = yp_node_alloc(parser);
 
@@ -591,9 +591,7 @@ yp_def_node_create(
       .receiver = receiver,
       .operator = *operator,
       .name = *name,
-      .lparen = *lparen,
       .parameters = parameters,
-      .rparen = *rparen,
       .equal = *equal,
       .statements = statements,
       .end_keyword = *end_keyword,
@@ -602,6 +600,14 @@ yp_def_node_create(
         .start = def_keyword->start,
         .end = def_keyword->end
       },
+      .lparen_loc = {
+        .start = lparen->start,
+        .end = lparen->end
+      },
+      .rparen_loc = {
+        .start = rparen->start,
+        .end = rparen->end
+      }
     }
   };
 
@@ -5534,7 +5540,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       }
 
       parser->current_scope = parent_scope;
-      return yp_def_node_create(parser, receiver, &operator, &name, &lparen, params, &rparen, &equal, statements, &end_keyword, scope, &def_keyword);
+      return yp_def_node_create(parser, receiver, &operator, &name, params, &equal, statements, &end_keyword, scope, &def_keyword, &lparen, &rparen);
     }
     case YP_TOKEN_KEYWORD_DEFINED: {
       parser_lex(parser);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -567,47 +567,42 @@ yp_class_variable_write_node_init(yp_parser_t *parser, yp_node_t *node, yp_token
 static yp_node_t *
 yp_def_node_create(
   yp_parser_t *parser,
-  yp_node_t *receiver,
-  const yp_token_t *operator,
   const yp_token_t *name,
+  yp_node_t *receiver,
   yp_node_t *parameters,
-  const yp_token_t *equal,
   yp_node_t *statements,
-  const yp_token_t *end_keyword,
   yp_node_t *scope,
   const yp_token_t *def_keyword,
+  const yp_token_t *operator,
   const yp_token_t *lparen,
-  const yp_token_t *rparen
+  const yp_token_t *rparen,
+  const yp_token_t *equal,
+  const yp_token_t *end_keyword
 ) {
   yp_node_t *node = yp_node_alloc(parser);
+  const char *end;
+
+  if (end_keyword->type == YP_TOKEN_NOT_PROVIDED) {
+    end = statements->location.end;
+  } else {
+    end = end_keyword->end;
+  }
 
   *node = (yp_node_t) {
     .type = YP_NODE_DEF_NODE,
-    .location = {
-      .start = def_keyword->start,
-      .end = (end_keyword->type == YP_TOKEN_NOT_PROVIDED ? statements->location.end : end_keyword->end)
-    },
+    .location = { .start = def_keyword->start, .end = end },
     .as.def_node = {
-      .receiver = receiver,
-      .operator = *operator,
       .name = *name,
+      .receiver = receiver,
       .parameters = parameters,
-      .equal = *equal,
       .statements = statements,
-      .end_keyword = *end_keyword,
       .scope = scope,
-      .def_keyword_loc = {
-        .start = def_keyword->start,
-        .end = def_keyword->end
-      },
-      .lparen_loc = {
-        .start = lparen->start,
-        .end = lparen->end
-      },
-      .rparen_loc = {
-        .start = rparen->start,
-        .end = rparen->end
-      }
+      .def_keyword_loc = { .start = def_keyword->start, .end = def_keyword->end },
+      .operator_loc = { .start = operator->start, .end = operator->end },
+      .lparen_loc = { .start = lparen->start, .end = lparen->end },
+      .rparen_loc = { .start = rparen->start, .end = rparen->end },
+      .equal_loc = { .start = equal->start, .end = equal->end },
+      .end_keyword_loc = { .start = end_keyword->start, .end = end_keyword->end }
     }
   };
 
@@ -5540,7 +5535,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       }
 
       parser->current_scope = parent_scope;
-      return yp_def_node_create(parser, receiver, &operator, &name, params, &equal, statements, &end_keyword, scope, &def_keyword, &lparen, &rparen);
+      return yp_def_node_create(parser, &name, receiver, params, statements, scope, &def_keyword, &operator, &lparen, &rparen, &equal, &end_keyword);
     }
     case YP_TOKEN_KEYWORD_DEFINED: {
       parser_lex(parser);

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -66,9 +66,9 @@ class ErrorsTest < Test::Unit::TestCase
   test "pre execution missing {" do
     expected = PreExecutionNode(
       Statements([expression("1")]),
-      Location(0, 5),
-      Location(5, 5),
-      Location(8, 9)
+      YARP::Location.new(0, 5),
+      YARP::Location.new(5, 5),
+      YARP::Location.new(8, 9)
     )
 
     assert_errors expected, "BEGIN 1 }", ["Expected '{' after 'BEGIN'."]
@@ -88,9 +88,9 @@ class ErrorsTest < Test::Unit::TestCase
           "+"
         )
       ]),
-      Location(0, 5),
-      Location(6, 7),
-      Location(12, 13)
+      YARP::Location.new(0, 5),
+      YARP::Location.new(6, 7),
+      YARP::Location.new(12, 13)
     )
 
     assert_errors expected, "BEGIN { 1 + }", ["Expected a value after the operator."]

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -860,14 +860,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a\nend"
@@ -878,14 +878,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
       ParametersNode([], [], nil, [], nil, nil),
-      PARENTHESIS_RIGHT(")"),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(6, 7)
     )
 
     assert_parses expected, "def a()\nend"
@@ -896,14 +896,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([expression("b = 1")]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a\nb = 1\nend"
@@ -914,14 +914,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
-      ParametersNode([RequiredParameterNode(IDENTIFIER("b"))], [], nil, [], nil, nil),
-      nil,
+      ParametersNode(
+        [RequiredParameterNode(IDENTIFIER("b"))],
+        [],
+        nil,
+        [],
+        nil,
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a b\nend"
@@ -932,14 +939,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
-      ParametersNode([], [], nil, [KeywordParameterNode(LABEL("b:"), nil)], nil, nil),
-      nil,
+      ParametersNode(
+        [],
+        [],
+        nil,
+        [KeywordParameterNode(LABEL("b:"), nil)],
+        nil,
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([LABEL("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a b:\nend"
@@ -950,14 +964,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
-      ParametersNode([], [], nil, [KeywordParameterNode(LABEL("b:"), nil)], nil, nil),
-      PARENTHESIS_RIGHT(")"),
+      ParametersNode(
+        [],
+        [],
+        nil,
+        [KeywordParameterNode(LABEL("b:"), nil)],
+        nil,
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([LABEL("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(8, 9)
     )
 
     assert_parses expected, "def a(b:)\nend"
@@ -968,7 +989,6 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode(
         [
           RequiredParameterNode(IDENTIFIER("b")),
@@ -982,11 +1002,12 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
-      nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b"), IDENTIFIER("c"), IDENTIFIER("d")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a b, c, d\nend"
@@ -997,7 +1018,6 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode(
         [RequiredParameterNode(IDENTIFIER("b"))],
         [OptionalParameterNode(IDENTIFIER("c"), EQUAL("="), expression("2"))],
@@ -1007,11 +1027,12 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
-      nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b"), IDENTIFIER("c")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a b, c = 2\nend"
@@ -1022,7 +1043,6 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode(
         [],
         [
@@ -1035,11 +1055,12 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
-      nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b"), IDENTIFIER("c")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a b = 1, c = 2\nend"
@@ -1050,7 +1071,6 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode(
         [],
         [KeywordParameterNode(LABEL("c:"), expression("1"))],
@@ -1060,11 +1080,12 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
-      nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([LABEL("b"), LABEL("c")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a b:, c: 1 \nend"
@@ -1075,7 +1096,6 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
       ParametersNode(
         [],
         [KeywordParameterNode(LABEL("c:"), expression("1"))],
@@ -1084,12 +1104,13 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      PARENTHESIS_RIGHT(")"),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([LABEL("b"), LABEL("c")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(14, 15)
     )
 
     assert_parses expected, "def a(b:, c: 1)\nend"
@@ -1100,7 +1121,6 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
       ParametersNode(
         [],
         [KeywordParameterNode(LABEL("b:"), expression("1"))],
@@ -1109,12 +1129,13 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      PARENTHESIS_RIGHT(")"),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([LABEL("b"), LABEL("c")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(16, 17)
     )
 
     assert_parses expected, <<~RUBY
@@ -1129,14 +1150,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
-      ParametersNode([], [], RestParameterNode(STAR("*"), IDENTIFIER("b")), [], nil, nil),
-      nil,
+      ParametersNode(
+        [],
+        [],
+        RestParameterNode(STAR("*"), IDENTIFIER("b")),
+        [],
+        nil,
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a *b\nend"
@@ -1147,14 +1175,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], RestParameterNode(STAR("*"), nil), [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([STAR("*")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a *\nend"
@@ -1165,14 +1193,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
-      ParametersNode([], [], nil, [], KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("b")), nil),
-      nil,
+      ParametersNode(
+        [],
+        [],
+        nil,
+        [],
+        KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("b")),
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a **b\nend"
@@ -1183,14 +1218,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
-      ParametersNode([], [], nil, [], KeywordRestParameterNode(STAR_STAR("**"), nil), nil),
-      nil,
+      ParametersNode(
+        [],
+        [],
+        nil,
+        [],
+        KeywordRestParameterNode(STAR_STAR("**"), nil),
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a **\nend"
@@ -1201,14 +1243,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a ...\nend"
@@ -1219,14 +1261,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
-      ParametersNode([], [], nil, [], nil, BlockParameterNode(IDENTIFIER("b"), Location(6, 7))),
-      nil,
+      ParametersNode(
+        [],
+        [],
+        nil,
+        [],
+        nil,
+        BlockParameterNode(IDENTIFIER("b"), Location(6, 7))
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a &b\nend"
@@ -1237,14 +1286,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
-      ParametersNode([], [], nil, [], nil, BlockParameterNode(nil, Location(6, 7))),
-      nil,
+      ParametersNode(
+        [],
+        [],
+        nil,
+        [],
+        nil,
+        BlockParameterNode(nil, Location(6, 7))
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a &\nend"
@@ -1255,7 +1311,6 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("m"),
-      nil,
       ParametersNode(
         [RequiredParameterNode(IDENTIFIER("a"))],
         [],
@@ -1265,11 +1320,12 @@ class ParseTest < Test::Unit::TestCase
         nil
       ),
       nil,
-      nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("a"), LABEL("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def m a, b:, **nil\nend"
@@ -1446,32 +1502,27 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
-      ParametersNode(
-        [],
-        [],
-        nil,
-        [],
-        ForwardingParameterNode(),
-        nil
-      ),
-      PARENTHESIS_RIGHT(")"),
+      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       nil,
       Statements(
-        [CallNode(
-           nil,
-           nil,
-           IDENTIFIER("b"),
-           PARENTHESIS_LEFT("("),
-           ArgumentsNode([ForwardingArgumentsNode()]),
-           PARENTHESIS_RIGHT(")"),
-           nil,
-           "b"
-         )]
+        [
+          CallNode(
+            nil,
+            nil,
+            IDENTIFIER("b"),
+            PARENTHESIS_LEFT("("),
+            ArgumentsNode([ForwardingArgumentsNode()]),
+            PARENTHESIS_RIGHT(")"),
+            nil,
+            "b"
+          )
+        ]
       ),
       KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(9, 10)
     )
 
     assert_parses expected, "def a(...); b(...); end"
@@ -1483,32 +1534,29 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
-      ParametersNode(
-        [],
-        [],
-        nil,
-        [],
-        ForwardingParameterNode(),
-        nil
-      ),
-      PARENTHESIS_RIGHT(")"),
+      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       nil,
       Statements(
-        [CallNode(
-           nil,
-           nil,
-           IDENTIFIER("b"),
-           PARENTHESIS_LEFT("("),
-           ArgumentsNode([IntegerNode(), IntegerNode(), ForwardingArgumentsNode()]),
-           PARENTHESIS_RIGHT(")"),
-           nil,
-           "b"
-         )]
+        [
+          CallNode(
+            nil,
+            nil,
+            IDENTIFIER("b"),
+            PARENTHESIS_LEFT("("),
+            ArgumentsNode(
+              [IntegerNode(), IntegerNode(), ForwardingArgumentsNode()]
+            ),
+            PARENTHESIS_RIGHT(")"),
+            nil,
+            "b"
+          )
+        ]
       ),
       KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(9, 10)
     )
 
     assert_parses expected, "def a(...); b(1, 2, ...); end"
@@ -1519,43 +1567,42 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
-      ParametersNode(
-        [],
-        [],
-        nil,
-        [],
-        ForwardingParameterNode(),
-        nil
-      ),
-      PARENTHESIS_RIGHT(")"),
+      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       nil,
       Statements(
-        [InterpolatedStringNode(
-           STRING_BEGIN("\""),
-           [StringNode(nil, STRING_CONTENT("foo"), nil, "foo"),
-            StringInterpolatedNode(
-              EMBEXPR_BEGIN("\#{"),
-              Statements(
-                [CallNode(
-                   nil,
-                   nil,
-                   IDENTIFIER("b"),
-                   PARENTHESIS_LEFT("("),
-                   ArgumentsNode([ForwardingArgumentsNode()]),
-                   PARENTHESIS_RIGHT(")"),
-                   nil,
-                   "b"
-                 )]
-              ),
-              EMBEXPR_END("}")
-            )],
-           STRING_END("\"")
-         )]
+        [
+          InterpolatedStringNode(
+            STRING_BEGIN("\""),
+            [
+              StringNode(nil, STRING_CONTENT("foo"), nil, "foo"),
+              StringInterpolatedNode(
+                EMBEXPR_BEGIN("\#{"),
+                Statements(
+                  [
+                    CallNode(
+                      nil,
+                      nil,
+                      IDENTIFIER("b"),
+                      PARENTHESIS_LEFT("("),
+                      ArgumentsNode([ForwardingArgumentsNode()]),
+                      PARENTHESIS_RIGHT(")"),
+                      nil,
+                      "b"
+                    )
+                  ]
+                ),
+                EMBEXPR_END("}")
+              )
+            ],
+            STRING_END("\"")
+          )
+        ]
       ),
       KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(9, 10)
     )
 
     assert_parses expected, "def a(...); \"foo\#{b(...)}\"; end"
@@ -1585,25 +1632,27 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
       ParametersNode([], [], RestParameterNode(STAR("*"), nil), [], nil, nil),
-      PARENTHESIS_RIGHT(")"),
       nil,
       Statements(
-        [CallNode(
-          nil,
-          nil,
-          IDENTIFIER("b"),
-          PARENTHESIS_LEFT("("),
-          ArgumentsNode([StarNode(STAR("*"), nil)]),
-          PARENTHESIS_RIGHT(")"),
-          nil,
-          "b"
-         )]
+        [
+          CallNode(
+            nil,
+            nil,
+            IDENTIFIER("b"),
+            PARENTHESIS_LEFT("("),
+            ArgumentsNode([StarNode(STAR("*"), nil)]),
+            PARENTHESIS_RIGHT(")"),
+            nil,
+            "b"
+          )
+        ]
       ),
       KEYWORD_END("end"),
       Scope([STAR("*")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(7, 8)
     )
 
     assert_parses expected, "def a(*); b(*); end"
@@ -1632,14 +1681,14 @@ class ParseTest < Test::Unit::TestCase
       expression("a"),
       DOT("."),
       IDENTIFIER("b"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a.b\nend"
@@ -1650,14 +1699,14 @@ class ParseTest < Test::Unit::TestCase
       expression("a"),
       DOT("."),
       MINUS("-"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def a.-;end"
@@ -1668,14 +1717,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(7, 10)
+      Location(7, 10),
+      nil,
+      nil
     )
 
     assert_parses expected, "a = 1; def a\nend"
@@ -1686,14 +1735,14 @@ class ParseTest < Test::Unit::TestCase
       NilNode(),
       COLON_COLON("::"),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def nil::a\nend"
@@ -1704,14 +1753,14 @@ class ParseTest < Test::Unit::TestCase
       NilNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def nil.a\nend"
@@ -1722,14 +1771,14 @@ class ParseTest < Test::Unit::TestCase
       SelfNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def self.a\nend"
@@ -1740,14 +1789,14 @@ class ParseTest < Test::Unit::TestCase
       TrueNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def true.a\nend"
@@ -1758,14 +1807,14 @@ class ParseTest < Test::Unit::TestCase
       FalseNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def false.a\nend"
@@ -1776,14 +1825,14 @@ class ParseTest < Test::Unit::TestCase
       ConstantRead(CONSTANT("Const")),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(11, 14)
+      Location(11, 14),
+      nil,
+      nil
     )
 
     assert_parses expected, "Const = 1; def Const.a\nend"
@@ -1794,14 +1843,14 @@ class ParseTest < Test::Unit::TestCase
       InstanceVariableReadNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def @var.a\nend"
@@ -1812,14 +1861,14 @@ class ParseTest < Test::Unit::TestCase
       ClassVariableReadNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def @@var.a\nend"
@@ -1830,14 +1879,14 @@ class ParseTest < Test::Unit::TestCase
       GlobalVariableRead(GLOBAL_VARIABLE("$var")),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def $var.a\nend"
@@ -1848,14 +1897,14 @@ class ParseTest < Test::Unit::TestCase
       SourceFileNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def __FILE__.a\nend"
@@ -1866,14 +1915,14 @@ class ParseTest < Test::Unit::TestCase
       SourceLineNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def __LINE__.a\nend"
@@ -1884,14 +1933,14 @@ class ParseTest < Test::Unit::TestCase
       SourceEncodingNode(),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def __ENCODING__.a\nend"
@@ -1906,14 +1955,14 @@ class ParseTest < Test::Unit::TestCase
       ),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def (b).a\nend"
@@ -1932,14 +1981,14 @@ class ParseTest < Test::Unit::TestCase
       ),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def (c = b).a\nend"
@@ -1954,14 +2003,14 @@ class ParseTest < Test::Unit::TestCase
       ),
       DOT("."),
       IDENTIFIER("a"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def (1).a\nend"
@@ -1976,14 +2025,14 @@ class ParseTest < Test::Unit::TestCase
       ),
       COLON_COLON("::"),
       IDENTIFIER("b"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def (a)::b\nend"
@@ -3365,14 +3414,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("foo"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       EQUAL("="),
       Statements([expression("123")]),
       nil,
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def foo = 123"
@@ -3383,14 +3432,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       IDENTIFIER("foo"),
-      PARENTHESIS_LEFT("("),
-      ParametersNode([RequiredParameterNode(IDENTIFIER("bar"))], [], nil, [], nil, nil),
-      PARENTHESIS_RIGHT(")"),
+      ParametersNode(
+        [RequiredParameterNode(IDENTIFIER("bar"))],
+        [],
+        nil,
+        [],
+        nil,
+        nil
+      ),
       EQUAL("="),
       Statements([expression("123")]),
       nil,
       Scope([IDENTIFIER("bar")]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(7, 8),
+      Location(11, 12)
     )
 
     assert_parses expected, "def foo(bar) = 123"
@@ -4158,14 +4214,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       PLUS("+"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def +\nend"
@@ -4176,14 +4232,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       PLUS("+"),
-      PARENTHESIS_LEFT("("),
       ParametersNode([], [], nil, [], nil, nil),
-      PARENTHESIS_RIGHT(")"),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      Location(5, 6),
+      Location(6, 7)
     )
 
     assert_parses expected, "def +()\nend"
@@ -4194,14 +4250,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       PLUS("+"),
-      nil,
-      ParametersNode([RequiredParameterNode(IDENTIFIER("b"))], [], nil, [], nil, nil),
-      nil,
+      ParametersNode(
+        [RequiredParameterNode(IDENTIFIER("b"))],
+        [],
+        nil,
+        [],
+        nil,
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def + b\nend"
@@ -4212,14 +4275,21 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       PLUS("+"),
-      nil,
-      ParametersNode([], [], nil, [], KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("b")), nil),
-      nil,
+      ParametersNode(
+        [],
+        [],
+        nil,
+        [],
+        KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("b")),
+        nil
+      ),
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def + **b\nend"
@@ -4230,14 +4300,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       MINUS("-"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def -\nend"
@@ -4248,14 +4318,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       EQUAL_EQUAL("=="),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def ==\nend"
@@ -4266,14 +4336,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       PIPE("|"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def |\nend"
@@ -4284,14 +4354,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       CARET("^"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def ^\nend"
@@ -4302,14 +4372,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       AMPERSAND("&"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def &\nend"
@@ -4320,14 +4390,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       LESS_EQUAL_GREATER("<=>"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def <=>\nend"
@@ -4338,14 +4408,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       EQUAL_EQUAL_EQUAL("==="),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def ===\nend"
@@ -4356,14 +4426,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       EQUAL_TILDE("=~"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def =~\nend"
@@ -4374,14 +4444,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       BANG_TILDE("!~"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def !~\nend"
@@ -4392,14 +4462,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       GREATER(">"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def >\nend"
@@ -4410,14 +4480,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       GREATER_EQUAL(">="),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def >=\nend"
@@ -4428,14 +4498,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       LESS("<"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def <\nend"
@@ -4446,14 +4516,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       LESS_EQUAL("<="),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def <=\nend"
@@ -4464,14 +4534,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       BANG_EQUAL("!="),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def !=\nend"
@@ -4482,14 +4552,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       LESS_LESS("<<"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def <<\nend"
@@ -4500,14 +4570,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       GREATER_GREATER(">>"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def >>\nend"
@@ -4518,14 +4588,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       STAR("*"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def *\nend"
@@ -4536,14 +4606,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       SLASH("/"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def /\nend"
@@ -4554,14 +4624,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       PERCENT("%"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def %\nend"
@@ -4572,14 +4642,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       STAR_STAR("**"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def **\nend"
@@ -4590,14 +4660,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       BANG("!"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def !\nend"
@@ -4608,14 +4678,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       TILDE("~"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def ~\nend"
@@ -4626,14 +4696,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       PLUS_AT("+@"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def +@\nend"
@@ -4644,14 +4714,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       MINUS_AT("-@"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def -@\nend"
@@ -4662,14 +4732,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       BRACKET_LEFT_RIGHT("[]"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def []\nend"
@@ -4680,14 +4750,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       BRACKET_LEFT_RIGHT_EQUAL("[]="),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def []=\nend"
@@ -4698,14 +4768,14 @@ class ParseTest < Test::Unit::TestCase
       SelfNode(),
       DOT("."),
       PLUS("+"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def self.+\nend"
@@ -4716,14 +4786,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       BACKTICK("`"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def `\nend"
@@ -4734,14 +4804,14 @@ class ParseTest < Test::Unit::TestCase
       SelfNode(),
       DOT("."),
       BACKTICK("`"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def self.`\nend"
@@ -4752,14 +4822,14 @@ class ParseTest < Test::Unit::TestCase
       SelfNode(),
       DOT("."),
       PLUS("+"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def self.+\nend"
@@ -4770,14 +4840,14 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil,
       KEYWORD_DEF("def"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def def\nend"
@@ -4788,14 +4858,14 @@ class ParseTest < Test::Unit::TestCase
       SelfNode(),
       DOT("."),
       KEYWORD_ENSURE("ensure"),
-      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       nil,
       Statements([]),
       KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3)
+      Location(0, 3),
+      nil,
+      nil
     )
 
     assert_parses expected, "def self.ensure\nend"

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -857,7 +857,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def without parentheses" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -867,7 +866,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a\nend"
@@ -875,7 +875,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with parentheses" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -885,7 +884,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a()\nend"
@@ -893,7 +893,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with scope" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -903,7 +902,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([expression("b = 1")]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b")])
+      Scope([IDENTIFIER("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a\nb = 1\nend"
@@ -911,7 +911,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with required parameter" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -921,7 +920,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b")])
+      Scope([IDENTIFIER("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a b\nend"
@@ -929,7 +929,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword parameter (no parenthesis)" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -939,7 +938,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([LABEL("b")])
+      Scope([LABEL("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a b:\nend"
@@ -947,7 +947,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword parameter (parenthesis)" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -957,7 +956,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([LABEL("b")])
+      Scope([LABEL("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a(b:)\nend"
@@ -965,7 +965,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with multiple required parameters" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -986,7 +985,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b"), IDENTIFIER("c"), IDENTIFIER("d")])
+      Scope([IDENTIFIER("b"), IDENTIFIER("c"), IDENTIFIER("d")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a b, c, d\nend"
@@ -994,7 +994,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with required and optional parameters" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1011,7 +1010,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b"), IDENTIFIER("c")])
+      Scope([IDENTIFIER("b"), IDENTIFIER("c")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a b, c = 2\nend"
@@ -1019,7 +1019,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional parameters" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1039,7 +1038,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b"), IDENTIFIER("c")])
+      Scope([IDENTIFIER("b"), IDENTIFIER("c")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a b = 1, c = 2\nend"
@@ -1047,7 +1047,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional keyword parameters (no parenthesis)" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1064,7 +1063,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([LABEL("b"), LABEL("c")])
+      Scope([LABEL("b"), LABEL("c")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a b:, c: 1 \nend"
@@ -1072,7 +1072,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional keyword parameters (parenthesis)" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1089,7 +1088,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([LABEL("b"), LABEL("c")])
+      Scope([LABEL("b"), LABEL("c")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a(b:, c: 1)\nend"
@@ -1097,7 +1097,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional keyword parameters and line break" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1114,7 +1113,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([LABEL("b"), LABEL("c")])
+      Scope([LABEL("b"), LABEL("c")]),
+      Location(0, 3)
     )
 
     assert_parses expected, <<~RUBY
@@ -1126,7 +1126,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with rest parameter" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1136,7 +1135,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b")])
+      Scope([IDENTIFIER("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a *b\nend"
@@ -1144,7 +1144,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with rest parameter without name" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1154,7 +1153,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([STAR("*")])
+      Scope([STAR("*")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a *\nend"
@@ -1162,7 +1162,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword rest parameter" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1172,7 +1171,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b")])
+      Scope([IDENTIFIER("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a **b\nend"
@@ -1180,7 +1180,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword rest parameter without name" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1190,7 +1189,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a **\nend"
@@ -1198,7 +1198,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with forwarding parameter" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1208,7 +1207,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([DOT_DOT_DOT("...")])
+      Scope([DOT_DOT_DOT("...")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a ...\nend"
@@ -1216,7 +1216,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with block parameter" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1226,7 +1225,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b")])
+      Scope([IDENTIFIER("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a &b\nend"
@@ -1234,7 +1234,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with block parameter without name" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1244,7 +1243,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a &\nend"
@@ -1252,7 +1252,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with **nil" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("m"),
@@ -1269,7 +1268,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("a"), LABEL("b")])
+      Scope([IDENTIFIER("a"), LABEL("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def m a, b:, **nil\nend"
@@ -1443,7 +1443,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "method call with ..." do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1471,7 +1470,8 @@ class ParseTest < Test::Unit::TestCase
          )]
       ),
       KEYWORD_END("end"),
-      Scope([DOT_DOT_DOT("...")])
+      Scope([DOT_DOT_DOT("...")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a(...); b(...); end"
@@ -1480,7 +1480,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "method call with ... after args" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1508,7 +1507,8 @@ class ParseTest < Test::Unit::TestCase
          )]
       ),
       KEYWORD_END("end"),
-      Scope([DOT_DOT_DOT("...")])
+      Scope([DOT_DOT_DOT("...")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a(...); b(1, 2, ...); end"
@@ -1516,7 +1516,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "method call with interpolated ..." do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1555,7 +1554,8 @@ class ParseTest < Test::Unit::TestCase
          )]
       ),
       KEYWORD_END("end"),
-      Scope([DOT_DOT_DOT("...")])
+      Scope([DOT_DOT_DOT("...")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a(...); \"foo\#{b(...)}\"; end"
@@ -1582,7 +1582,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "method call with *" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1603,7 +1602,8 @@ class ParseTest < Test::Unit::TestCase
          )]
       ),
       KEYWORD_END("end"),
-      Scope([STAR("*")])
+      Scope([STAR("*")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a(*); b(*); end"
@@ -1629,7 +1629,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with identifier receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       expression("a"),
       DOT("."),
       IDENTIFIER("b"),
@@ -1639,7 +1638,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a.b\nend"
@@ -1647,7 +1647,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def - with identifier receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       expression("a"),
       DOT("."),
       MINUS("-"),
@@ -1657,7 +1656,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def a.-;end"
@@ -1665,7 +1665,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with local variable identifier receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("a"),
@@ -1675,7 +1674,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(7, 10)
     )
 
     assert_parses expected, "a = 1; def a\nend"
@@ -1683,7 +1683,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with colon_colon nil receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       NilNode(),
       COLON_COLON("::"),
       IDENTIFIER("a"),
@@ -1693,7 +1692,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def nil::a\nend"
@@ -1701,7 +1701,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with nil receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       NilNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1711,7 +1710,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def nil.a\nend"
@@ -1719,7 +1719,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with self receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SelfNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1729,7 +1728,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def self.a\nend"
@@ -1737,7 +1737,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with true receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       TrueNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1747,7 +1746,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def true.a\nend"
@@ -1755,7 +1755,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with false receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       FalseNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1765,7 +1764,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def false.a\nend"
@@ -1773,7 +1773,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with constant receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       ConstantRead(CONSTANT("Const")),
       DOT("."),
       IDENTIFIER("a"),
@@ -1783,7 +1782,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(11, 14)
     )
 
     assert_parses expected, "Const = 1; def Const.a\nend"
@@ -1791,7 +1791,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with instance variable receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       InstanceVariableReadNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1801,7 +1800,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def @var.a\nend"
@@ -1809,7 +1809,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with class variable receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       ClassVariableReadNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1819,7 +1818,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def @@var.a\nend"
@@ -1827,7 +1827,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with global variable receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       GlobalVariableRead(GLOBAL_VARIABLE("$var")),
       DOT("."),
       IDENTIFIER("a"),
@@ -1837,7 +1836,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def $var.a\nend"
@@ -1845,7 +1845,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with __FILE__ receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SourceFileNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1855,7 +1854,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def __FILE__.a\nend"
@@ -1863,7 +1863,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with __LINE__ receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SourceLineNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1873,7 +1872,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def __LINE__.a\nend"
@@ -1881,7 +1881,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with __ENCODING__ receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SourceEncodingNode(),
       DOT("."),
       IDENTIFIER("a"),
@@ -1891,7 +1890,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def __ENCODING__.a\nend"
@@ -1899,7 +1899,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with expression as receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, nil, "b"),
@@ -1913,7 +1912,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def (b).a\nend"
@@ -1921,7 +1921,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with assignment expression as receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         LocalVariableWrite(
@@ -1939,7 +1938,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def (c = b).a\nend"
@@ -1947,7 +1947,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with literal expression as receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         IntegerNode(),
@@ -1961,7 +1960,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def (1).a\nend"
@@ -1969,7 +1969,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with expression as reciever and colon colon operator" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, nil, "a"),
@@ -1983,7 +1982,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def (a)::b\nend"
@@ -3362,7 +3362,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "endless method definition without arguments" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("foo"),
@@ -3372,7 +3371,8 @@ class ParseTest < Test::Unit::TestCase
       EQUAL("="),
       Statements([expression("123")]),
       nil,
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def foo = 123"
@@ -3380,7 +3380,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "endless method definition with arguments" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       IDENTIFIER("foo"),
@@ -3390,7 +3389,8 @@ class ParseTest < Test::Unit::TestCase
       EQUAL("="),
       Statements([expression("123")]),
       nil,
-      Scope([IDENTIFIER("bar")])
+      Scope([IDENTIFIER("bar")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def foo(bar) = 123"
@@ -4155,7 +4155,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + without parentheses" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       PLUS("+"),
@@ -4165,7 +4164,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def +\nend"
@@ -4173,7 +4173,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with parentheses" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       PLUS("+"),
@@ -4183,7 +4182,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def +()\nend"
@@ -4191,7 +4191,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with required parameter" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       PLUS("+"),
@@ -4201,7 +4200,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b")])
+      Scope([IDENTIFIER("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def + b\nend"
@@ -4209,7 +4209,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with keyword rest parameter" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       PLUS("+"),
@@ -4219,7 +4218,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([IDENTIFIER("b")])
+      Scope([IDENTIFIER("b")]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def + **b\nend"
@@ -4227,7 +4227,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def -" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       MINUS("-"),
@@ -4237,7 +4236,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def -\nend"
@@ -4245,7 +4245,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ==" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       EQUAL_EQUAL("=="),
@@ -4255,7 +4254,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def ==\nend"
@@ -4263,7 +4263,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def |" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       PIPE("|"),
@@ -4273,7 +4272,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def |\nend"
@@ -4281,7 +4281,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ^" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       CARET("^"),
@@ -4291,7 +4290,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def ^\nend"
@@ -4299,7 +4299,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def &" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       AMPERSAND("&"),
@@ -4309,7 +4308,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def &\nend"
@@ -4317,7 +4317,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <=>" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       LESS_EQUAL_GREATER("<=>"),
@@ -4327,7 +4326,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def <=>\nend"
@@ -4335,7 +4335,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ===" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       EQUAL_EQUAL_EQUAL("==="),
@@ -4345,7 +4344,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def ===\nend"
@@ -4353,7 +4353,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def =~" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       EQUAL_TILDE("=~"),
@@ -4363,7 +4362,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def =~\nend"
@@ -4371,7 +4371,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def !~" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       BANG_TILDE("!~"),
@@ -4381,7 +4380,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def !~\nend"
@@ -4389,7 +4389,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def >" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       GREATER(">"),
@@ -4399,7 +4398,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def >\nend"
@@ -4407,7 +4407,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def >=" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       GREATER_EQUAL(">="),
@@ -4417,7 +4416,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def >=\nend"
@@ -4425,7 +4425,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       LESS("<"),
@@ -4435,7 +4434,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def <\nend"
@@ -4443,7 +4443,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <=" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       LESS_EQUAL("<="),
@@ -4453,7 +4452,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def <=\nend"
@@ -4461,7 +4461,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def !=" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       BANG_EQUAL("!="),
@@ -4471,7 +4470,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def !=\nend"
@@ -4479,7 +4479,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <<" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       LESS_LESS("<<"),
@@ -4489,7 +4488,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def <<\nend"
@@ -4497,7 +4497,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def >>" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       GREATER_GREATER(">>"),
@@ -4507,7 +4506,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def >>\nend"
@@ -4515,7 +4515,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def *" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       STAR("*"),
@@ -4525,7 +4524,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def *\nend"
@@ -4533,7 +4533,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def /" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       SLASH("/"),
@@ -4543,7 +4542,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def /\nend"
@@ -4551,7 +4551,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def %" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       PERCENT("%"),
@@ -4561,7 +4560,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def %\nend"
@@ -4569,7 +4569,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def **" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       STAR_STAR("**"),
@@ -4579,7 +4578,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def **\nend"
@@ -4587,7 +4587,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def !" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       BANG("!"),
@@ -4597,7 +4596,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def !\nend"
@@ -4605,7 +4605,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ~" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       TILDE("~"),
@@ -4615,7 +4614,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def ~\nend"
@@ -4623,7 +4623,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def +@" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       PLUS_AT("+@"),
@@ -4633,7 +4632,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def +@\nend"
@@ -4641,7 +4641,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def -@" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       MINUS_AT("-@"),
@@ -4651,7 +4650,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def -@\nend"
@@ -4659,7 +4659,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def []" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       BRACKET_LEFT_RIGHT("[]"),
@@ -4669,7 +4668,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def []\nend"
@@ -4677,7 +4677,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def []=" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       BRACKET_LEFT_RIGHT_EQUAL("[]="),
@@ -4687,7 +4686,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def []=\nend"
@@ -4695,7 +4695,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with self receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SelfNode(),
       DOT("."),
       PLUS("+"),
@@ -4705,7 +4704,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def self.+\nend"
@@ -4713,7 +4713,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def `" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       BACKTICK("`"),
@@ -4723,7 +4722,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def `\nend"
@@ -4731,7 +4731,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def self.`" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SelfNode(),
       DOT("."),
       BACKTICK("`"),
@@ -4741,7 +4740,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def self.`\nend"
@@ -4749,7 +4749,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def % with self receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SelfNode(),
       DOT("."),
       PLUS("+"),
@@ -4759,7 +4758,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def self.+\nend"
@@ -4767,7 +4767,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def def" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       nil,
       nil,
       KEYWORD_DEF("def"),
@@ -4777,7 +4776,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def def\nend"
@@ -4785,7 +4785,6 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ensure with self receiver" do
     expected = DefNode(
-      KEYWORD_DEF("def"),
       SelfNode(),
       DOT("."),
       KEYWORD_ENSURE("ensure"),
@@ -4795,7 +4794,8 @@ class ParseTest < Test::Unit::TestCase
       nil,
       Statements([]),
       KEYWORD_END("end"),
-      Scope([])
+      Scope([]),
+      Location(0, 3)
     )
 
     assert_parses expected, "def self.ensure\nend"

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -36,7 +36,7 @@ class ParseTest < Test::Unit::TestCase
     expected = AliasNode(
       SymbolNode(nil, IDENTIFIER("foo"), nil),
       SymbolNode(nil, IDENTIFIER("bar"), nil),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "alias foo bar"
@@ -46,7 +46,7 @@ class ParseTest < Test::Unit::TestCase
     expected = AliasNode(
       SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("foo"), nil),
       SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("bar"), nil),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "alias :foo :bar"
@@ -56,7 +56,7 @@ class ParseTest < Test::Unit::TestCase
     expected = AliasNode(
       GlobalVariableRead(GLOBAL_VARIABLE("$foo")),
       GlobalVariableRead(GLOBAL_VARIABLE("$bar")),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "alias $foo $bar"
@@ -66,7 +66,7 @@ class ParseTest < Test::Unit::TestCase
     expected = AliasNode(
       GlobalVariableRead(GLOBAL_VARIABLE("$a")),
       GlobalVariableRead(BACK_REFERENCE("$'")),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "alias $a $'"
@@ -279,13 +279,13 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "break" do
-    expected = BreakNode(nil, Location(0, 5))
+    expected = BreakNode(nil, Location())
 
     assert_parses expected, "break"
   end
 
   test "break 1" do
-    expected = BreakNode(ArgumentsNode([expression("1")]), Location(0, 5))
+    expected = BreakNode(ArgumentsNode([expression("1")]), Location())
 
     assert_parses expected, "break 1"
   end
@@ -297,7 +297,7 @@ class ParseTest < Test::Unit::TestCase
         expression("2"),
         expression("3"),
       ]),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "break 1, 2, 3"
@@ -310,7 +310,7 @@ class ParseTest < Test::Unit::TestCase
         expression("2"),
         expression("3"),
       ]),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "break 1, 2,\n3"
@@ -319,7 +319,7 @@ class ParseTest < Test::Unit::TestCase
   test "break()" do
     expected = BreakNode(
       ArgumentsNode([expression("()")]),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "break()"
@@ -328,7 +328,7 @@ class ParseTest < Test::Unit::TestCase
   test "break(1)" do
     expected = BreakNode(
       ArgumentsNode([expression("(1)")]),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "break(1)"
@@ -341,7 +341,7 @@ class ParseTest < Test::Unit::TestCase
         expression("(2)"),
         expression("(3)"),
       ]),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "break (1), (2), (3)"
@@ -350,7 +350,7 @@ class ParseTest < Test::Unit::TestCase
   test "break [1, 2, 3]" do
     expected = BreakNode(
       ArgumentsNode([expression("[1, 2, 3]")]),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "break [1, 2, 3]"
@@ -365,7 +365,7 @@ class ParseTest < Test::Unit::TestCase
           PARENTHESIS_RIGHT(")")
         )
       ]),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, <<~RUBY
@@ -753,7 +753,7 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "class variable write" do
-    assert_parses ClassVariableWriteNode(Location(0, 5), expression("1"), Location(6, 7)), "@@abc = 1"
+    assert_parses ClassVariableWriteNode(Location(), expression("1"), Location()), "@@abc = 1"
   end
 
   test "constant path" do
@@ -857,17 +857,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def without parentheses" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a\nend"
@@ -875,17 +875,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with parentheses" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
-      ParametersNode([], [], nil, [], nil, nil),
       nil,
+      ParametersNode([], [], nil, [], nil, nil),
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(6, 7)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a()\nend"
@@ -893,17 +893,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with scope" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([expression("b = 1")]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a\nb = 1\nend"
@@ -911,9 +911,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with required parameter" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [RequiredParameterNode(IDENTIFIER("b"))],
         [],
@@ -922,13 +921,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a b\nend"
@@ -936,9 +936,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword parameter (no parenthesis)" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [],
@@ -947,13 +946,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([LABEL("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a b:\nend"
@@ -961,9 +961,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword parameter (parenthesis)" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [],
@@ -972,13 +971,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([LABEL("b")]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(8, 9)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a(b:)\nend"
@@ -986,9 +986,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with multiple required parameters" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [
           RequiredParameterNode(IDENTIFIER("b")),
@@ -1001,13 +1000,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b"), IDENTIFIER("c"), IDENTIFIER("d")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a b, c, d\nend"
@@ -1015,9 +1015,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with required and optional parameters" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [RequiredParameterNode(IDENTIFIER("b"))],
         [OptionalParameterNode(IDENTIFIER("c"), EQUAL("="), expression("2"))],
@@ -1026,13 +1025,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b"), IDENTIFIER("c")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a b, c = 2\nend"
@@ -1040,9 +1040,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional parameters" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [
@@ -1054,13 +1053,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b"), IDENTIFIER("c")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a b = 1, c = 2\nend"
@@ -1068,9 +1068,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional keyword parameters (no parenthesis)" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [KeywordParameterNode(LABEL("c:"), expression("1"))],
@@ -1079,13 +1078,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([LABEL("b"), LABEL("c")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a b:, c: 1 \nend"
@@ -1093,9 +1093,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional keyword parameters (parenthesis)" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [KeywordParameterNode(LABEL("c:"), expression("1"))],
@@ -1104,13 +1103,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([LABEL("b"), LABEL("c")]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(14, 15)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a(b:, c: 1)\nend"
@@ -1118,9 +1118,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with optional keyword parameters and line break" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [KeywordParameterNode(LABEL("b:"), expression("1"))],
@@ -1129,13 +1128,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([LABEL("b"), LABEL("c")]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(16, 17)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, <<~RUBY
@@ -1147,9 +1147,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with rest parameter" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [],
@@ -1158,13 +1157,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a *b\nend"
@@ -1172,17 +1172,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with rest parameter without name" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode([], [], RestParameterNode(STAR("*"), nil), [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([STAR("*")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a *\nend"
@@ -1190,9 +1190,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword rest parameter" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [],
@@ -1201,13 +1200,14 @@ class ParseTest < Test::Unit::TestCase
         KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("b")),
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a **b\nend"
@@ -1215,9 +1215,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with keyword rest parameter without name" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [],
@@ -1226,13 +1225,14 @@ class ParseTest < Test::Unit::TestCase
         KeywordRestParameterNode(STAR_STAR("**"), nil),
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a **\nend"
@@ -1240,17 +1240,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with forwarding parameter" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a ...\nend"
@@ -1258,24 +1258,24 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with block parameter" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [],
         nil,
         [],
         nil,
-        BlockParameterNode(IDENTIFIER("b"), Location(6, 7))
+        BlockParameterNode(IDENTIFIER("b"), Location())
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a &b\nend"
@@ -1283,24 +1283,24 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with block parameter without name" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode(
         [],
         [],
         nil,
         [],
         nil,
-        BlockParameterNode(nil, Location(6, 7))
+        BlockParameterNode(nil, Location())
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a &\nend"
@@ -1308,24 +1308,24 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with **nil" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("m"),
+      nil,
       ParametersNode(
         [RequiredParameterNode(IDENTIFIER("a"))],
         [],
         nil,
         [KeywordParameterNode(LABEL("b:"), nil)],
-        NoKeywordsParameterNode(Location(13, 15), Location(15, 18)),
+        NoKeywordsParameterNode(Location(), Location()),
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("a"), LABEL("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def m a, b:, **nil\nend"
@@ -1400,7 +1400,7 @@ class ParseTest < Test::Unit::TestCase
               ),
               AssocSplatNode(
                 HashNode(BRACE_LEFT("{"), [], BRACE_RIGHT("}")),
-                Location(22, 24)
+                Location()
               ),
               AssocNode(
                 SymbolNode(nil, LABEL("whatup"), LABEL_END(":")),
@@ -1438,7 +1438,7 @@ class ParseTest < Test::Unit::TestCase
               ),
               AssocSplatNode(
                 HashNode(BRACE_LEFT("{"), [], BRACE_RIGHT("}")),
-                Location(22, 24)
+                Location()
               ),
               AssocNode(
                 SymbolNode(nil, LABEL("whatup"), LABEL_END(":")),
@@ -1477,7 +1477,7 @@ class ParseTest < Test::Unit::TestCase
               ),
               AssocSplatNode(
                 HashNode(BRACE_LEFT("{"), [], BRACE_RIGHT("}")),
-                Location(29, 31)
+                Location()
               ),
               AssocNode(
                 SymbolNode(nil, LABEL("whatup"), LABEL_END(":")),
@@ -1499,11 +1499,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "method call with ..." do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
-      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       nil,
+      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       Statements(
         [
           CallNode(
@@ -1518,24 +1516,23 @@ class ParseTest < Test::Unit::TestCase
           )
         ]
       ),
-      KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(9, 10)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a(...); b(...); end"
   end
 
-
   test "method call with ... after args" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
-      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       nil,
+      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       Statements(
         [
           CallNode(
@@ -1552,11 +1549,13 @@ class ParseTest < Test::Unit::TestCase
           )
         ]
       ),
-      KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(9, 10)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a(...); b(1, 2, ...); end"
@@ -1564,11 +1563,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "method call with interpolated ..." do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
-      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       nil,
+      ParametersNode([], [], nil, [], ForwardingParameterNode(), nil),
       Statements(
         [
           InterpolatedStringNode(
@@ -1598,11 +1595,13 @@ class ParseTest < Test::Unit::TestCase
           )
         ]
       ),
-      KEYWORD_END("end"),
       Scope([DOT_DOT_DOT("...")]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(9, 10)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a(...); \"foo\#{b(...)}\"; end"
@@ -1629,11 +1628,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "method call with *" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
-      ParametersNode([], [], RestParameterNode(STAR("*"), nil), [], nil, nil),
       nil,
+      ParametersNode([], [], RestParameterNode(STAR("*"), nil), [], nil, nil),
       Statements(
         [
           CallNode(
@@ -1648,11 +1645,13 @@ class ParseTest < Test::Unit::TestCase
           )
         ]
       ),
-      KEYWORD_END("end"),
       Scope([STAR("*")]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(7, 8)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a(*); b(*); end"
@@ -1678,17 +1677,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with identifier receiver" do
     expected = DefNode(
-      expression("a"),
-      DOT("."),
       IDENTIFIER("b"),
+      expression("a"),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a.b\nend"
@@ -1696,17 +1695,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def - with identifier receiver" do
     expected = DefNode(
-      expression("a"),
-      DOT("."),
       MINUS("-"),
+      expression("a"),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def a.-;end"
@@ -1714,17 +1713,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with local variable identifier receiver" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("a"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(7, 10),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "a = 1; def a\nend"
@@ -1732,17 +1731,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with colon_colon nil receiver" do
     expected = DefNode(
-      NilNode(),
-      COLON_COLON("::"),
       IDENTIFIER("a"),
+      NilNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def nil::a\nend"
@@ -1750,17 +1749,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with nil receiver" do
     expected = DefNode(
-      NilNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      NilNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def nil.a\nend"
@@ -1768,17 +1767,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with self receiver" do
     expected = DefNode(
-      SelfNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      SelfNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def self.a\nend"
@@ -1786,17 +1785,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with true receiver" do
     expected = DefNode(
-      TrueNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      TrueNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def true.a\nend"
@@ -1804,17 +1803,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with false receiver" do
     expected = DefNode(
-      FalseNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      FalseNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def false.a\nend"
@@ -1822,17 +1821,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with constant receiver" do
     expected = DefNode(
-      ConstantRead(CONSTANT("Const")),
-      DOT("."),
       IDENTIFIER("a"),
+      ConstantRead(CONSTANT("Const")),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(11, 14),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "Const = 1; def Const.a\nend"
@@ -1840,17 +1839,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with instance variable receiver" do
     expected = DefNode(
-      InstanceVariableReadNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      InstanceVariableReadNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def @var.a\nend"
@@ -1858,17 +1857,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with class variable receiver" do
     expected = DefNode(
-      ClassVariableReadNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      ClassVariableReadNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def @@var.a\nend"
@@ -1876,17 +1875,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with global variable receiver" do
     expected = DefNode(
-      GlobalVariableRead(GLOBAL_VARIABLE("$var")),
-      DOT("."),
       IDENTIFIER("a"),
+      GlobalVariableRead(GLOBAL_VARIABLE("$var")),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def $var.a\nend"
@@ -1894,17 +1893,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with __FILE__ receiver" do
     expected = DefNode(
-      SourceFileNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      SourceFileNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def __FILE__.a\nend"
@@ -1912,17 +1911,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with __LINE__ receiver" do
     expected = DefNode(
-      SourceLineNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      SourceLineNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def __LINE__.a\nend"
@@ -1930,17 +1929,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with __ENCODING__ receiver" do
     expected = DefNode(
-      SourceEncodingNode(),
-      DOT("."),
       IDENTIFIER("a"),
+      SourceEncodingNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def __ENCODING__.a\nend"
@@ -1948,21 +1947,21 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with expression as receiver" do
     expected = DefNode(
+      IDENTIFIER("a"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         CallNode(nil, nil, IDENTIFIER("b"), nil, nil, nil, nil, "b"),
         PARENTHESIS_RIGHT(")")
       ),
-      DOT("."),
-      IDENTIFIER("a"),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def (b).a\nend"
@@ -1970,6 +1969,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with assignment expression as receiver" do
     expected = DefNode(
+      IDENTIFIER("a"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         LocalVariableWrite(
@@ -1979,16 +1979,15 @@ class ParseTest < Test::Unit::TestCase
         ),
         PARENTHESIS_RIGHT(")")
       ),
-      DOT("."),
-      IDENTIFIER("a"),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def (c = b).a\nend"
@@ -1996,21 +1995,21 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with literal expression as receiver" do
     expected = DefNode(
+      IDENTIFIER("a"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         IntegerNode(),
         PARENTHESIS_RIGHT(")")
       ),
-      DOT("."),
-      IDENTIFIER("a"),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def (1).a\nend"
@@ -2018,39 +2017,39 @@ class ParseTest < Test::Unit::TestCase
 
   test "def with expression as reciever and colon colon operator" do
     expected = DefNode(
+      IDENTIFIER("b"),
       ParenthesesNode(
         PARENTHESIS_LEFT("("),
         CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, nil, "a"),
         PARENTHESIS_RIGHT(")")
       ),
-      COLON_COLON("::"),
-      IDENTIFIER("b"),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def (a)::b\nend"
   end
 
   test "defined? without parentheses" do
-    assert_parses DefinedNode(nil, expression("1"), nil, Location(0, 8)), "defined? 1"
+    assert_parses DefinedNode(nil, expression("1"), nil, Location()), "defined? 1"
   end
 
   test "defined? with parentheses" do
-    assert_parses DefinedNode(PARENTHESIS_LEFT("("), expression("1"), PARENTHESIS_RIGHT(")"), Location(0, 8)), "defined?(1)"
+    assert_parses DefinedNode(PARENTHESIS_LEFT("("), expression("1"), PARENTHESIS_RIGHT(")"), Location()), "defined?(1)"
   end
 
   test "defined? binding power" do
     expected =
       AndNode(
-        DefinedNode(nil, expression("1"), nil, Location(0, 8)),
-        DefinedNode(nil, expression("2"), nil, Location(15, 23)),
+        DefinedNode(nil, expression("1"), nil, Location()),
+        DefinedNode(nil, expression("2"), nil, Location()),
         KEYWORD_AND("and")
       )
 
@@ -2324,7 +2323,7 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "instance variable write" do
-    assert_parses InstanceVariableWriteNode(Location(0, 4), expression("1"), Location(5, 6)), "@abc = 1"
+    assert_parses InstanceVariableWriteNode(Location(), expression("1"), Location()), "@abc = 1"
   end
 
   test "local variable write" do
@@ -2350,11 +2349,11 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "next" do
-    assert_parses NextNode(nil, Location(0, 4)), "next"
+    assert_parses NextNode(nil, Location()), "next"
   end
 
   test "next 1" do
-    expected = NextNode(ArgumentsNode([expression("1")]), Location(0, 4))
+    expected = NextNode(ArgumentsNode([expression("1")]), Location())
 
     assert_parses expected, "next 1"
   end
@@ -2362,7 +2361,7 @@ class ParseTest < Test::Unit::TestCase
   test "next 1, 2, 3" do
     expected = NextNode(
       ArgumentsNode([expression("1"), expression("2"), expression("3")]),
-      Location(0, 4)
+      Location()
     )
 
     assert_parses expected, "next 1, 2, 3"
@@ -2371,20 +2370,20 @@ class ParseTest < Test::Unit::TestCase
   test "next 1, 2,\n3" do
     expected = NextNode(
       ArgumentsNode([expression("1"), expression("2"), expression("3")]),
-      Location(0, 4)
+      Location()
     )
 
     assert_parses expected, "next 1, 2,\n3"
   end
 
   test "next()" do
-    expected = NextNode(ArgumentsNode([expression("()")]), Location(0, 4))
+    expected = NextNode(ArgumentsNode([expression("()")]), Location())
 
     assert_parses expected, "next()"
   end
 
   test "next(1)" do
-    expected = NextNode(ArgumentsNode([expression("(1)"),]), Location(0, 4))
+    expected = NextNode(ArgumentsNode([expression("(1)"),]), Location())
 
     assert_parses expected, "next(1)"
   end
@@ -2396,7 +2395,7 @@ class ParseTest < Test::Unit::TestCase
         expression("(2)"),
         expression("(3)"),
       ]),
-      Location(0, 4)
+      Location()
     )
 
     assert_parses expected, "next (1), (2), (3)"
@@ -2405,7 +2404,7 @@ class ParseTest < Test::Unit::TestCase
   test "next [1, 2, 3]" do
     expected = NextNode(
       ArgumentsNode([expression("[1, 2, 3]")]),
-      Location(0, 4)
+      Location()
     )
 
     assert_parses expected, "next [1, 2, 3]"
@@ -2420,7 +2419,7 @@ class ParseTest < Test::Unit::TestCase
           PARENTHESIS_RIGHT(")")
         )
       ]),
-      Location(0, 4)
+      Location()
     )
 
     assert_parses expected, <<~RUBY
@@ -2444,7 +2443,7 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "operator and assignment" do
-    assert_parses OperatorAndAssignmentNode(expression("a"), expression("b"), Location(2, 5)), "a &&= b"
+    assert_parses OperatorAndAssignmentNode(expression("a"), expression("b"), Location()), "a &&= b"
   end
 
   test "operator or assignment" do
@@ -2456,11 +2455,11 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "post execution" do
-    assert_parses PostExecutionNode(Statements([expression("1")]), Location(0, 3), Location(4, 5), Location(8, 9)), "END { 1 }"
+    assert_parses PostExecutionNode(Statements([expression("1")]), Location(), Location(), Location()), "END { 1 }"
   end
 
   test "pre execution" do
-    assert_parses PreExecutionNode(Statements([expression("1")]), Location(0, 5), Location(6, 7), Location(10, 11)), "BEGIN { 1 }"
+    assert_parses PreExecutionNode(Statements([expression("1")]), Location(), Location(), Location()), "BEGIN { 1 }"
   end
 
   test "range inclusive" do
@@ -3074,7 +3073,7 @@ class ParseTest < Test::Unit::TestCase
     expected = AliasNode(
       SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'")),
       SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("def"), STRING_END("'")),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "alias :'abc' :'def'"
@@ -3093,7 +3092,7 @@ class ParseTest < Test::Unit::TestCase
         STRING_END("\"")
       ),
       SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("def"), STRING_END("'")),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "alias :\"abc\#{1}\" :'def'"
@@ -3102,7 +3101,7 @@ class ParseTest < Test::Unit::TestCase
   test "undef with dynamic symbols" do
     expected = UndefNode(
       [SymbolNode(SYMBOL_BEGIN(":'"), STRING_CONTENT("abc"), STRING_END("'"))],
-      Location(0, 5)
+      Location()
     )
     assert_parses expected, "undef :'abc'"
   end
@@ -3121,7 +3120,7 @@ class ParseTest < Test::Unit::TestCase
           STRING_END("\"")
         )
       ],
-      Location(0, 5)
+      Location()
     )
     assert_parses expected, "undef :\"abc\#{1}\""
   end
@@ -3135,7 +3134,7 @@ class ParseTest < Test::Unit::TestCase
     expected = AliasNode(
       SymbolNode(SYMBOL_BEGIN("%s["), STRING_CONTENT("abc"), STRING_END("]")),
       SymbolNode(SYMBOL_BEGIN("%s["), STRING_CONTENT("def"), STRING_END("]")),
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "alias %s[abc] %s[def]"
@@ -3170,15 +3169,15 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "undef bare" do
-    assert_parses UndefNode([SymbolNode(nil, IDENTIFIER("a"), nil)], Location(0, 5)), "undef a"
+    assert_parses UndefNode([SymbolNode(nil, IDENTIFIER("a"), nil)], Location()), "undef a"
   end
 
   test "undef bare, multiple" do
-    assert_parses UndefNode([SymbolNode(nil, IDENTIFIER("a"), nil), SymbolNode(nil, IDENTIFIER("b"), nil)], Location(0, 5)), "undef a, b"
+    assert_parses UndefNode([SymbolNode(nil, IDENTIFIER("a"), nil), SymbolNode(nil, IDENTIFIER("b"), nil)], Location()), "undef a, b"
   end
 
   test "undef symbol" do
-    assert_parses UndefNode([SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil)], Location(0, 5)), "undef :a"
+    assert_parses UndefNode([SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil)], Location()), "undef :a"
   end
 
   test "undef symbol, multiple" do
@@ -3188,7 +3187,7 @@ class ParseTest < Test::Unit::TestCase
         SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil),
         SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("c"), nil)
       ],
-      Location(0, 5)
+      Location()
     )
 
     assert_parses expected, "undef :a, :b, :c"
@@ -3411,16 +3410,16 @@ class ParseTest < Test::Unit::TestCase
 
   test "endless method definition without arguments" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("foo"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      EQUAL("="),
       Statements([expression("123")]),
-      nil,
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
+      nil,
+      nil,
+      Location(),
       nil
     )
 
@@ -3429,9 +3428,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "endless method definition with arguments" do
     expected = DefNode(
-      nil,
-      nil,
       IDENTIFIER("foo"),
+      nil,
       ParametersNode(
         [RequiredParameterNode(IDENTIFIER("bar"))],
         [],
@@ -3440,13 +3438,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      EQUAL("="),
       Statements([expression("123")]),
-      nil,
       Scope([IDENTIFIER("bar")]),
-      Location(0, 3),
-      Location(7, 8),
-      Location(11, 12)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      Location(),
+      nil
     )
 
     assert_parses expected, "def foo(bar) = 123"
@@ -3856,7 +3855,7 @@ class ParseTest < Test::Unit::TestCase
       [
         AssocNode(SymbolNode(nil, LABEL("a"), LABEL_END(":")), expression("b"), nil),
         AssocNode(SymbolNode(nil, LABEL("c"), LABEL_END(":")), expression("d"), nil),
-        AssocSplatNode(expression("e"), Location(14, 16)),
+        AssocSplatNode(expression("e"), Location()),
         AssocNode(SymbolNode(nil, LABEL("f"), LABEL_END(":")), expression("g"), nil),
       ],
       BRACE_RIGHT("}")
@@ -3876,7 +3875,7 @@ class ParseTest < Test::Unit::TestCase
         ),
         AssocSplatNode(
           CallNode(nil, nil, IDENTIFIER("c"), nil, nil, nil, nil, "c"),
-          Location(10, 12)
+          Location()
         )
       ],
       BRACE_RIGHT("}")
@@ -4211,17 +4210,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + without parentheses" do
     expected = DefNode(
-      nil,
-      nil,
       PLUS("+"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def +\nend"
@@ -4229,17 +4228,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with parentheses" do
     expected = DefNode(
-      nil,
-      nil,
       PLUS("+"),
-      ParametersNode([], [], nil, [], nil, nil),
       nil,
+      ParametersNode([], [], nil, [], nil, nil),
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
-      Location(5, 6),
-      Location(6, 7)
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
     )
 
     assert_parses expected, "def +()\nend"
@@ -4247,9 +4246,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with required parameter" do
     expected = DefNode(
-      nil,
-      nil,
       PLUS("+"),
+      nil,
       ParametersNode(
         [RequiredParameterNode(IDENTIFIER("b"))],
         [],
@@ -4258,13 +4256,14 @@ class ParseTest < Test::Unit::TestCase
         nil,
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def + b\nend"
@@ -4272,9 +4271,8 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with keyword rest parameter" do
     expected = DefNode(
-      nil,
-      nil,
       PLUS("+"),
+      nil,
       ParametersNode(
         [],
         [],
@@ -4283,13 +4281,14 @@ class ParseTest < Test::Unit::TestCase
         KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("b")),
         nil
       ),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([IDENTIFIER("b")]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def + **b\nend"
@@ -4297,17 +4296,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def -" do
     expected = DefNode(
-      nil,
-      nil,
       MINUS("-"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def -\nend"
@@ -4315,17 +4314,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ==" do
     expected = DefNode(
-      nil,
-      nil,
       EQUAL_EQUAL("=="),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def ==\nend"
@@ -4333,17 +4332,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def |" do
     expected = DefNode(
-      nil,
-      nil,
       PIPE("|"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def |\nend"
@@ -4351,17 +4350,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ^" do
     expected = DefNode(
-      nil,
-      nil,
       CARET("^"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def ^\nend"
@@ -4369,17 +4368,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def &" do
     expected = DefNode(
-      nil,
-      nil,
       AMPERSAND("&"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def &\nend"
@@ -4387,17 +4386,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <=>" do
     expected = DefNode(
-      nil,
-      nil,
       LESS_EQUAL_GREATER("<=>"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def <=>\nend"
@@ -4405,17 +4404,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ===" do
     expected = DefNode(
-      nil,
-      nil,
       EQUAL_EQUAL_EQUAL("==="),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def ===\nend"
@@ -4423,17 +4422,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def =~" do
     expected = DefNode(
-      nil,
-      nil,
       EQUAL_TILDE("=~"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def =~\nend"
@@ -4441,17 +4440,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def !~" do
     expected = DefNode(
-      nil,
-      nil,
       BANG_TILDE("!~"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def !~\nend"
@@ -4459,17 +4458,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def >" do
     expected = DefNode(
-      nil,
-      nil,
       GREATER(">"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def >\nend"
@@ -4477,17 +4476,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def >=" do
     expected = DefNode(
-      nil,
-      nil,
       GREATER_EQUAL(">="),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def >=\nend"
@@ -4495,17 +4494,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <" do
     expected = DefNode(
-      nil,
-      nil,
       LESS("<"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def <\nend"
@@ -4513,17 +4512,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <=" do
     expected = DefNode(
-      nil,
-      nil,
       LESS_EQUAL("<="),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def <=\nend"
@@ -4531,17 +4530,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def !=" do
     expected = DefNode(
-      nil,
-      nil,
       BANG_EQUAL("!="),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def !=\nend"
@@ -4549,17 +4548,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def <<" do
     expected = DefNode(
-      nil,
-      nil,
       LESS_LESS("<<"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def <<\nend"
@@ -4567,17 +4566,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def >>" do
     expected = DefNode(
-      nil,
-      nil,
       GREATER_GREATER(">>"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def >>\nend"
@@ -4585,17 +4584,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def *" do
     expected = DefNode(
-      nil,
-      nil,
       STAR("*"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def *\nend"
@@ -4603,17 +4602,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def /" do
     expected = DefNode(
-      nil,
-      nil,
       SLASH("/"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def /\nend"
@@ -4621,17 +4620,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def %" do
     expected = DefNode(
-      nil,
-      nil,
       PERCENT("%"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def %\nend"
@@ -4639,17 +4638,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def **" do
     expected = DefNode(
-      nil,
-      nil,
       STAR_STAR("**"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def **\nend"
@@ -4657,17 +4656,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def !" do
     expected = DefNode(
-      nil,
-      nil,
       BANG("!"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def !\nend"
@@ -4675,17 +4674,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ~" do
     expected = DefNode(
-      nil,
-      nil,
       TILDE("~"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def ~\nend"
@@ -4693,17 +4692,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def +@" do
     expected = DefNode(
-      nil,
-      nil,
       PLUS_AT("+@"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def +@\nend"
@@ -4711,17 +4710,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def -@" do
     expected = DefNode(
-      nil,
-      nil,
       MINUS_AT("-@"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def -@\nend"
@@ -4729,17 +4728,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def []" do
     expected = DefNode(
-      nil,
-      nil,
       BRACKET_LEFT_RIGHT("[]"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def []\nend"
@@ -4747,17 +4746,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def []=" do
     expected = DefNode(
-      nil,
-      nil,
       BRACKET_LEFT_RIGHT_EQUAL("[]="),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def []=\nend"
@@ -4765,17 +4764,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def + with self receiver" do
     expected = DefNode(
-      SelfNode(),
-      DOT("."),
       PLUS("+"),
+      SelfNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def self.+\nend"
@@ -4783,17 +4782,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def `" do
     expected = DefNode(
-      nil,
-      nil,
       BACKTICK("`"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def `\nend"
@@ -4801,17 +4800,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def self.`" do
     expected = DefNode(
-      SelfNode(),
-      DOT("."),
       BACKTICK("`"),
+      SelfNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def self.`\nend"
@@ -4819,17 +4818,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def % with self receiver" do
     expected = DefNode(
-      SelfNode(),
-      DOT("."),
       PLUS("+"),
+      SelfNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def self.+\nend"
@@ -4837,17 +4836,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def def" do
     expected = DefNode(
-      nil,
-      nil,
       KEYWORD_DEF("def"),
+      nil,
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def def\nend"
@@ -4855,17 +4854,17 @@ class ParseTest < Test::Unit::TestCase
 
   test "def ensure with self receiver" do
     expected = DefNode(
-      SelfNode(),
-      DOT("."),
       KEYWORD_ENSURE("ensure"),
+      SelfNode(),
       ParametersNode([], [], nil, [], nil, nil),
-      nil,
       Statements([]),
-      KEYWORD_END("end"),
       Scope([]),
-      Location(0, 3),
+      Location(),
+      Location(),
       nil,
-      nil
+      nil,
+      nil,
+      Location()
     )
 
     assert_parses expected, "def self.ensure\nend"
@@ -4954,7 +4953,7 @@ class ParseTest < Test::Unit::TestCase
           RestParameterNode(STAR("*"), IDENTIFIER("e")),
           [KeywordParameterNode(LABEL("c:"), nil), KeywordParameterNode(LABEL("d:"), nil)],
           KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("f")),
-          BlockParameterNode(IDENTIFIER("g"), Location(31, 32))
+          BlockParameterNode(IDENTIFIER("g"), Location())
         ),
         []
       ),
@@ -4986,7 +4985,7 @@ class ParseTest < Test::Unit::TestCase
           nil,
           [KeywordParameterNode(LABEL("c:"), nil), KeywordParameterNode(LABEL("d:"), nil)],
           nil,
-          BlockParameterNode(IDENTIFIER("e"), Location(21, 22))
+          BlockParameterNode(IDENTIFIER("e"), Location())
         ),
         []
       ),
@@ -5020,7 +5019,7 @@ class ParseTest < Test::Unit::TestCase
           RestParameterNode(STAR("*"), IDENTIFIER("e")),
           [KeywordParameterNode(LABEL("c:"), nil), KeywordParameterNode(LABEL("d:"), nil)],
           KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("f")),
-          BlockParameterNode(IDENTIFIER("g"), Location(31, 32))
+          BlockParameterNode(IDENTIFIER("g"), Location())
         ),
         []
       ),
@@ -5125,4 +5124,19 @@ class ParseTest < Test::Unit::TestCase
     result.node => YARP::Program[statements: YARP::Statements[body: [*, node]]]
     node
   end
+
+  # This method is just named this way to mirror the other DSL methods.
+  def Location()
+    YARP::Location.new(0, 0)
+  end
 end
+
+# Here we're going to override the == method in order to avoid having to
+# specifically track offsets and compare them.
+YARP::Location.prepend(
+  Module.new do
+    def ==(other)
+      true
+    end
+  end
+)


### PR DESCRIPTION
This PR introduces the concept of an optional location parameter, which is very similar to a location parameter except that if it is set to the parser start then it will only serialize as a single 0.

This allows us to replace optional tokens with optional locations when the token type is constant. For example, in the `DefNode`, there are `lparen` and `rparen` fields, which are both optional tokens. They will always be `(` and `)` respectively, so we don't need to attach the type information. We can replace these with optional location params instead and save the 8 bytes per field.

The `DefNode` ends up being a good use case here, because it's the largest node by summing the size of its child nodes. Since it's the largest, reducing the size of it actually reduces the size of _every_ node since it's a union. This PR therefore reduces the size of all nodes from `224` bytes to `176` bytes. That still feels absolutely huge, so I'd like to keep working on this.

The remaining size of the various node types is now below.

<details><summary>Node sizes</summary>
<p>

DefNode: 152
CallNode: 144
ForNode: 120
RescueNode: 112
ClassNode: 104
SClassNode: 96
ParametersNode: 96
StringNode: 96
SuperNode: 88
BeginNode: 80
YieldNode: 80
HeredocNode: 76
InterpolatedSymbolNode: 72
InterpolatedStringNode: 72
XStringNode: 72
HashNode: 72
RegularExpressionNode: 72
IfNode: 72
UnlessNode: 72
InterpolatedRegularExpressionNode: 72
ArrayNode: 72
InterpolatedXStringNode: 72
SymbolNode: 72
Ternary: 72
ModuleNode: 72
LambdaNode: 72
DefinedNode: 72
BlockNode: 64
GlobalVariableWrite: 56
StringInterpolatedNode: 56
OptionalParameterNode: 56
LocalVariableWrite: 56
PreExecutionNode: 56
PostExecutionNode: 56
ElseNode: 56
EnsureNode: 56
ParenthesesNode: 56
RestParameterNode: 48
KeywordRestParameterNode: 48
WhileNode: 40
UntilNode: 40
UndefNode: 40
RescueModifierNode: 40
RangeNode: 40
OperatorOrAssignmentNode: 40
OperatorAssignmentNode: 40
InstanceVariableWriteNode: 40
ConstantPathWriteNode: 40
ConstantPathNode: 40
ClassVariableWriteNode: 40
BlockParameterNode: 40
AssocNode: 40
AndNode: 40
OrNode: 40
NoKeywordsParameterNode: 32
OperatorAndAssignmentNode: 32
KeywordParameterNode: 32
AliasNode: 32
BlockVarNode: 32
ReturnNode: 32
KeywordStarNode: 32
BlockArgumentNode: 32
StarNode: 32
Statements: 24
RequiredParameterNode: 24
Scope: 24
ConstantRead: 24
AssocSplatNode: 24
ArgumentsNode: 24
BreakNode: 24
MultiTargetNode: 24
LocalVariableRead: 24
NextNode: 24
GlobalVariableRead: 24
Program: 16
StringConcatNode: 16
ForwardingSuperNode: 8
MissingNode: 0
NilNode: 0
IntegerNode: 0
ClassVariableReadNode: 0
SourceFileNode: 0
SourceLineNode: 0
InstanceVariableReadNode: 0
TrueNode: 0
SelfNode: 0
SourceEncodingNode: 0
ForwardingParameterNode: 0
RedoNode: 0
RationalNode: 0
ForwardingArgumentsNode: 0
RetryNode: 0
FloatNode: 0
FalseNode: 0
ImaginaryNode: 0

</p>
</details> 

This commit also moves things around in the serialization of `DefNode` so that it is in the best order for consumers (hopefully). 