### PR TITLE
Blocks with keywords

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -260,6 +260,10 @@ struct yp_parser {
   // while, until, or for loop
   yp_state_stack_t do_loop_stack;
 
+  // the stack used to determine if a do keyword belongs to the beginning of a
+  // block
+  yp_state_stack_t accepts_block_stack;
+
   struct {
     yp_lex_mode_t *current;                 // the current mode of the lexer
     yp_lex_mode_t stack[YP_LEX_STACK_SIZE]; // the stack of lexer modes

--- a/src/parser.h
+++ b/src/parser.h
@@ -165,29 +165,30 @@ typedef struct yp_parser yp_parser_t;
 // error recovery so that we can pop back to a previous context when we hit a
 // token that is understood by a parent context but not by the current context.
 typedef enum {
-  YP_CONTEXT_MAIN,        // the top level context
-  YP_CONTEXT_PREEXE,      // a BEGIN block
-  YP_CONTEXT_POSTEXE,     // an END block
-  YP_CONTEXT_MODULE,      // a module declaration
-  YP_CONTEXT_CLASS,       // a class declaration
-  YP_CONTEXT_DEF,         // a method definition
-  YP_CONTEXT_IF,          // an if statement
-  YP_CONTEXT_ELSIF,       // an elsif clause
-  YP_CONTEXT_UNLESS,      // an unless statement
-  YP_CONTEXT_ELSE,        // an else clause
-  YP_CONTEXT_WHILE,       // a while statement
-  YP_CONTEXT_UNTIL,       // an until statement
-  YP_CONTEXT_EMBEXPR,     // an interpolated expression
-  YP_CONTEXT_BLOCK_BRACES,      // expressions in block arguments using braces
-  YP_CONTEXT_BEGIN,       // a begin statement
-  YP_CONTEXT_SCLASS,      // a singleton class definition
-  YP_CONTEXT_FOR,         // a for loop
-  YP_CONTEXT_PARENS,      // a parenthesized expression
-  YP_CONTEXT_ENSURE,      // an ensure statement
-  YP_CONTEXT_RESCUE,      // a rescue statement
-  YP_CONTEXT_RESCUE_ELSE, // a rescue else statement
-  YP_CONTEXT_LAMBDA_BRACES, // a lambda expression with braces
-  YP_CONTEXT_LAMBDA_DO_END, // a lambda expression with do..end
+  YP_CONTEXT_MAIN,           // the top level context
+  YP_CONTEXT_PREEXE,         // a BEGIN block
+  YP_CONTEXT_POSTEXE,        // an END block
+  YP_CONTEXT_MODULE,         // a module declaration
+  YP_CONTEXT_CLASS,          // a class declaration
+  YP_CONTEXT_DEF,            // a method definition
+  YP_CONTEXT_IF,             // an if statement
+  YP_CONTEXT_ELSIF,          // an elsif clause
+  YP_CONTEXT_UNLESS,         // an unless statement
+  YP_CONTEXT_ELSE,           // an else clause
+  YP_CONTEXT_WHILE,          // a while statement
+  YP_CONTEXT_UNTIL,          // an until statement
+  YP_CONTEXT_EMBEXPR,        // an interpolated expression
+  YP_CONTEXT_BLOCK_BRACES,   // expressions in block arguments using braces
+  YP_CONTEXT_BLOCK_KEYWORDS, // expressions in block arguments using do..end
+  YP_CONTEXT_BEGIN,          // a begin statement
+  YP_CONTEXT_SCLASS,         // a singleton class definition
+  YP_CONTEXT_FOR,            // a for loop
+  YP_CONTEXT_PARENS,         // a parenthesized expression
+  YP_CONTEXT_ENSURE,         // an ensure statement
+  YP_CONTEXT_RESCUE,         // a rescue statement
+  YP_CONTEXT_RESCUE_ELSE,    // a rescue else statement
+  YP_CONTEXT_LAMBDA_BRACES,  // a lambda expression with braces
+  YP_CONTEXT_LAMBDA_DO_END,  // a lambda expression with do..end
 } yp_context_t;
 
 // This is a node in a linked list of contexts.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6387,19 +6387,8 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, binding_power_t bin
       yp_arguments_t arguments = yp_arguments();
 
       // This if statement handles the foo.() syntax.
-      if (accept(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
-        arguments.opening = parser->previous;
-
-        if (accept(parser, YP_TOKEN_PARENTHESIS_RIGHT)) {
-          arguments.closing = parser->previous;
-        } else {
-          arguments.arguments = yp_arguments_node_create(parser);
-          parse_arguments(parser, arguments.arguments, YP_TOKEN_PARENTHESIS_RIGHT);
-
-          expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, "Expected ')' after arguments.");
-          arguments.closing = parser->previous;
-        }
-
+      if (match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT)) {
+        parse_arguments_list(parser, &arguments, true);
         return yp_call_node_shorthand_create(parser, node, &operator, &arguments);
       }
 
@@ -6655,6 +6644,7 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size) {
   };
 
   yp_state_stack_init(&parser->do_loop_stack);
+  yp_state_stack_init(&parser->accepts_block_stack);
   yp_list_init(&parser->warning_list);
   yp_list_init(&parser->error_list);
   yp_list_init(&parser->comment_list);


### PR DESCRIPTION
This PR adds support for blocks that use keywords (as opposed to braces).

Semantically, the big difference between `{}` and `do`..`end` is precedence. In the expression: `foo bar {}` the `bar` method call gets the block, whereas in `foo bar do end` the `foo` method call gets the block.

To implement this, we add a new stack to the parser that tracks whether or not any method calls are allowed to accept booleans. By default, all method calls are.

```ruby
foo bar do end
   ^
```

When you get to the point indicated in the example above, we push a `false` onto the stack, indicating that arguments to this method call cannot accept blocks.

```ruby
foo bar do end
       ^
```

When we get to the point indicated in the example above, we pop a value from the stack.

Importantly, there are other times when we push and pop values as well. For example:

```ruby
foo bar, (baz do end) do end
          ^
```

When we get to the point indicated in the example above, we push a `true` onto the stack, because we know from context that we will be able to accept keyword blocks again.

I don't imagine that this PR actually covers all use cases, and I have purposefully not implemented the fact that blocks with keywords can have `rescue`/`else`/`ensure` attached to them. But for now, this gets us up to being able to parse `56%` of ruby/spec.