### PR TITLE
support return with trailing conditional

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5342,7 +5342,7 @@ parse_expression_prefix(yp_parser_t *parser) {
           // If parsing the argument resulted in error recovery, then we can
           // stop parsing the arguments entirely now.
           if (expression->type == YP_NODE_MISSING_NODE || parser->recovering) break;
-          if (accept_any(parser, 3, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF)) break;
+          if (match_any_type_p(parser, 3, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF)) break;
 
           expect(parser, YP_TOKEN_COMMA, "Expected an ',' to delimit arguments.");
           accept(parser, YP_TOKEN_NEWLINE);

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5204,6 +5204,38 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "foo bar, (baz do end)"
   end
 
+  test "trailing return conditional in list of statements" do
+    expected = DefNode(
+      IDENTIFIER("hi"),
+      nil,
+      ParametersNode([], [], nil, [], nil, nil),
+      Statements(
+        [ReturnNode(
+           KEYWORD_RETURN("return"),
+           ArgumentsNode(
+             [IfNode(
+                KEYWORD_IF("if"),
+                TrueNode(),
+                Statements([SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("hi"), nil)]),
+                nil,
+                nil
+              )]
+           )
+         ),
+         SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("bye"), nil)]
+      ),
+      Scope([]),
+      Location(),
+      nil,
+      nil,
+      nil,
+      nil,
+      Location()
+    )
+
+    assert_parses expected, "def hi\nreturn :hi if true\n:bye\nend"
+  end
+  
   private
 
   def assert_serializes(expected, source)


### PR DESCRIPTION
parse statements needs the newline to still be `parser->current` to know we are done with the return line.