### PR TITLE
Multi assign

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build:
-    timeout-minutes: 20
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +19,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: 3.2
         bundler-cache: true
 
     - name: Run Ruby tests
@@ -47,7 +46,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: head
+        ruby-version: 3.2
         bundler-cache: true
 
     - name: Run Ruby tests with valgrind

--- a/Rakefile
+++ b/Rakefile
@@ -93,6 +93,7 @@ task lex: :compile do
     end
 
   filepaths.each do |filepath|
+    print "#{filepath} " if ENV["CI"]
     source = File.read(filepath)
 
     begin
@@ -105,6 +106,8 @@ task lex: :compile do
         print colorize.call(31, "E")
         failing += 1
       end
+
+      puts if ENV["CI"]
     rescue ArgumentError => e
       puts "\nError in #{filepath}"
       raise e

--- a/Rakefile
+++ b/Rakefile
@@ -93,6 +93,7 @@ task lex: :compile do
     end
 
   filepaths.each do |filepath|
+    puts filepath if ENV["VERBOSE"]
     source = File.read(filepath)
 
     begin

--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,6 @@ task lex: :compile do
     end
 
   filepaths.each do |filepath|
-    puts filepath if ENV["VERBOSE"]
     source = File.read(filepath)
 
     begin
@@ -102,6 +101,7 @@ task lex: :compile do
         print colorize.call(32, ".")
         passing += 1
       else
+        warn(filepath) if ENV["VERBOSE"]
         print colorize.call(31, "E")
         failing += 1
       end

--- a/config.yml
+++ b/config.yml
@@ -333,9 +333,9 @@ nodes:
       - name: elements
         type: node[]
       - name: opening
-        type: token
+        type: token?
       - name: closing
-        type: token
+        type: token?
     comment: |
       Represents an array literal. This can be a regular array using brackets or
       a special array using % like %w or %i.
@@ -1013,8 +1013,8 @@ nodes:
     comment: |
       Represents a multi-left-hand expression.
 
-        a, b, c = 1, 2, 3
-        ^^^^^^^
+          a, b, c = 1, 2, 3
+          ^^^^^^^
   - name: NextNode
     child_nodes:
       - name: arguments

--- a/config.yml
+++ b/config.yml
@@ -1005,7 +1005,7 @@ nodes:
 
           module Foo end
           ^^^^^^^^^^^^^^
-  - name: MultiTargetNode
+  - name: MultiWriteNode
     child_nodes:
       - name: targets
         type: node[]

--- a/config.yml
+++ b/config.yml
@@ -1009,12 +1009,16 @@ nodes:
     child_nodes:
       - name: targets
         type: node[]
+      - name: operator
+        type: token?
+      - name: value
+        type: node?
     location: targets
     comment: |
-      Represents a multi-left-hand expression.
+      Represents a multi-target expression.
 
           a, b, c = 1, 2, 3
-          ^^^^^^^
+          ^^^^^^^^^^^^^^^^^
   - name: NextNode
     child_nodes:
       - name: arguments

--- a/config.yml
+++ b/config.yml
@@ -1267,8 +1267,8 @@ nodes:
         type: node[]
       - name: equal_greater
         type: token?
-      - name: exception_variable
-        type: token?
+      - name: exception
+        type: node?
       - name: statements
         type: node
       - name: consequent

--- a/config.yml
+++ b/config.yml
@@ -504,9 +504,9 @@ nodes:
       - name: name_loc
         type: location
       - name: value
-        type: node
+        type: node?
       - name: operator_loc
-        type: location
+        type: location?
     comment: |
       Represents writing to a class variable.
 
@@ -531,10 +531,10 @@ nodes:
       - name: target
         type: node
       - name: operator
-        type: token
+        type: token?
       - name: value
-        type: node
-    location: target->value
+        type: node?
+    location: target->value|target
     comment: |
       Represents writing to a constant.
 
@@ -727,10 +727,10 @@ nodes:
       - name: name
         type: token
       - name: operator
-        type: token
+        type: token?
       - name: value
-        type: node
-    location: name->value
+        type: node?
+    location: name->value|name
     comment: |
       Represents writing to a global variable.
 
@@ -839,9 +839,9 @@ nodes:
       - name: name_loc
         type: location
       - name: value
-        type: node
+        type: node?
       - name: operator_loc
-        type: location
+        type: location?
     comment: |
       Represents writing to an instance variable.
 
@@ -974,10 +974,10 @@ nodes:
       - name: name
         type: token
       - name: operator
-        type: token
+        type: token?
       - name: value
-        type: node
-    location: name->value
+        type: node?
+    location: name->value|name
     comment: |
       Represents writing to a local variable.
 

--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -185,6 +185,13 @@ static yp_encoding_t yp_encoding_ascii = { .name = "ascii",
                                            .alpha_char = yp_encoding_ascii_alpha_char,
                                            .isupper_char = yp_encoding_ascii_isupper_char };
 
+static yp_encoding_t yp_encoding_ascii_8bit = {
+  .name = "ascii-8bit",
+  .alnum_char = yp_encoding_ascii_alnum_char,
+  .alpha_char = yp_encoding_ascii_alpha_char,
+  .isupper_char = yp_encoding_ascii_isupper_char,
+};
+
 static yp_encoding_t yp_encoding_iso_8859_9 = { .name = "iso-8859-9",
                                                 .alnum_char = yp_encoding_iso_8859_9_alnum_char,
                                                 .alpha_char = yp_encoding_iso_8859_9_alpha_char,
@@ -221,7 +228,7 @@ lex_encoding_callback(yp_parser_t *parser, const char *start, size_t width) {
   ENCODING("ascii", yp_encoding_ascii);
   ENCODING("iso-8859-9", yp_encoding_iso_8859_9);
   ENCODING("utf-8", yp_encoding_utf_8);
-  ENCODING("binary", yp_encoding_ascii);
+  ENCODING("binary", yp_encoding_ascii_8bit);
   ENCODING("us-ascii", yp_encoding_ascii);
 
 #undef ENCODING

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -445,17 +445,7 @@ module YARP
     end
 
     def value_for(event, value)
-      case event
-      when :on_comment, :on_tstring_content
-        # Ripper unescapes string content and comments, so we need to do the
-        # same here. We're going to attempt to force it into UTF-8, but if
-        # that doesn't work we'll just use the plain value.
-        begin
-          value.force_encoding("UTF-8").unicode_normalize
-        rescue ArgumentError
-          value
-        end
-      when :on___end__
+      if event == :on___end__
         # Ripper doesn't include the rest of the token in the event, so we
         # need to trim it down to just the first newline.
         value[0..value.index("\n")]

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4525,10 +4525,9 @@ parse_rescues(yp_parser_t *parser, yp_node_t *parent_node) {
   while (accept(parser, YP_TOKEN_KEYWORD_RESCUE)) {
     yp_token_t rescue_keyword = parser->previous;
 
-    yp_token_t exception_variable = not_provided(parser);
     yp_token_t equal_greater = not_provided(parser);
     yp_node_t *statements = yp_node_statements_create(parser);
-    yp_node_t *rescue = yp_node_rescue_node_create(parser, &rescue_keyword, &equal_greater, &exception_variable, statements, NULL);
+    yp_node_t *rescue = yp_node_rescue_node_create(parser, &rescue_keyword, &equal_greater, NULL, statements, NULL);
     yp_node_destroy(parser, statements);
 
     if (match_type_p(parser, YP_TOKEN_CONSTANT)) {
@@ -4547,8 +4546,11 @@ parse_rescues(yp_parser_t *parser, yp_node_t *parent_node) {
         if (accept(parser, YP_TOKEN_EQUAL_GREATER)) {
           rescue->as.rescue_node.equal_greater = parser->previous;
 
-          expect(parser, YP_TOKEN_IDENTIFIER, "Expected variable name after `=>` in rescue statement");
-          rescue->as.rescue_node.exception_variable = parser->previous;
+          yp_node_t *node = parse_expression(parser, BINDING_POWER_INDEX, "Expected an exception variable after `=>` in rescue statement.");
+          yp_token_t operator = not_provided(parser);
+          node = parse_target(parser, node, &operator, NULL);
+
+          rescue->as.rescue_node.exception = node;
           break;
         }
 
@@ -4557,8 +4559,11 @@ parse_rescues(yp_parser_t *parser, yp_node_t *parent_node) {
     } else if (accept(parser, YP_TOKEN_EQUAL_GREATER)) {
       rescue->as.rescue_node.equal_greater = parser->previous;
 
-      expect(parser, YP_TOKEN_IDENTIFIER, "Expected variable name after `=>` in rescue statement");
-      rescue->as.rescue_node.exception_variable = parser->previous;
+      yp_node_t *node = parse_expression(parser, BINDING_POWER_INDEX, "Expected an exception variable after `=>` in rescue statement.");
+      yp_token_t operator = not_provided(parser);
+      node = parse_target(parser, node, &operator, NULL);
+
+      rescue->as.rescue_node.exception = node;
     }
 
     rescue->as.rescue_node.statements = parse_statements(parser, YP_CONTEXT_RESCUE);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5326,7 +5326,13 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
         return yp_call_node_fcall_create(parser, &constant, &arguments);
       }
 
-      return yp_node_constant_read_create(parser, &parser->previous);
+      yp_node_t *node = yp_node_constant_read_create(parser, &parser->previous);
+
+      if ((binding_power == BINDING_POWER_STATEMENT) && match_type_p(parser, YP_TOKEN_COMMA)) {
+        node = parse_targets(parser, node, BINDING_POWER_INDEX);
+      }
+
+      return node;
     }
     case YP_TOKEN_COLON_COLON: {
       parser_lex(parser);
@@ -5335,7 +5341,13 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
       expect(parser, YP_TOKEN_CONSTANT, "Expected a constant after ::.");
 
       yp_node_t *constant = yp_node_constant_read_create(parser, &parser->previous);
-      return yp_node_constant_path_node_create(parser, NULL, &delimiter, constant);
+      yp_node_t *node = yp_node_constant_path_node_create(parser, NULL, &delimiter, constant);
+
+      if ((binding_power == BINDING_POWER_STATEMENT) && match_type_p(parser, YP_TOKEN_COMMA)) {
+        node = parse_targets(parser, node, BINDING_POWER_INDEX);
+      }
+
+      return node;
     }
     case YP_TOKEN_FLOAT:
       parser_lex(parser);
@@ -5352,9 +5364,16 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
 
       return node;
     }
-    case YP_TOKEN_IDENTIFIER:
+    case YP_TOKEN_IDENTIFIER: {
       parser_lex(parser);
-      return parse_identifier(parser);
+      yp_node_t *node = parse_identifier(parser);
+
+      if ((binding_power == BINDING_POWER_STATEMENT) && match_type_p(parser, YP_TOKEN_COMMA)) {
+        node = parse_targets(parser, node, BINDING_POWER_INDEX);
+      }
+
+      return node;
+    }
     case YP_TOKEN_HEREDOC_START: {
       parser_lex(parser);
       yp_node_t *node;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3434,6 +3434,13 @@ static yp_encoding_t yp_encoding_ascii = {
   .isupper_char = yp_encoding_ascii_isupper_char
 };
 
+static yp_encoding_t yp_encoding_ascii_8bit = {
+  .name = "ascii-8bit",
+  .alnum_char = yp_encoding_ascii_alnum_char,
+  .alpha_char = yp_encoding_ascii_alpha_char,
+  .isupper_char = yp_encoding_ascii_isupper_char,
+};
+
 static yp_encoding_t yp_encoding_iso_8859_9 = {
   .name = "iso-8859-9",
   .alnum_char = yp_encoding_iso_8859_9_alnum_char,
@@ -3501,7 +3508,7 @@ parser_lex_magic_comments(yp_parser_t *parser) {
     ENCODING("ascii", yp_encoding_ascii);
     ENCODING("iso-8859-9", yp_encoding_iso_8859_9);
     ENCODING("utf-8", yp_encoding_utf_8);
-    ENCODING("binary", yp_encoding_ascii);
+    ENCODING("binary", yp_encoding_ascii_8bit);
     ENCODING("us-ascii", yp_encoding_ascii);
 
 #undef ENCODING

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6428,7 +6428,7 @@ static inline yp_node_t *
 parse_assignment_value(yp_parser_t *parser, binding_power_t previous_binding_power, binding_power_t binding_power, const char *message) {
   yp_node_t *value = parse_expression(parser, binding_power, message);
 
-  if (previous_binding_power == BINDING_POWER_STATEMENT && match_type_p(parser, YP_TOKEN_COMMA)) {
+  if (previous_binding_power == BINDING_POWER_STATEMENT && accept(parser, YP_TOKEN_COMMA)) {
     yp_token_t opening = not_provided(parser);
     yp_token_t closing = not_provided(parser);
     yp_node_t *array = yp_array_node_create(parser, &opening, &closing);
@@ -6436,8 +6436,7 @@ parse_assignment_value(yp_parser_t *parser, binding_power_t previous_binding_pow
     yp_array_node_append(array, value);
     value = array;
 
-    while (!match_any_type_p(parser, 3, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF)) {
-      expect(parser, YP_TOKEN_COMMA, "Expected a ',' to delimit elements in the array.");
+    do {
       yp_node_t *element;
 
       if (accept(parser, YP_TOKEN_STAR)) {
@@ -6449,7 +6448,7 @@ parse_assignment_value(yp_parser_t *parser, binding_power_t previous_binding_pow
 
       yp_array_node_append(array, element);
       if (element->type == YP_NODE_MISSING_NODE) break;
-    }
+    } while (accept(parser, YP_TOKEN_COMMA));
   }
 
   return value;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1859,7 +1859,7 @@ lex_identifier(yp_parser_t *parser, bool previous_command_start) {
         if (lex_keyword(parser, "BEGIN", YP_LEX_STATE_END, false)) return YP_TOKEN_KEYWORD_BEGIN_UPCASE;
         if (lex_keyword(parser, "break", YP_LEX_STATE_MID, false)) return YP_TOKEN_KEYWORD_BREAK;
         if (lex_keyword(parser, "class", YP_LEX_STATE_CLASS, false)) return YP_TOKEN_KEYWORD_CLASS;
-        if (lex_keyword(parser, "elsif", YP_LEX_STATE_END, false)) return YP_TOKEN_KEYWORD_ELSIF;
+        if (lex_keyword(parser, "elsif", YP_LEX_STATE_BEG, false)) return YP_TOKEN_KEYWORD_ELSIF;
         if (lex_keyword(parser, "false", YP_LEX_STATE_END, false)) return YP_TOKEN_KEYWORD_FALSE;
         if (lex_keyword(parser, "retry", YP_LEX_STATE_END, false)) return YP_TOKEN_KEYWORD_RETRY;
         if (lex_keyword(parser, "super", YP_LEX_STATE_ARG, false)) return YP_TOKEN_KEYWORD_SUPER;
@@ -4916,6 +4916,7 @@ parse_symbol(yp_parser_t *parser, int mode, yp_lex_state_t next_state) {
           break;
         }
         case YP_TOKEN_EMBEXPR_BEGIN: {
+          assert(parser->lex_modes.current->mode == YP_LEX_EMBEXPR);
           yp_lex_state_t state = parser->lex_modes.current->as.embexpr.state;
           parser_lex(parser);
 
@@ -5055,6 +5056,7 @@ parse_string_part(yp_parser_t *parser) {
     //     "aaa #{bbb} #@ccc ddd"
     //          ^^^^^^
     case YP_TOKEN_EMBEXPR_BEGIN: {
+      assert(parser->lex_modes.current->mode == YP_LEX_EMBEXPR);
       yp_lex_state_t state = parser->lex_modes.current->as.embexpr.state;
 
       yp_token_t opening = parser->previous;
@@ -6126,6 +6128,7 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
               break;
             }
             case YP_TOKEN_EMBEXPR_BEGIN: {
+              assert(parser->lex_modes.current->mode == YP_LEX_EMBEXPR);
               yp_lex_state_t state = parser->lex_modes.current->as.embexpr.state;
 
               parser_lex(parser);
@@ -6225,6 +6228,7 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
             break;
           }
           case YP_TOKEN_EMBEXPR_BEGIN: {
+            assert(parser->lex_modes.current->mode == YP_LEX_EMBEXPR);
             yp_lex_state_t state = parser->lex_modes.current->as.embexpr.state;
             parser_lex(parser);
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3746,7 +3746,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop with 2 indexes" do
     expected = ForNode(
-      MultiTargetNode(
+      MultiWriteNode(
         [
           LocalVariableWrite(IDENTIFIER("i"), nil, nil),
           LocalVariableWrite(IDENTIFIER("j"), nil, nil)
@@ -3767,7 +3767,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop with 3 indexes" do
     expected = ForNode(
-      MultiTargetNode(
+      MultiWriteNode(
         [
           LocalVariableWrite(IDENTIFIER("i"), nil, nil),
           LocalVariableWrite(IDENTIFIER("j"), nil, nil),
@@ -5816,7 +5816,20 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "foo { |a| break } == 42"
   end
 
-  test "multiple assignment on class variable" do
+  test "multiple assignment on class variable (left-hand side)" do
+    expected = MultiWriteNode(
+      [
+        ClassVariableWriteNode(Location(), nil, nil),
+        ClassVariableWriteNode(Location(), nil, nil)
+      ],
+      EQUAL("="),
+      IntegerNode()
+    )
+
+    assert_parses expected, "@@foo, @@bar = 1"
+  end
+
+  test "multiple assignment on class variable (right-hand side)" do
     expected = ClassVariableWriteNode(
       Location(),
       ArrayNode([IntegerNode(), IntegerNode()], nil, nil),
@@ -5826,7 +5839,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "@@foo = 1, 2"
   end
 
-  test "multiple assignment on constant" do
+  test "multiple assignment on constant (right-hand side)" do
     expected = ConstantPathWriteNode(
       ConstantRead(CONSTANT("Foo")),
       EQUAL("="),
@@ -5850,7 +5863,20 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "Foo::Bar = 1, 2"
   end
 
-  test "multiple assignment on global variable" do
+  test "multiple assignment on global variable (left-hand side)" do
+    expected = MultiWriteNode(
+      [
+        GlobalVariableWrite(GLOBAL_VARIABLE("$foo"), nil, nil),
+        GlobalVariableWrite(GLOBAL_VARIABLE("$bar"), nil, nil)
+      ],
+      EQUAL("="),
+      IntegerNode()
+    )    
+
+    assert_parses expected, "$foo, $bar = 1"
+  end
+
+  test "multiple assignment on global variable (right-hand side)" do
     expected = GlobalVariableWrite(
       GLOBAL_VARIABLE("$foo"),
       EQUAL("="),
@@ -5860,7 +5886,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "$foo = 1, 2"
   end
 
-  test "multiple assignment on local variable (known)" do
+  test "multiple assignment on local variable (known, right-hand side)" do
     expected = LocalVariableWrite(
       IDENTIFIER("foo"),
       EQUAL("="),
@@ -5870,7 +5896,7 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "foo = 1; foo = 1, 2"
   end
 
-  test "multiple assignment on local variable (unknown)" do
+  test "multiple assignment on local variable (unknown, right-hand side)" do
     expected = LocalVariableWrite(
       IDENTIFIER("foo"),
       EQUAL("="),
@@ -5880,7 +5906,20 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "foo = 1, 2"
   end
 
-  test "multiple assignment on instance variable" do
+  test "multiple assignment on instance variable (left-hand side)" do
+    expected = MultiWriteNode(
+      [
+        InstanceVariableWriteNode(Location(), nil, nil),
+        InstanceVariableWriteNode(Location(), nil, nil)
+      ],
+      EQUAL("="),
+      IntegerNode()
+    )
+
+    assert_parses expected, "@foo, @bar = 1"
+  end
+
+  test "multiple assignment on instance variable (right-hand side)" do
     expected = InstanceVariableWriteNode(
       Location(),
       ArrayNode([IntegerNode(), IntegerNode()], nil, nil),

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3746,10 +3746,14 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop with 2 indexes" do
     expected = ForNode(
-      MultiTargetNode([
-        LocalVariableWrite(IDENTIFIER("i"), nil, nil),
-        LocalVariableWrite(IDENTIFIER("j"), nil, nil)
-      ]),
+      MultiTargetNode(
+        [
+          LocalVariableWrite(IDENTIFIER("i"), nil, nil),
+          LocalVariableWrite(IDENTIFIER("j"), nil, nil)
+        ],
+        nil,
+        nil
+      ),
       expression("1..10"),
       Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),
@@ -3763,11 +3767,15 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop with 3 indexes" do
     expected = ForNode(
-      MultiTargetNode([
-        LocalVariableWrite(IDENTIFIER("i"), nil, nil),
-        LocalVariableWrite(IDENTIFIER("j"), nil, nil),
-        LocalVariableWrite(IDENTIFIER("k"), nil, nil)
-      ]),
+      MultiTargetNode(
+        [
+          LocalVariableWrite(IDENTIFIER("i"), nil, nil),
+          LocalVariableWrite(IDENTIFIER("j"), nil, nil),
+          LocalVariableWrite(IDENTIFIER("k"), nil, nil)
+        ],
+        nil,
+        nil
+      ),
       expression("1..10"),
       Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5849,20 +5849,6 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "Foo = 1, 2"
   end
 
-  test "multiple assignment on constant path" do
-    expected = ConstantPathWriteNode(
-      ConstantPathNode(
-        ConstantRead(CONSTANT("Foo")),
-        COLON_COLON("::"),
-        ConstantRead(CONSTANT("Bar"))
-      ),
-      EQUAL("="),
-      ArrayNode([IntegerNode(), IntegerNode()], nil, nil)
-    )
-
-    assert_parses expected, "Foo::Bar = 1, 2"
-  end
-
   test "multiple assignment on global variable (left-hand side)" do
     expected = MultiWriteNode(
       [

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5808,6 +5808,80 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "foo { |a| break } == 42"
   end
 
+  test "multiple assignment on class variable" do
+    expected = ClassVariableWriteNode(
+      Location(),
+      ArrayNode([IntegerNode(), IntegerNode()], nil, nil),
+      Location()
+    )
+
+    assert_parses expected, "@@foo = 1, 2"
+  end
+
+  test "multiple assignment on constant" do
+    expected = ConstantPathWriteNode(
+      ConstantRead(CONSTANT("Foo")),
+      EQUAL("="),
+      ArrayNode([IntegerNode(), IntegerNode()], nil, nil)
+    )
+
+    assert_parses expected, "Foo = 1, 2"
+  end
+
+  test "multiple assignment on constant path" do
+    expected = ConstantPathWriteNode(
+      ConstantPathNode(
+        ConstantRead(CONSTANT("Foo")),
+        COLON_COLON("::"),
+        ConstantRead(CONSTANT("Bar"))
+      ),
+      EQUAL("="),
+      ArrayNode([IntegerNode(), IntegerNode()], nil, nil)
+    )
+
+    assert_parses expected, "Foo::Bar = 1, 2"
+  end
+
+  test "multiple assignment on global variable" do
+    expected = GlobalVariableWrite(
+      GLOBAL_VARIABLE("$foo"),
+      EQUAL("="),
+      ArrayNode([IntegerNode(), IntegerNode()], nil, nil)
+    )
+
+    assert_parses expected, "$foo = 1, 2"
+  end
+
+  test "multiple assignment on local variable (known)" do
+    expected = LocalVariableWrite(
+      IDENTIFIER("foo"),
+      EQUAL("="),
+      ArrayNode([IntegerNode(), IntegerNode()], nil, nil)
+    )
+
+    assert_parses expected, "foo = 1; foo = 1, 2"
+  end
+
+  test "multiple assignment on local variable (unknown)" do
+    expected = LocalVariableWrite(
+      IDENTIFIER("foo"),
+      EQUAL("="),
+      ArrayNode([IntegerNode(), IntegerNode()], nil, nil)
+    )
+
+    assert_parses expected, "foo = 1, 2"
+  end
+
+  test "multiple assignment on instance variable" do
+    expected = InstanceVariableWriteNode(
+      Location(),
+      ArrayNode([IntegerNode(), IntegerNode()], nil, nil),
+      Location()
+    )
+
+    assert_parses expected, "@foo = 1, 2"
+  end
+
   private
 
   def assert_serializes(expected, source)

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3690,9 +3690,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop" do
     expected = ForNode(
-      expression("i"),
+      LocalVariableWrite(IDENTIFIER("i"), nil, nil),
       expression("1..10"),
-      Statements([expression("i")]),
+      Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),
       Location(),
       nil,
@@ -3704,9 +3704,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop with do keyword" do
     expected = ForNode(
-      expression("i"),
+      LocalVariableWrite(IDENTIFIER("i"), nil, nil),
       expression("1..10"),
-      Statements([expression("i")]),
+      Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),
       Location(),
       Location(),
@@ -3718,9 +3718,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop no newlines" do
     expected = ForNode(
-      expression("i"),
+      LocalVariableWrite(IDENTIFIER("i"), nil, nil),
       expression("1..10"),
-      Statements([expression("i")]),
+      Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),
       Location(),
       nil,
@@ -3732,9 +3732,9 @@ class ParseTest < Test::Unit::TestCase
 
   test "for loop with semicolons" do
     expected = ForNode(
-      expression("i"),
+      LocalVariableWrite(IDENTIFIER("i"), nil, nil),
       expression("1..10"),
-      Statements([expression("i")]),
+      Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),
       Location(),
       nil,
@@ -3747,11 +3747,11 @@ class ParseTest < Test::Unit::TestCase
   test "for loop with 2 indexes" do
     expected = ForNode(
       MultiTargetNode([
-        expression("i"),
-        expression("j"),
+        LocalVariableWrite(IDENTIFIER("i"), nil, nil),
+        LocalVariableWrite(IDENTIFIER("j"), nil, nil)
       ]),
       expression("1..10"),
-      Statements([expression("i")]),
+      Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),
       Location(),
       nil,
@@ -3764,12 +3764,12 @@ class ParseTest < Test::Unit::TestCase
   test "for loop with 3 indexes" do
     expected = ForNode(
       MultiTargetNode([
-        expression("i"),
-        expression("j"),
-        expression("k"),
+        LocalVariableWrite(IDENTIFIER("i"), nil, nil),
+        LocalVariableWrite(IDENTIFIER("j"), nil, nil),
+        LocalVariableWrite(IDENTIFIER("k"), nil, nil)
       ]),
       expression("1..10"),
-      Statements([expression("i")]),
+      Statements([LocalVariableRead(IDENTIFIER("i"))]),
       Location(),
       Location(),
       nil,

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3874,7 +3874,7 @@ class ParseTest < Test::Unit::TestCase
         KEYWORD_RESCUE("rescue"),
         [ConstantRead(CONSTANT("Exception"))],
         EQUAL_GREATER("=>"),
-        IDENTIFIER("ex"),
+        LocalVariableWrite(IDENTIFIER("ex"), nil, nil),
         Statements([expression("b")]),
         nil,
       ),
@@ -3883,7 +3883,13 @@ class ParseTest < Test::Unit::TestCase
       KEYWORD_END("end"),
     )
 
-    assert_parses expected, "begin\na\nrescue Exception => ex\nb\nend"
+    assert_parses expected, <<~RUBY
+      begin
+        a
+      rescue Exception => ex
+        b
+      end
+    RUBY
   end
 
   test "begin with rescue statement and exception list" do
@@ -3914,7 +3920,7 @@ class ParseTest < Test::Unit::TestCase
         KEYWORD_RESCUE("rescue"),
         [ConstantRead(CONSTANT("Exception")), ConstantRead(CONSTANT("CustomException"))],
         EQUAL_GREATER("=>"),
-        IDENTIFIER("ex"),
+        LocalVariableWrite(IDENTIFIER("ex"), nil, nil),
         Statements([expression("b")]),
         nil
       ),
@@ -3923,7 +3929,13 @@ class ParseTest < Test::Unit::TestCase
       KEYWORD_END("end"),
     )
 
-    assert_parses expected, "begin\na\nrescue Exception, CustomException => ex\nb\nend"
+    assert_parses expected, <<~RUBY
+      begin
+        a
+      rescue Exception, CustomException => ex
+        b
+      end
+    RUBY
   end
 
   test "begin with multiple rescue statements" do
@@ -3968,13 +3980,13 @@ class ParseTest < Test::Unit::TestCase
         KEYWORD_RESCUE("rescue"),
         [ConstantRead(CONSTANT("Exception"))],
         EQUAL_GREATER("=>"),
-        IDENTIFIER("ex"),
+        LocalVariableWrite(IDENTIFIER("ex"), nil, nil),
         Statements([expression("b")]),
         RescueNode(
           KEYWORD_RESCUE("rescue"),
           [ConstantRead(CONSTANT("AnotherException")), ConstantRead(CONSTANT("OneMoreException"))],
           EQUAL_GREATER("=>"),
-          IDENTIFIER("ex"),
+          LocalVariableWrite(IDENTIFIER("ex"), nil, nil),
           Statements([expression("c")]),
           nil
         )
@@ -4103,7 +4115,7 @@ class ParseTest < Test::Unit::TestCase
         KEYWORD_RESCUE("rescue"),
         [ConstantRead(CONSTANT("Exception"))],
         EQUAL_GREATER("=>"),
-        IDENTIFIER("ex"),
+        LocalVariableWrite(IDENTIFIER("ex"), nil, nil),
         Statements([expression("b")]),
         nil
       ),
@@ -4116,7 +4128,15 @@ class ParseTest < Test::Unit::TestCase
       KEYWORD_END("end")
     )
 
-    assert_parses expected, "begin\na\nrescue Exception => ex\nb\nensure\nb\nend"
+    assert_parses expected, <<~RUBY
+      begin
+        a
+      rescue Exception => ex
+        b
+      ensure
+        b
+      end
+    RUBY
   end
 
   test "blocks with rescues" do


### PR DESCRIPTION
This PR introduces multiple assignment. There are two kinds.

The first is multiple assignment where you have multiple values on the left-hand side of the expression. This looks like:

```ruby
@foo, bar =
@@foo, bar =
$foo, bar =
```

and many others. To accomplish this, we've repurposed the previously-named `MultiTargetNode` to now be a `MultiWriteNode`. All of the examples in the above are `MultiWriteNode`s. It has an array of targets (in the first line, it would be a `InstanceVariableWriteNode` and a `LocalVariableWriteNode`, both will `nil` for their values), an operator, and a value.

The second is when you have multiple-values on the right-hand side of the expression. This looks like:

```ruby
foo = 1, 2, 3
@foo = 1, 2, 3
```

This is effectively the same thing as assigning an array without brackets. So this is the way it has been implemented. We made the brackets optional on arrays, and now it effectively does the same thing.

The MultiTargetNode is also being used in `ForNode` now, since that's what the index value effectively is. This solves a bug where local variables didn't get introduced properly.

Mostly closes #151.