### PR TITLE
Fix parsing module names starting with `::`

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5990,10 +5990,7 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
       parser_lex(parser);
 
       yp_token_t module_keyword = parser->previous;
-      yp_node_t *name;
-
-      expect(parser, YP_TOKEN_CONSTANT, "Expected to find a module name after `module`.");
-      name = yp_node_constant_read_create(parser, &parser->previous);
+      yp_node_t *name = parse_expression(parser, BINDING_POWER_CALL, "Expected to find a module name after `module`.");
 
       // If we can recover from a syntax error that occurred while parsing the
       // name of the module, then we'll handle that here.

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -24,15 +24,18 @@ class ErrorsTest < Test::Unit::TestCase
         [ModuleNode(
            Scope([]),
            KEYWORD_MODULE("module"),
-           ConstantRead(MISSING("")),
+           MissingNode(),
            Statements([]),
-           MISSING("")
+           KEYWORD_END("end")
          )]
       ),
-      KEYWORD_END("end")
+      MISSING("")
     )
 
-    assert_errors expected, "module Parent module end", ["Expected to find a module name after `module`."]
+    assert_errors expected, "module Parent module end", [
+      "Expected to find a module name after `module`.",
+      "Expected `end` to close `module` statement.",
+    ]
   end
 
   test "for loops index missing" do

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2567,6 +2567,17 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "module A a = 1 end"
   end
 
+  test "module constant path" do
+    expected = ModuleNode(
+      Scope([]),
+      KEYWORD_MODULE("module"),
+      ConstantPathNode(nil, COLON_COLON("::"), ConstantRead(CONSTANT("Foo"))),
+      Statements([]),
+      KEYWORD_END("end")
+    )
+    assert_parses expected, "module ::Foo end"
+  end
+
   test "module with rescue, else ensure" do
     expected = ModuleNode(
       Scope([IDENTIFIER("x")]),


### PR DESCRIPTION
Fixes parsing:

```ruby
module ::Foo
end
```