### PR TITLE
Fix parsing modifiers with arguments to call

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4270,16 +4270,21 @@ parse_assoc(yp_parser_t *parser, yp_node_t *hash, yp_token_type_t terminator) {
   return true;
 }
 
+static inline
+bool should_parse_argument(yp_parser_t *parser, yp_token_type_t terminator) {
+  binding_power_t binding_power = binding_powers[parser->current.type].left;
+  return !match_any_type_p(parser, 6, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
+    !context_terminator(parser->current_context->context, &parser->current) &&
+    (binding_power == BINDING_POWER_UNSET || binding_power >= BINDING_POWER_RANGE);
+}
+
 // Parse a list of arguments.
 static void
 parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t terminator) {
   bool parsed_double_splat_argument = false;
   bool parsed_block_argument = false;
 
-  while (
-    !match_any_type_p(parser, 6, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
-    !context_terminator(parser->current_context->context, &parser->current)
-  ) {
+  while (should_parse_argument(parser, terminator)) {
     if (yp_arguments_node_size(arguments) > 0) {
       expect(parser, YP_TOKEN_COMMA, "Expected a ',' to delimit arguments.");
     }

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -293,8 +293,7 @@ class ErrorsTest < Test::Unit::TestCase
           [StarNode(
              STAR("*"),
              CallNode(nil, nil, IDENTIFIER("bar"), nil, nil, nil, nil, "bar")
-           ),
-           MissingNode()]
+           )]
         ),
         MISSING(""),
         nil,
@@ -305,8 +304,6 @@ class ErrorsTest < Test::Unit::TestCase
     )
 
     assert_errors expected, "foo(*bar and baz)", [
-      "Expected a ',' to delimit arguments.",
-      "Expected to be able to parse an argument.",
       "Expected a ')' to close the argument list."
     ]
   end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2468,6 +2468,31 @@ class ParseTest < Test::Unit::TestCase
     assert_parses IfNode(KEYWORD_IF("if"), expression("true"), Statements([expression("1")]), nil, nil), "1 if true"
   end
 
+  test "if modifier with arguments" do
+    expected = IfNode(
+      KEYWORD_IF("if"),
+      CallNode(nil, nil, IDENTIFIER("bar?"), nil, nil, nil, nil, "bar?"),
+      Statements(
+        [CallNode(
+          nil,
+          nil,
+          IDENTIFIER("foo"),
+          nil,
+          ArgumentsNode([
+          SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil),
+          SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil)
+          ]),
+          nil,
+          nil,
+          "foo"
+         )]
+      ),
+      nil,
+      nil
+    )
+    assert_parses expected, "foo :a, :b if bar?"
+  end
+
   test "if else" do
     expected = IfNode(
       KEYWORD_IF("if"),
@@ -3441,6 +3466,31 @@ class ParseTest < Test::Unit::TestCase
     assert_parses UnlessNode(KEYWORD_UNLESS("unless"), expression("true"), Statements([expression("1")]), nil, nil), "1 unless true"
   end
 
+  test "unless modifier with arguments" do
+    expected = UnlessNode(
+      KEYWORD_UNLESS("unless"),
+      CallNode(nil, nil, IDENTIFIER("bar?"), nil, nil, nil, nil, "bar?"),
+      Statements(
+        [CallNode(
+          nil,
+          nil,
+          IDENTIFIER("foo"),
+          nil,
+          ArgumentsNode([
+            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil),
+            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil)
+          ]),
+          nil,
+          nil,
+          "foo"
+         )]
+      ),
+      nil,
+      nil
+    )
+    assert_parses expected, "foo :a, :b unless bar?"
+  end
+
   test "unless else" do
     expected = UnlessNode(
       KEYWORD_UNLESS("unless"),
@@ -3465,12 +3515,58 @@ class ParseTest < Test::Unit::TestCase
     assert_parses UntilNode(KEYWORD_UNTIL("until"), expression("true"), Statements([expression("1")])), "1 until true"
   end
 
+  test "until modifier with arguments" do
+    expected = UntilNode(
+      KEYWORD_UNTIL("until"),
+      CallNode(nil, nil, IDENTIFIER("bar?"), nil, nil, nil, nil, "bar?"),
+      Statements(
+        [CallNode(
+          nil,
+          nil,
+          IDENTIFIER("foo"),
+          nil,
+          ArgumentsNode([
+            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil),
+            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil)
+          ]),
+          nil,
+          nil,
+          "foo"
+         )]
+      )
+    )
+    assert_parses expected, "foo :a, :b until bar?"
+  end
+
   test "while" do
     assert_parses WhileNode(KEYWORD_WHILE("while"), expression("true"), Statements([expression("1")])), "while true; 1; end"
   end
 
   test "while modifier" do
     assert_parses WhileNode(KEYWORD_WHILE("while"), expression("true"), Statements([expression("1")])), "1 while true"
+  end
+
+  test "while modifier with arguments" do
+    expected = WhileNode(
+      KEYWORD_WHILE("while"),
+      CallNode(nil, nil, IDENTIFIER("bar?"), nil, nil, nil, nil, "bar?"),
+      Statements(
+        [CallNode(
+          nil,
+          nil,
+          IDENTIFIER("foo"),
+          nil,
+          ArgumentsNode([
+            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("a"), nil),
+            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("b"), nil)
+          ]),
+          nil,
+          nil,
+          "foo"
+         )]
+      )
+    )
+    assert_parses expected, "foo :a, :b while bar?"
   end
 
   test "yield" do

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2471,7 +2471,15 @@ class ParseTest < Test::Unit::TestCase
   test "if modifier with arguments" do
     expected = IfNode(
       KEYWORD_IF("if"),
-      CallNode(nil, nil, IDENTIFIER("bar?"), nil, nil, nil, nil, "bar?"),
+      AndNode(
+        OrNode(
+          CallNode(nil, nil, IDENTIFIER("bar?"), nil, nil, nil, nil, "bar?"),
+          KEYWORD_OR("or"),
+          CallNode(nil, nil, IDENTIFIER("baz"), nil, nil, nil, nil, "baz"),
+        ),
+        CallNode(nil, nil, IDENTIFIER("qux"), nil, nil, nil, nil, "qux"),
+        KEYWORD_AND("and"),
+      ),
       Statements(
         [CallNode(
           nil,
@@ -2490,7 +2498,7 @@ class ParseTest < Test::Unit::TestCase
       nil,
       nil
     )
-    assert_parses expected, "foo :a, :b if bar?"
+    assert_parses expected, "foo :a, :b if bar? or baz and qux"
   end
 
   test "if else" do


### PR DESCRIPTION
Fixes parsing:

```ruby
foo :a if b?
foo :a unless b?
foo :a until b?
foo :a while b?
```

The following should also be parsed but I couldn't fix it:

```ruby
foo :a rescue :b
```

Takes `rake lex` from `88.87%` to `89.24%`.
