### PR TITLE
Fix argument parsing in if-then blocks

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4088,7 +4088,7 @@ parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t termi
   bool parsed_block_argument = false;
 
   while (
-    !match_any_type_p(parser, 5, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
+    !match_any_type_p(parser, 6, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
     !context_terminator(parser->current_context->context, &parser->current)
   ) {
     if (yp_arguments_node_size(arguments) > 0) {
@@ -5427,7 +5427,7 @@ parse_expression_prefix(yp_parser_t *parser) {
         if (match_any_type_p(parser, 2, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
           statements = parse_rescues_as_begin(parser, statements);
         }
-        
+
         expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `class` statement.");
 
         yp_node_t *scope = parser->current_scope->node;
@@ -5456,7 +5456,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       if (match_any_type_p(parser, 2, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
         statements = parse_rescues_as_begin(parser, statements);
       }
-      
+
       expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `class` statement.");
 
       yp_node_t *scope = parser->current_scope->node;
@@ -5790,7 +5790,7 @@ parse_expression_prefix(yp_parser_t *parser) {
       if (match_any_type_p(parser, 2, YP_TOKEN_KEYWORD_RESCUE, YP_TOKEN_KEYWORD_ENSURE)) {
         statements = parse_rescues_as_begin(parser, statements);
       }
-      
+
       yp_node_t *scope = parser->current_scope->node;
       yp_parser_scope_pop(parser);
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -747,7 +747,7 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "class A < B\na = 1\nend"
   end
-  
+
   test "class with rescue, else, ensure" do
     expected = ClassNode(
       Scope([]),
@@ -864,7 +864,7 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "class A; class << self; ensure; end; end"
   end
-  
+
   test "class variable read" do
     assert_parses ClassVariableReadNode(), "@@abc"
   end
@@ -2475,6 +2475,27 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "if true then true elsif false then false elsif nil then nil else self end"
   end
 
+  test "if then call" do
+    expected = IfNode(
+      KEYWORD_IF("if"),
+      CallNode(
+        nil,
+        nil,
+        IDENTIFIER("exit_loop"),
+        nil,
+        ArgumentsNode([]),
+        nil,
+        nil,
+        "exit_loop"
+      ),
+      Statements([BreakNode(ArgumentsNode([IntegerNode()]), Location())]),
+      nil,
+      KEYWORD_END("end")
+    )
+
+    assert_parses expected, "if exit_loop then break 42 end"
+  end
+
   test "imaginary" do
     assert_parses ImaginaryNode(), "1i"
   end
@@ -2529,7 +2550,7 @@ class ParseTest < Test::Unit::TestCase
 
     assert_parses expected, "module A\n x = 1; rescue; end"
   end
-  
+
   test "next" do
     assert_parses NextNode(nil, Location()), "next"
   end


### PR DESCRIPTION
Fixes argument parsing in codes like:

```ruby
if exit_loop then break 42 end
```
