### PR TITLE
Fix state on &. tokens

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2660,6 +2660,7 @@ lex_token_type(yp_parser_t *parser) {
           }
 
           if (match(parser, '.')) {
+            lex_state_set(parser, YP_LEX_STATE_DOT);
             return YP_TOKEN_AMPERSAND_DOT;
           }
 


### PR DESCRIPTION
`hi&.there`

before:

```
Ripper lex                                                             YARP lex                                                              
---------------------------------------------------------------------- ----------------------------------------------------------------------
[[1, 0], :on_ident, "hi", CMDARG]                                      [[1, 0], :on_ident, "hi", CMDARG]                                     
[[1, 2], :on_op, "&.", DOT]                                            [[1, 2], :on_op, "&.", CMDARG]                                        
[[1, 4], :on_ident, "there", ARG]                                      [[1, 4], :on_ident, "there", ARG]                                     
[[1, 9], :on_nl, "\n", BEG]                                            [[1, 9], :on_nl, "\n", BEG]
```

after,

```
Ripper lex                                                             YARP lex                                                              
---------------------------------------------------------------------- ----------------------------------------------------------------------
[[1, 0], :on_ident, "hi", CMDARG]                                      [[1, 0], :on_ident, "hi", CMDARG]                                     
[[1, 2], :on_op, "&.", DOT]                                            [[1, 2], :on_op, "&.", DOT]                                           
[[1, 4], :on_ident, "there", ARG]                                      [[1, 4], :on_ident, "there", ARG]                                     
[[1, 9], :on_nl, "\n", BEG]                                            [[1, 9], :on_nl, "\n", BEG]
```