### PR TITLE
fix state for nodes after ternary operator

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2059,6 +2059,7 @@ lex_question_mark(yp_parser_t *parser) {
       // TODO: this is wrong. We need to track the state for the lexer on
       // whether or not the ? operator is allowed here. For now, we're depending
       // on space characters.
+      lex_state_set(parser, YP_LEX_STATE_BEG);
       return YP_TOKEN_QUESTION_MARK;
     case '\t':
     case '\v':

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3152,6 +3152,18 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "a ? b : c"
   end
 
+  test "ternary with symbols" do
+    expected = Ternary(
+      SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("hey"), nil),
+      QUESTION_MARK("?"),
+      SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("hi"), nil),
+      COLON(":"),
+      SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("there"), nil)
+    )
+
+    assert_parses expected, ":hey ? :hi : :there"
+  end
+
   test "true" do
     assert_parses TrueNode(), "true"
   end


### PR DESCRIPTION
Testing `true ? :hi : :bye`

before:

```
Ripper lex                                                             YARP lex                                                              
---------------------------------------------------------------------- ----------------------------------------------------------------------
[[1, 0], :on_kw, "true", END]                                          [[1, 0], :on_kw, "true", END]                                         
[[1, 5], :on_op, "?", BEG]                                             [[1, 5], :on_op, "?", END]                                            
[[1, 7], :on_symbeg, ":", FNAME]                                       [[1, 7], :on_op, ":", BEG]                                            
[[1, 8], :on_ident, "hi", ENDFN]                                       [[1, 8], :on_ident, "hi", ARG]                                        
[[1, 11], :on_op, ":", BEG]                                            nil                                                                   
[[1, 13], :on_symbeg, ":", FNAME]                                      nil                                                                   
[[1, 14], :on_ident, "bye", ENDFN]                                     nil                                                                   
[[1, 17], :on_nl, "\n", BEG]                                           nil  
```

after:

```
Ripper lex                                                             YARP lex                                                              
---------------------------------------------------------------------- ----------------------------------------------------------------------
[[1, 0], :on_kw, "true", END]                                          [[1, 0], :on_kw, "true", END]                                         
[[1, 5], :on_op, "?", BEG]                                             [[1, 5], :on_op, "?", BEG]                                            
[[1, 7], :on_symbeg, ":", FNAME]                                       [[1, 7], :on_symbeg, ":", FNAME]                                      
[[1, 8], :on_ident, "hi", ENDFN]                                       [[1, 8], :on_ident, "hi", ENDFN]                                      
[[1, 11], :on_op, ":", BEG]                                            [[1, 11], :on_op, ":", BEG]                                           
[[1, 13], :on_symbeg, ":", FNAME]                                      [[1, 13], :on_symbeg, ":", FNAME]                                     
[[1, 14], :on_ident, "bye", ENDFN]                                     [[1, 14], :on_ident, "bye", ENDFN]                                    
[[1, 17], :on_nl, "\n", BEG]                                           [[1, 17], :on_nl, "\n", BEG] 
```