### PR TITLE
Dedent tilde heredocs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -106,6 +106,8 @@ tokens:
     comment: "the start of a heredoc"
   - name: IDENTIFIER
     comment: "an identifier"
+  - name: IGNORED_SPACE
+    comment: "in a tilde heredoc"
   - name: IMAGINARY_NUMBER
     comment: "an imaginary number literal"
   - name: INSTANCE_VARIABLE

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -231,6 +231,7 @@ module YARP
       HEREDOC_END: :on_heredoc_end,
       HEREDOC_START: :on_heredoc_beg,
       IDENTIFIER: :on_ident,
+      IGNORED_SPACE: :on_ignored_sp,
       IMAGINARY_NUMBER: :on_imaginary,
       INTEGER: :on_int,
       INSTANCE_VARIABLE: :on_ivar,

--- a/src/parser.h
+++ b/src/parser.h
@@ -61,6 +61,24 @@ typedef enum {
   YP_HEREDOC_INDENT_TILDE,
 } yp_heredoc_indent_t;
 
+typedef struct {
+  // These pointers point to the beginning and end of the heredoc
+  // identifier.
+  const char *ident_start;
+  uint32_t ident_length;
+
+  uint32_t ignored_whitespace;
+
+  yp_heredoc_quote_t quote;
+  yp_heredoc_indent_t indent;
+
+  bool newline_was_last_breakpoint;
+
+  // This is the pointer to the character where lexing should resume once
+  // the heredoc has been completely processed.
+  const char *next_start;
+} heredoc_struct_t;
+
 // When lexing Ruby source, the lexer has a small amount of state to tell which
 // kind of token it is currently lexing. For example, when we find the start of
 // a string, the first token that we return is a TOKEN_STRING_BEGIN token. After
@@ -133,23 +151,7 @@ typedef struct yp_lex_mode {
       bool interpolation;
     } symbol;
 
-    struct {
-      // These pointers point to the beginning and end of the heredoc
-      // identifier.
-      const char *ident_start;
-      uint32_t ident_length;
-
-      uint32_t ignored_whitespace;
-
-      yp_heredoc_quote_t quote;
-      yp_heredoc_indent_t indent;
-
-      bool newline_was_last_breakpoint;
-
-      // This is the pointer to the character where lexing should resume once
-      // the heredoc has been completely processed.
-      const char *next_start;
-    } heredoc;
+    heredoc_struct_t heredoc;
   } as;
 
   // The previous lex state so that it knows how to pop.

--- a/src/parser.h
+++ b/src/parser.h
@@ -139,8 +139,12 @@ typedef struct yp_lex_mode {
       const char *ident_start;
       uint32_t ident_length;
 
+      uint32_t ignored_whitespace;
+
       yp_heredoc_quote_t quote;
       yp_heredoc_indent_t indent;
+
+      bool newline_was_last_breakpoint;
 
       // This is the pointer to the character where lexing should resume once
       // the heredoc has been completely processed.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1920,6 +1920,18 @@ current_token_starts_line(yp_parser_t *parser) {
   return (parser->current.start == parser->start) || (parser->current.start[-1] == '\n');
 }
 
+static yp_token_type_t
+lex_heredoc_whitespace(yp_parser_t *parser) {
+  uint32_t whitespace = parser->lex_modes.current->as.heredoc.ignored_whitespace;
+
+  if (whitespace != 0 && parser->current.end + whitespace <= parser->end) {
+      parser->current.end += whitespace;
+      return YP_TOKEN_IGNORED_SPACE;
+  }
+
+  return YP_TOKEN_INVALID;
+}
+
 // When we hit a # while lexing something like a string, we need to potentially
 // handle interpolation. This function performs that check. It returns a token
 // type representing what it found. Those cases are:
@@ -2540,7 +2552,9 @@ lex_token_type(yp_parser_t *parser) {
                     .ident_length = ident_length,
                     .next_start = parser->current.end,
                     .quote = quote,
-                    .indent = indent
+                    .indent = indent,
+                    .ignored_whitespace = -1,
+                    .newline_was_last_breakpoint = true
                   }
                 });
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2224,6 +2224,12 @@ lex_newline(yp_parser_t *parser, bool previous_command_start) {
   }
 }
 
+// Optionally call out to the lex callback if one is provided.
+static inline void
+parser_lex_callback(yp_parser_t *parser) {
+  parser->lex_callback->callback(parser->lex_callback->data, parser, &parser->current);
+}
+
 // This is the overall lexer function. It is responsible for advancing both
 // parser->current.start and parser->current.end such that they point to the
 // beginning and end of the next token. It should return the type of token that
@@ -3404,7 +3410,7 @@ lex_token_type(yp_parser_t *parser) {
 
             // Otherwise we hit a newline and it wasn't followed by a
             // terminator, so we can continue parsing.
-            breakpoint = strpbrk(breakpoint + 1, breakpoints);
+            breakpoint = strpbrk(start, breakpoints);
             break;
           }
           case '\\':
@@ -3659,14 +3665,6 @@ match_any_type_p(yp_parser_t *parser, size_t count, ...) {
 
   va_end(types);
   return false;
-}
-
-// Optionally call out to the lex callback if one is provided.
-static inline void
-parser_lex_callback(yp_parser_t *parser) {
-  if (parser->lex_callback) {
-    parser->lex_callback->callback(parser->lex_callback->data, parser, &parser->current);
-  }
 }
 
 // Called when the parser requires a new token. The parser maintains a moving

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2212,6 +2212,76 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "<<-EOF\n  a\n  b\n  EOF\n"
   end
 
+  test "heredocs with tildes" do
+    expected = HeredocNode(
+      HEREDOC_START("<<~EOF"),
+      [
+        StringNode(nil, STRING_CONTENT("a\n"), nil, "a\n"),
+        StringNode(nil, STRING_CONTENT("b\n"), nil, "b\n")
+      ],
+      HEREDOC_END("  EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<~EOF\n  a\n  b\n  EOF\n"
+  end
+
+  test "heredocs with tildes and first string indented more" do
+    expected = HeredocNode(
+      HEREDOC_START("<<~EOF"),
+      [
+        StringNode(nil, STRING_CONTENT(" a\n"), nil, " a\n"),
+        StringNode(nil, STRING_CONTENT("b\n"), nil, "b\n")
+      ],
+      HEREDOC_END("  EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<~EOF\n   a\n  b\n  EOF\n"
+  end
+
+  test "heredocs with tildes and second string indented more" do
+    expected = HeredocNode(
+      HEREDOC_START("<<~EOF"),
+      [
+        StringNode(nil, STRING_CONTENT("a\n"), nil, "a\n"),
+        StringNode(nil, STRING_CONTENT(" b\n"), nil, " b\n")
+      ],
+      HEREDOC_END("  EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<~EOF\n  a\n   b\n  EOF\n"
+  end
+
+  test "heredocs with tildes and interpolation" do
+    expected = HeredocNode(
+      HEREDOC_START("<<~EOF"),
+      [
+        StringNode(nil, STRING_CONTENT("a\n"), nil, "a\n"),
+       StringNode(nil, STRING_CONTENT("1\n"), nil, "1\n")
+      ],
+      HEREDOC_END("  EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<~EOF\n  a\n  #{1}\n  EOF\n"
+  end
+
+  test "heredocs with tildes, interpolation and indentation" do
+    expected = HeredocNode(
+      HEREDOC_START("<<~EOF"),
+      [
+        StringNode(nil, STRING_CONTENT("a\n"), nil, "a\n"),
+       StringNode(nil, STRING_CONTENT(" 1\n"), nil, " 1\n")
+      ],
+      HEREDOC_END("  EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<~EOF\n  a\n   #{1}\n  EOF\n"
+  end
+
   test "heredocs with interpolation" do
     expected = HeredocNode(
       HEREDOC_START("<<-EOF"),


### PR DESCRIPTION
This PR implements the correct indentation in tilde heredocs. It calculates the minimum whitespace indentation, and then applies that to all lines within the heredoc.

Closes #310 