### PR TITLE
Ignored newlines

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -106,6 +106,8 @@ tokens:
     comment: "the start of a heredoc"
   - name: IDENTIFIER
     comment: "an identifier"
+  - name: IGNORED_NEWLINE
+    comment: "an ignored newline"
   - name: IMAGINARY_NUMBER
     comment: "an imaginary number literal"
   - name: INSTANCE_VARIABLE

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -162,18 +162,11 @@ module YARP
     end
   end
 
-  # This lexes with the Ripper lex. It drops any space events and normalizes all
-  # ignored newlines into regular newlines.
+  # This lexes with the Ripper lex. It drops any space events but otherwise
+  # returns the same tokens.
   def self.lex_ripper(source)
     Ripper.lex(source).each_with_object([]) do |token, tokens|
-      case token[1]
-      when :on_ignored_nl
-        tokens << [token[0], :on_nl, token[2], token[3]]
-      when :on_sp
-        # skip
-      else
-        tokens << token
-      end
+      tokens << token unless token[1] == :on_sp
     end
   end
 
@@ -231,6 +224,7 @@ module YARP
       HEREDOC_END: :on_heredoc_end,
       HEREDOC_START: :on_heredoc_beg,
       IDENTIFIER: :on_ident,
+      IGNORED_NEWLINE: :on_ignored_nl,
       IMAGINARY_NUMBER: :on_imaginary,
       INTEGER: :on_int,
       INSTANCE_VARIABLE: :on_ivar,

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -217,7 +217,6 @@ class ErrorsTest < Test::Unit::TestCase
 
   test "def with multiple statements receiver" do
     assert_errors expression("def (\na\nb\n).c; end"), "def (\na\nb\n).c; end", [
-      "Expected to be able to parse receiver.",
       "Expected closing ')' for receiver.",
       "Expected '.' or '::' after receiver",
       "Expected a method name after receiver.",

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -745,7 +745,7 @@ class ParseTest < Test::Unit::TestCase
       KEYWORD_END("end")
     )
 
-    assert_parses expected, "class A < B a = 1 end"
+    assert_parses expected, "class A < B\na = 1\nend"
   end
 
   test "class variable read" do
@@ -956,7 +956,7 @@ class ParseTest < Test::Unit::TestCase
       Location()
     )
 
-    assert_parses expected, "def a b:\nend"
+    assert_parses expected, "def a b:; end"
   end
 
   test "def with keyword parameter (parenthesis)" do
@@ -1179,13 +1179,13 @@ class ParseTest < Test::Unit::TestCase
       Scope([STAR("*")]),
       Location(),
       nil,
-      nil,
-      nil,
+      Location(),
+      Location(),
       nil,
       Location()
     )
 
-    assert_parses expected, "def a *\nend"
+    assert_parses expected, "def a(*)\nend"
   end
 
   test "def with keyword rest parameter" do
@@ -1204,13 +1204,13 @@ class ParseTest < Test::Unit::TestCase
       Scope([IDENTIFIER("b")]),
       Location(),
       nil,
-      nil,
-      nil,
+      Location(),
+      Location(),
       nil,
       Location()
     )
 
-    assert_parses expected, "def a **b\nend"
+    assert_parses expected, "def a(**b)\nend"
   end
 
   test "def with keyword rest parameter without name" do
@@ -1229,13 +1229,13 @@ class ParseTest < Test::Unit::TestCase
       Scope([]),
       Location(),
       nil,
-      nil,
-      nil,
+      Location(),
+      Location(),
       nil,
       Location()
     )
 
-    assert_parses expected, "def a **\nend"
+    assert_parses expected, "def a(**)\nend"
   end
 
   test "def with forwarding parameter" do
@@ -1247,13 +1247,13 @@ class ParseTest < Test::Unit::TestCase
       Scope([DOT_DOT_DOT("...")]),
       Location(),
       nil,
-      nil,
-      nil,
+      Location(),
+      Location(),
       nil,
       Location()
     )
 
-    assert_parses expected, "def a ...\nend"
+    assert_parses expected, "def a(...)\nend"
   end
 
   test "def with block parameter" do
@@ -1297,13 +1297,13 @@ class ParseTest < Test::Unit::TestCase
       Scope([]),
       Location(),
       nil,
-      nil,
-      nil,
+      Location(),
+      Location(),
       nil,
       Location()
     )
 
-    assert_parses expected, "def a &\nend"
+    assert_parses expected, "def a(&)\nend"
   end
 
   test "def with **nil" do
@@ -1314,21 +1314,21 @@ class ParseTest < Test::Unit::TestCase
         [RequiredParameterNode(IDENTIFIER("a"))],
         [],
         nil,
-        [KeywordParameterNode(LABEL("b:"), nil)],
+        [],
         NoKeywordsParameterNode(Location(), Location()),
         nil
       ),
       Statements([]),
-      Scope([IDENTIFIER("a"), LABEL("b")]),
+      Scope([IDENTIFIER("a")]),
       Location(),
       nil,
-      nil,
-      nil,
+      Location(),
+      Location(),
       nil,
       Location()
     )
 
-    assert_parses expected, "def m a, b:, **nil\nend"
+    assert_parses expected, "def m(a, **nil)\nend"
   end
 
   test "method call with label keyword args" do
@@ -3261,34 +3261,6 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "unless true\n1 else 2 end"
   end
 
-  test "unless elsif" do
-    expected = UnlessNode(
-      KEYWORD_UNLESS("unless"),
-      TrueNode(),
-      Statements([TrueNode()]),
-      IfNode(
-        KEYWORD_ELSIF("elsif"),
-        FalseNode(),
-        Statements([FalseNode()]),
-        IfNode(
-          KEYWORD_ELSIF("elsif"),
-          NilNode(),
-          Statements([NilNode()]),
-          ElseNode(
-            KEYWORD_ELSE("else"),
-            Statements([SelfNode()]),
-            KEYWORD_END("end")
-          ),
-          nil
-        ),
-        nil
-      ),
-      KEYWORD_END("end")
-    )
-
-    assert_parses expected, "unless true then true elsif false then false elsif nil then nil else self end"
-  end
-
   test "until" do
     assert_parses UntilNode(KEYWORD_UNTIL("until"), expression("true"), Statements([expression("1")])), "until true; 1; end"
   end
@@ -3596,7 +3568,7 @@ class ParseTest < Test::Unit::TestCase
       Location()
     )
 
-    assert_parses expected, "for i in 1..10 i end"
+    assert_parses expected, "for i in 1..10; i; end"
   end
 
   test "for loop with semicolons" do
@@ -5035,9 +5007,9 @@ class ParseTest < Test::Unit::TestCase
       Scope([
         IDENTIFIER("a"),
         IDENTIFIER("b"),
-        LABEL("c"),
+        IDENTIFIER("c"),
         LABEL("d"),
-        IDENTIFIER("e"),
+        LABEL("e"),
         IDENTIFIER("f"),
         IDENTIFIER("g")
       ]),
@@ -5050,8 +5022,8 @@ class ParseTest < Test::Unit::TestCase
             EQUAL("="),
             IntegerNode()
           )],
-          RestParameterNode(STAR("*"), IDENTIFIER("e")),
-          [KeywordParameterNode(LABEL("c:"), nil), KeywordParameterNode(LABEL("d:"), nil)],
+          RestParameterNode(STAR("*"), IDENTIFIER("c")),
+          [KeywordParameterNode(LABEL("d:"), nil), KeywordParameterNode(LABEL("e:"), nil)],
           KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("f")),
           BlockParameterNode(IDENTIFIER("g"), Location())
         ),
@@ -5061,7 +5033,7 @@ class ParseTest < Test::Unit::TestCase
       Statements([expression("a")])
     )
 
-    assert_parses expected, "-> (a, b = 1, c:, d:, *e, **f, &g) { a }"
+    assert_parses expected, "-> (a, b = 1, *c, d:, e:, **f, &g) { a }"
   end
 
   test "stabby lambda with non-parenthesised parameters with braces" do
@@ -5101,9 +5073,9 @@ class ParseTest < Test::Unit::TestCase
       Scope([
         IDENTIFIER("a"),
         IDENTIFIER("b"),
-        LABEL("c"),
+        IDENTIFIER("c"),
         LABEL("d"),
-        IDENTIFIER("e"),
+        LABEL("e"),
         IDENTIFIER("f"),
         IDENTIFIER("g")
       ]),
@@ -5116,8 +5088,8 @@ class ParseTest < Test::Unit::TestCase
             EQUAL("="),
             IntegerNode()
           )],
-          RestParameterNode(STAR("*"), IDENTIFIER("e")),
-          [KeywordParameterNode(LABEL("c:"), nil), KeywordParameterNode(LABEL("d:"), nil)],
+          RestParameterNode(STAR("*"), IDENTIFIER("c")),
+          [KeywordParameterNode(LABEL("d:"), nil), KeywordParameterNode(LABEL("e:"), nil)],
           KeywordRestParameterNode(STAR_STAR("**"), IDENTIFIER("f")),
           BlockParameterNode(IDENTIFIER("g"), Location())
         ),
@@ -5127,7 +5099,7 @@ class ParseTest < Test::Unit::TestCase
       Statements([expression("a")])
     )
 
-    assert_parses expected, "-> (a, b = 1, c:, d:, *e, **f, &g) do\n  a\nend"
+    assert_parses expected, "-> (a, b = 1, *c, d:, e:, **f, &g) do\n  a\nend"
   end
 
   test "nested lambdas" do
@@ -5347,6 +5319,8 @@ class ParseTest < Test::Unit::TestCase
   end
 
   def assert_parses(expected, source)
+    refute_nil Ripper.sexp_raw(source)
+
     assert_equal expected, expression(source)
     assert_serializes expected, source
 


### PR DESCRIPTION
CRuby has the concept of a newline that is ignored. In this case the lexer just continues on to the subsequent token. This PR mirrors that behavior, which helps to simplify our parser by not forcing us to accept newlines in a loop wherever ignored newlines are possible.

As a result of adding this delineation, I was able to strip out a bunch of `while (accept(parser, YP_TOKEN_NEWLINE))` because newlines are never found in those places now.

As a part of this PR, a bunch of tests started failing. I realized that was because we were mirroring Ruby better now, and errors actually should have been there the whole time. So now whenever we run a parse, we also check that it parses validly with ripper as well. This led to fixing a bunch of tests that were actually broken in the first place.