### PR TITLE
Fix parsing arguments with hash and block

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4189,6 +4189,10 @@ parse_assoc(yp_parser_t *parser, yp_node_t *hash, yp_token_type_t terminator) {
     return true;
   }
 
+  if (match_type_p(parser, YP_TOKEN_AMPERSAND)) {
+    return false;
+  }
+
   yp_node_t *element;
 
   switch (parser->current.type) {
@@ -4247,12 +4251,14 @@ static void
 parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t terminator) {
   bool parsed_double_splat_argument = false;
   bool parsed_block_argument = false;
+  bool parsed_assoc = false;
 
   while (
     !match_any_type_p(parser, 6, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
     !context_terminator(parser->current_context->context, &parser->current)
   ) {
-    if (yp_arguments_node_size(arguments) > 0) {
+    // Don't expect a comma if we have already parsed hash assocs.
+    if ((yp_arguments_node_size(arguments) > 0) && !parsed_assoc) {
       expect(parser, YP_TOKEN_COMMA, "Expected a ',' to delimit arguments.");
     }
 
@@ -4279,7 +4285,7 @@ parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t termi
             break;
           }
         }
-
+        parsed_assoc = true;
         break;
       }
       case YP_TOKEN_STAR_STAR: {

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -338,7 +338,7 @@ class ErrorsTest < Test::Unit::TestCase
       "a"
     )
 
-    assert_errors expected, "a(foo: bar, *args)", ["Expected a key in the hash literal.", "Expected a ',' to delimit arguments."]
+    assert_errors expected, "a(foo: bar, *args)", ["Expected a key in the hash literal."]
   end
 
   private

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5640,6 +5640,74 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "foo :a, b: true do |a, b| puts a end"
   end
 
+  test "method call without parenthesis with hash and a block argument" do
+    expected = CallNode(
+      nil,
+      nil,
+      IDENTIFIER("foo"),
+      nil,
+      ArgumentsNode(
+        [HashNode(
+           nil,
+           [AssocNode(
+              SymbolNode(nil, LABEL("a"), LABEL_END(":")),
+              TrueNode(),
+              nil
+            ),
+            AssocNode(
+              SymbolNode(nil, LABEL("b"), LABEL_END(":")),
+              FalseNode(),
+              nil
+            )],
+           nil
+         ),
+         BlockArgumentNode(
+           AMPERSAND("&"),
+           SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("block"), nil)
+         )]
+      ),
+      nil,
+      nil,
+      "foo"
+    )
+
+    assert_parses expected, "foo a: true, b: false, &:block"
+  end
+
+  test "method call with parenthesis with hash and a block argument" do
+    expected = CallNode(
+      nil,
+      nil,
+      IDENTIFIER("foo"),
+      PARENTHESIS_LEFT("("),
+      ArgumentsNode(
+        [HashNode(
+           BRACE_LEFT("{"),
+           [AssocNode(
+              SymbolNode(nil, LABEL("a"), LABEL_END(":")),
+              TrueNode(),
+              nil
+            ),
+            AssocNode(
+              SymbolNode(nil, LABEL("b"), LABEL_END(":")),
+              FalseNode(),
+              nil
+            )],
+           BRACE_RIGHT("}")
+         ),
+         BlockArgumentNode(
+           AMPERSAND("&"),
+           SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("block"), nil)
+         )]
+      ),
+      PARENTHESIS_RIGHT(")"),
+      nil,
+      "foo"
+    )
+
+    assert_parses expected, "foo({ a: true, b: false, }, &:block)"
+  end
+
   test "basic case when syntax" do
     expected = CaseNode(
       KEYWORD_CASE("case"),
@@ -5877,7 +5945,7 @@ class ParseTest < Test::Unit::TestCase
       ],
       EQUAL("="),
       IntegerNode()
-    )    
+    )
 
     assert_parses expected, "$foo, $bar = 1"
   end


### PR DESCRIPTION
Fixes #345

`rake lex` from `88.87%` to `88.93%`
