### PR TITLE
Fixes for the case keyword

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,8 @@ task lex: :compile do
   require "yarp"
   require "ripper"
 
-  results = { passing: [], failing: [] }
+  passing = 0
+  failing = 0
   colorize = ->(code, string) { "\033[#{code}m#{string}\033[0m" }
 
   filepaths =
@@ -97,10 +98,10 @@ task lex: :compile do
     begin
       if YARP.lex_ripper(source) == YARP.lex_compat(source)
         print colorize.call(32, ".")
-        results[:passing] << filepath
+        passing += 1
       else
         print colorize.call(31, "E")
-        results[:failing] << filepath
+        failing += 1
       end
     rescue ArgumentError => e
       puts "\nError in #{filepath}"
@@ -108,5 +109,11 @@ task lex: :compile do
     end
   end
 
-  puts "\n\nPASSING=#{results[:passing].length}\nFAILING=#{results[:failing].length}"
+  puts <<~RESULTS
+
+
+    PASSING=#{passing}
+    FAILING=#{failing}
+    PERCENT=#{(passing.to_f / (passing + failing) * 100).round(2)}%
+  RESULTS
 end

--- a/config.yml
+++ b/config.yml
@@ -612,7 +612,7 @@ nodes:
       - name: else_keyword
         type: token
       - name: statements
-        type: node
+        type: node?
       - name: end_keyword
         type: token
     location: else_keyword->end_keyword

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5310,7 +5310,7 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "foo :a, b: true do |a, b| puts a end"
   end
-  
+
   test "basic case when syntax" do
     expected = CaseNode(
       KEYWORD_CASE("case"),
@@ -5336,7 +5336,7 @@ class ParseTest < Test::Unit::TestCase
          [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("hi"), nil)],
          nil
        )],
-      ElseNode(KEYWORD_ELSE("else"), Statements([]), NEWLINE("\n")),
+      ElseNode(KEYWORD_ELSE("else"), nil, KEYWORD_END("end")),
       KEYWORD_END("end")
     )
 


### PR DESCRIPTION
* The statements on the `else` node need to be marked as optional.
* We need to optionally accept the `then` keyword after the `when` clause predicates.
* We need to expect a predicate after the `when` keyword.
* The rakefile now automatically prints out the percentage passed.
* The `when` keyword should default to the `beg` state after it is lexed.