### PR TITLE
Fix case-else with else containing statements

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3653,7 +3653,7 @@ context_terminator(yp_context_t context, yp_token_t *token) {
     case YP_CONTEXT_ENSURE:
       return token->type == YP_TOKEN_KEYWORD_END;
     case YP_CONTEXT_CASE_WHEN:
-      return token->type == YP_TOKEN_KEYWORD_WHEN || token->type == YP_TOKEN_KEYWORD_END;
+      return token->type == YP_TOKEN_KEYWORD_WHEN || token->type == YP_TOKEN_KEYWORD_END || token->type == YP_TOKEN_KEYWORD_ELSE;
     case YP_CONTEXT_IF:
     case YP_CONTEXT_ELSIF:
       return token->type == YP_TOKEN_KEYWORD_ELSE || token->type == YP_TOKEN_KEYWORD_ELSIF || token->type == YP_TOKEN_KEYWORD_END;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5201,7 +5201,7 @@ parse_expression_prefix(yp_parser_t *parser) {
         yp_node_t *else_node;
 
         if (!match_type_p(parser, YP_TOKEN_KEYWORD_END)) {
-          else_node = yp_node_else_node_create(parser, &else_keyword, parse_statements(parser, YP_CONTEXT_CASE_WHEN), &parser->current);
+          else_node = yp_node_else_node_create(parser, &else_keyword, parse_statements(parser, YP_CONTEXT_ELSE), &parser->current);
         } else {
           else_node = yp_node_else_node_create(parser, &else_keyword, NULL, &parser->current);
         }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5201,7 +5201,7 @@ parse_expression_prefix(yp_parser_t *parser) {
         yp_node_t *else_node;
 
         if (!match_type_p(parser, YP_TOKEN_KEYWORD_END)) {
-          else_node = yp_node_else_node_create(parser, &else_keyword, parse_statements(parser, YP_CONTEXT_CASE_WHEN), &parser->previous);
+          else_node = yp_node_else_node_create(parser, &else_keyword, parse_statements(parser, YP_CONTEXT_CASE_WHEN), &parser->current);
         } else {
           else_node = yp_node_else_node_create(parser, &else_keyword, NULL, &parser->current);
         }

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5339,7 +5339,7 @@ class ParseTest < Test::Unit::TestCase
       ElseNode(
         KEYWORD_ELSE("else"),
         Statements([SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil)]),
-        NEWLINE("\n")
+        KEYWORD_END("end")
       ),
       KEYWORD_END("end")
     )

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5336,11 +5336,15 @@ class ParseTest < Test::Unit::TestCase
          [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("hi"), nil)],
          nil
        )],
-      ElseNode(KEYWORD_ELSE("else"), nil, KEYWORD_END("end")),
+      ElseNode(
+        KEYWORD_ELSE("else"),
+        Statements([SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil)]),
+        NEWLINE("\n")
+      ),
       KEYWORD_END("end")
     )
 
-    assert_parses expected, "case :hi\nwhen :hi\nelse\nend"
+    assert_parses expected, "case :hi\nwhen :hi\nelse\n:b\nend"
   end
 
   test "case when statements" do


### PR DESCRIPTION
This PR fixes parsing

```ruby
case arg
when foo
  :a
else
  :b
end
```

However, I am not sure about what should be the `end_keyword` of the `ElseNode` here. Currently it is `newline` but I don't know whether this is OK. On the other hand I see that `CaseNode` also has an `end_keyword` child, so in this case I don't know what the last `end` token should be part of, should it be part of `CaseNode` or `ElseNode`?
