### PR TITLE
Results for lexing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,8 @@ task lex: :compile do
     source = File.read(filepath)
 
     begin
-      if YARP.lex_ripper(source) == YARP.lex_compat(source)
+      lexed = YARP.lex_compat(source)
+      if lexed.errors.empty? && YARP.lex_ripper(source) == lexed.value
         print colorize.call(32, ".")
         passing += 1
       else

--- a/bin/lex
+++ b/bin/lex
@@ -13,7 +13,7 @@ puts pattern % ["-" * 70, "-" * 70]
 
 source = File.read(filepath)
 ripper = YARP.lex_ripper(source)
-yarp = YARP.lex_compat(source)
+yarp = YARP.lex_compat(source).value
 
 [yarp.length, ripper.length].max.times do |i|
   left = ripper[i].inspect

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -14,7 +14,7 @@ Every entry in `config.yml` will generate a Ruby class as well as the code that 
 
 * `YARP.dump(source)` - parse the syntax tree corresponding to the given source string and serialize it to a string
 * `YARP.dump_file(filepath)` - parse the syntax tree corresponding to the given source file and serialize it to a string
-* `YARP.lex(source)` - parse the tokens corresponding to the given source string and return them as an array
-* `YARP.lex_file(filepath)` - parse the tokens corresponding to the given source file and return them as an array
-* `YARP.parse(source)` - parse the syntax tree corresponding to the given source string and return it
-* `YARP.parse_file(filepath)` - parse the syntax tree corresponding to the given source file and return it
+* `YARP.lex(source)` - parse the tokens corresponding to the given source string and return them as an array within a parse result
+* `YARP.lex_file(filepath)` - parse the tokens corresponding to the given source file and return them as an array within a parse result
+* `YARP.parse(source)` - parse the syntax tree corresponding to the given source string and return it within a parse result
+* `YARP.parse_file(filepath)` - parse the syntax tree corresponding to the given source file and return it within a parse result

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -73,17 +73,17 @@ module YARP
   # the AST, any comments that were encounters, and any errors that were
   # encountered.
   class ParseResult
-    attr_reader :node, :comments, :errors, :warnings
+    attr_reader :value, :comments, :errors, :warnings
 
-    def initialize(node, comments, errors, warnings)
-      @node = node
+    def initialize(value, comments, errors, warnings)
+      @value = value
       @comments = comments
       @errors = errors
       @warnings = warnings
     end
 
     def deconstruct_keys(keys)
-      { node: node, comments: comments, errors: errors, warnings: warnings }
+      { value: value, comments: comments, errors: errors, warnings: warnings }
     end
 
     def success?
@@ -356,13 +356,14 @@ module YARP
       end
     end
 
-    def tokens
+    def result
       tokens = []
 
       state = :default
       heredocs = []
 
-      YARP.lex(source).each do |(token, lex_state)|
+      result = YARP.lex(source)
+      result.value.each do |(token, lex_state)|
         event = RIPPER.fetch(token.type)
         lex_state = Ripper::Lexer::State.new(lex_state)
 
@@ -411,7 +412,7 @@ module YARP
         end
       end
 
-      tokens[0...-1]
+      ParseResult.new(tokens[0...-1], result.comments, result.errors, result.warnings)
     end
 
     private
@@ -453,7 +454,7 @@ module YARP
   # The only difference is that since we don't keep track of lexer state in the
   # same way, it's going to always return the NONE state.
   def self.lex_compat(source)
-    LexCompat.new(source).tokens
+    LexCompat.new(source).result
   end
 
   # Load the serialized AST using the source as a reference into a tree.

--- a/lib/yarp/ripper_compat.rb
+++ b/lib/yarp/ripper_compat.rb
@@ -72,7 +72,7 @@ module YARP
     end
 
     def parse
-      result.node.accept(self) unless error?
+      result.value.accept(self) unless error?
     end
 
     ############################################################################

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -357,14 +357,14 @@ class ErrorsTest < Test::Unit::TestCase
 
   def assert_errors(expected, source, errors)
     result = YARP.parse(source)
-    result => YARP::ParseResult[node: YARP::Program[statements: YARP::Statements[body: [*, node]]]]
+    result => YARP::ParseResult[value: YARP::Program[statements: YARP::Statements[body: [*, node]]]]
 
     assert_equal expected, node
     assert_equal errors, result.errors.map(&:message)
   end
 
   def expression(source)
-    YARP.parse(source) => YARP::ParseResult[node: YARP::Program[statements: YARP::Statements[body: [*, node]]]]
+    YARP.parse(source) => YARP::ParseResult[value: YARP::Program[statements: YARP::Statements[body: [*, node]]]]
     node
   end
 

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -186,7 +186,7 @@ module YARP
     private
 
     def assert_location(kind, source, expected = 0...source.length)
-      YARP.parse(source) => ParseResult[comments: [], errors: [], node:]
+      YARP.parse(source) => ParseResult[comments: [], errors: [], value: node]
 
       node => Program[statements: [*, node]]
       node = yield node if block_given?

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -6,7 +6,7 @@ class ParseTest < Test::Unit::TestCase
   include YARP::DSL
 
   test "empty string" do
-    YARP.parse("") => YARP::ParseResult[node: YARP::Program[statements: YARP::Statements[body: []]]]
+    YARP.parse("") => YARP::ParseResult[value: YARP::Program[statements: YARP::Statements[body: []]]]
   end
 
   test "comment inline" do
@@ -5535,16 +5535,17 @@ class ParseTest < Test::Unit::TestCase
     assert_equal expected, expression(source)
     assert_serializes expected, source
 
-    YARP.lex_ripper(source).zip(YARP.lex_compat(source)).each do |(ripper, yarp)|
+    YARP.lex_compat(source) => { errors: [], warnings: [], value: tokens }
+    YARP.lex_ripper(source).zip(tokens).each do |(ripper, yarp)|
       assert_equal ripper[0...-1], yarp[0...-1]
     end
   end
 
   def expression(source)
     result = YARP.parse(source)
-    assert_empty result.errors, PP.pp(result.node, +"")
+    assert_empty result.errors, PP.pp(result.value, +"")
 
-    result.node => YARP::Program[statements: YARP::Statements[body: [*, node]]]
+    result.value => YARP::Program[statements: YARP::Statements[body: [*, node]]]
     node
   end
 


### PR DESCRIPTION
Previously, we only returned an array of tokens when we lexed. This could be misleading, since the parser could have gathered up errors and warnings without it being known to the consumer. Now when we call lex or lex_compat, we return a ParseResult that contains the tokens as well as errors, warnings, and comments.

As a part of this, we know ensure we don't have any errors when we call `rake lex`, which actually has made our percentage drop to 79% from 80%, presumably because there are a couple of files where we matched the lexer output but didn't correctly match the parser output.