### PR TITLE
Correctly check subsequent token when parsing arguments for break, next, and return

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5525,17 +5525,30 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
       yp_token_t keyword = parser->previous;
       yp_node_t *arguments = NULL;
 
-      if (!accept_any(parser, 3, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF)) {
-        arguments = yp_arguments_node_create(parser);
+      if (
+        !accept_any(parser, 3, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
+        !context_terminator(parser->current_context->context, &parser->current)
+      ) {
+        // If the next token is not a statement terminator or the end of the
+        // file then it is either an argument or a modifier to the keyword. We
+        // should only parse an argument if it is an argument, which we can
+        // determine by looking at the next token's infix binding power. If it
+        // is unset (it can't be used as an infix operator) then it's definitely
+        // an argument. Otherwise we'll check if it's >= BINDING_POWER_RANGE,
+        // which would mean it's part of the expression.
+        binding_power_t binding_power = binding_powers[parser->current.type].left;
 
-        while (!match_type_p(parser, YP_TOKEN_EOF) && !context_terminator(parser->current_context->context, &parser->current)) {
-          yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected to be able to parse an argument.");
-          yp_arguments_node_append(arguments, expression);
+        if (binding_power == BINDING_POWER_UNSET || binding_power >= BINDING_POWER_RANGE) {
+          arguments = yp_arguments_node_create(parser);
 
-          // If parsing the argument resulted in error recovery, then we can
-          // stop parsing the arguments entirely now.
-          if (expression->type == YP_NODE_MISSING_NODE || parser->recovering) break;
-          if (!accept(parser, YP_TOKEN_COMMA)) break;
+          do {
+            yp_node_t *expression = parse_expression(parser, BINDING_POWER_DEFINED, "Expected to be able to parse an argument.");
+            yp_arguments_node_append(arguments, expression);
+
+            // If parsing the argument resulted in error recovery, then we can
+            // stop parsing the arguments entirely now.
+            if (expression->type == YP_NODE_MISSING_NODE || parser->recovering) break;
+          } while (accept(parser, YP_TOKEN_COMMA));
         }
       }
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -5843,7 +5843,7 @@ class ParseTest < Test::Unit::TestCase
             nil,
             nil
           ),
-          Statements([BreakNode(ArgumentsNode([]), Location())]),
+          Statements([BreakNode(nil, Location())]),
           BRACE_RIGHT("}")
         ),
         "foo"
@@ -5956,6 +5956,84 @@ class ParseTest < Test::Unit::TestCase
     )
 
     assert_parses expected, "@foo = 1, 2"
+  end
+
+  test "if modifier after break" do
+    assert_parses IfNode(KEYWORD_IF("if"), expression("true"), Statements([BreakNode(nil, Location())]), nil, nil), "break if true"
+  end
+
+  test "if modifier after next" do
+    assert_parses IfNode(KEYWORD_IF("if"), expression("true"), Statements([NextNode(nil, Location())]), nil, nil), "next if true"
+  end
+
+  test "if modifier after return" do
+    assert_parses IfNode(KEYWORD_IF("if"), expression("true"), Statements([ReturnNode(KEYWORD_RETURN("return"), nil)]), nil, nil), "return if true"
+  end
+
+  test "unless modifier after break" do
+    assert_parses UnlessNode(KEYWORD_UNLESS("unless"), expression("true"), Statements([BreakNode(nil, Location())]), nil, nil), "break unless true"
+  end
+
+  test "unless modifier after next" do
+    assert_parses UnlessNode(KEYWORD_UNLESS("unless"), expression("true"), Statements([NextNode(nil, Location())]), nil, nil), "next unless true"
+  end
+
+  test "unless modifier after return" do
+    assert_parses UnlessNode(KEYWORD_UNLESS("unless"), expression("true"), Statements([ReturnNode(KEYWORD_RETURN("return"), nil)]), nil, nil), "return unless true"
+  end
+
+  test "until modifier after break" do
+    assert_parses UntilNode(KEYWORD_UNTIL("until"), expression("true"), Statements([BreakNode(nil, Location())])), "break until true"
+  end
+
+  test "until modifier after next" do
+    assert_parses UntilNode(KEYWORD_UNTIL("until"), expression("true"), Statements([NextNode(nil, Location())])), "next until true"
+  end
+
+  test "until modifier after return" do
+    assert_parses UntilNode(KEYWORD_UNTIL("until"), expression("true"), Statements([ReturnNode(KEYWORD_RETURN("return"), nil)])), "return until true"
+  end
+
+  test "while modifier after break" do
+    assert_parses WhileNode(KEYWORD_WHILE("while"), expression("true"), Statements([BreakNode(nil, Location())])), "break while true"
+  end
+
+  test "while modifier after next" do
+    assert_parses WhileNode(KEYWORD_WHILE("while"), expression("true"), Statements([NextNode(nil, Location())])), "next while true"
+  end
+
+  test "while modifier after return" do
+    assert_parses WhileNode(KEYWORD_WHILE("while"), expression("true"), Statements([ReturnNode(KEYWORD_RETURN("return"), nil)])), "return while true"
+  end
+
+  test "rescue modifier after break" do
+    expected = RescueModifierNode(
+      BreakNode(nil, Location()),
+      KEYWORD_RESCUE("rescue"),
+      NilNode()
+    )
+
+    assert_parses expected, "break rescue nil"
+  end
+
+  test "rescue modifier after next" do
+    expected = RescueModifierNode(
+      NextNode(nil, Location()),
+      KEYWORD_RESCUE("rescue"),
+      NilNode()
+    )
+
+    assert_parses expected, "next rescue nil"
+  end
+
+  test "rescue modifier after return" do
+    expected = RescueModifierNode(
+      ReturnNode(KEYWORD_RETURN("return"), nil),
+      KEYWORD_RESCUE("rescue"),
+      NilNode()
+    )
+
+    assert_parses expected, "return rescue nil"
   end
 
   private


### PR DESCRIPTION
When parsing arguments to `break`, `next`, and `return`, it would previously eagerly grab up the remaining tokens on the line. This wasn't exactly correct, because you could be in a situation like

```ruby
break if true
```

In that case the `if` is a modifier form, so it shouldn't be parsed as an argument. To solve this, we now check the next token's left binding power. If it's unset, then it's the beginning of an expression and we should parse it as a regular argument. Otherwise we'll check that it's not going to modify this expression like `if` or `and`. In that case we shouldn't parse it.