### PR TITLE
Fix array literals with labels

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5198,6 +5198,16 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
           // [*splat]
           yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected an expression after '*' in the array.");
           element = yp_node_star_node_create(parser, &parser->previous, expression);
+        } else if (match_type_p(parser, YP_TOKEN_LABEL)) {
+          yp_token_t opening = not_provided(parser);
+          yp_token_t closing = not_provided(parser);
+          element = yp_node_hash_node_create(parser, &opening, &closing);
+
+          while (!match_any_type_p(parser, 8, YP_TOKEN_EOF, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF, YP_TOKEN_BRACE_RIGHT, YP_TOKEN_BRACKET_RIGHT, YP_TOKEN_KEYWORD_DO, YP_TOKEN_PARENTHESIS_RIGHT)) {
+            if (!parse_assoc(parser, element, YP_TOKEN_EOF)) {
+              break;
+            }
+          }
         } else {
           element = parse_expression(parser, BINDING_POWER_DEFINED, "Expected an element for the array.");
         }

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -123,6 +123,29 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "[:a, :b,\n:c,1,\n\n\n\n:d,\n]"
   end
 
+  test "array literal with labels" do
+    expected = ArrayNode(
+      [HashNode(
+        nil,
+        [AssocNode(
+           SymbolNode(nil, LABEL("a"), LABEL_END(":")),
+           ArrayNode(
+             [SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil),
+              SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("c"), nil)],
+             BRACKET_LEFT("["),
+             BRACKET_RIGHT("]")
+           ),
+           nil
+         )],
+        nil
+      )],
+     BRACKET_LEFT("["),
+     BRACKET_RIGHT("]")
+    )
+
+    assert_parses expected, "[a: [:b, :c]]"
+  end
+
   test "empty array literal" do
     assert_parses ArrayNode([], BRACKET_LEFT("["), BRACKET_RIGHT("]")), "[\n]\n"
   end
@@ -5877,7 +5900,7 @@ class ParseTest < Test::Unit::TestCase
       ],
       EQUAL("="),
       IntegerNode()
-    )    
+    )
 
     assert_parses expected, "$foo, $bar = 1"
   end


### PR DESCRIPTION
Fixes parsing array literals with labels, so we should parse this

```ruby
[a: [:b, :c]]
```

but **not** this

```ruby
[a: [:b, :c], :d]
```
