### PR TITLE
Fix the states for interpolation, __END__, "#", ~@, &=, and `

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -413,7 +413,7 @@ module YARP
           tokens << token
 
           case event
-          when :on_nl
+          when :on_nl, :on_ignored_nl
             heredocs.each do |heredoc|
               tokens.concat(heredoc.to_a)
             end


### PR DESCRIPTION
Also heredocs should be able to start based on `on_ignored_nl`