### PR TITLE
Simplify args parsing

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -173,6 +173,7 @@ typedef enum {
   YP_CONTEXT_CLASS,          // a class declaration
   YP_CONTEXT_CASE_WHEN,      // a case when statements
   YP_CONTEXT_DEF,            // a method definition
+  YP_CONTEXT_PREDICATE,      // a predicate inside an if/elsif/unless statement
   YP_CONTEXT_IF,             // an if statement
   YP_CONTEXT_ELSIF,          // an elsif clause
   YP_CONTEXT_UNLESS,         // an unless statement

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -31,6 +31,7 @@ debug_context(yp_context_t context) {
     case YP_CONTEXT_MODULE: return "MODULE";
     case YP_CONTEXT_PARENS: return "PARENS";
     case YP_CONTEXT_POSTEXE: return "POSTEXE";
+    case YP_CONTEXT_PREDICATE: return "PREDICATE";
     case YP_CONTEXT_PREEXE: return "PREEXE";
     case YP_CONTEXT_RESCUE: return "RESCUE";
     case YP_CONTEXT_RESCUE_ELSE: return "RESCUE ELSE";
@@ -3726,6 +3727,8 @@ context_terminator(yp_context_t context, yp_token_t *token) {
       return token->type == YP_TOKEN_KEYWORD_ENSURE || token->type == YP_TOKEN_KEYWORD_END;
     case YP_CONTEXT_LAMBDA_BRACES:
       return token->type == YP_TOKEN_BRACE_RIGHT;
+    case YP_CONTEXT_PREDICATE:
+      return token->type == YP_TOKEN_KEYWORD_THEN || token->type == YP_TOKEN_NEWLINE || token->type == YP_TOKEN_SEMICOLON;
   }
 
   return false;
@@ -4270,31 +4273,25 @@ parse_assoc(yp_parser_t *parser, yp_node_t *hash, yp_token_type_t terminator) {
   return true;
 }
 
-static inline
-bool should_parse_argument(yp_parser_t *parser, yp_token_type_t terminator) {
-  binding_power_t binding_power = binding_powers[parser->current.type].left;
-  return !match_any_type_p(parser, 6, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) &&
-    !context_terminator(parser->current_context->context, &parser->current) &&
-    (binding_power == BINDING_POWER_UNSET || binding_power >= BINDING_POWER_RANGE);
-}
-
 // Parse a list of arguments.
 static void
 parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t terminator) {
+  binding_power_t binding_power = binding_powers[parser->current.type].left;
+
+  // First we need to check if the next token is one that could be the start of
+  // an argument. If it's not, then we can just return.
+  if (
+    match_any_type_p(parser, 2, terminator, YP_TOKEN_EOF) ||
+    (binding_power != BINDING_POWER_UNSET && binding_power < BINDING_POWER_RANGE) ||
+    context_terminator(parser->current_context->context, &parser->current)
+  ) {
+    return;
+  }
+
   bool parsed_double_splat_argument = false;
   bool parsed_block_argument = false;
 
-  while (should_parse_argument(parser, terminator)) {
-    if (yp_arguments_node_size(arguments) > 0) {
-      expect(parser, YP_TOKEN_COMMA, "Expected a ',' to delimit arguments.");
-    }
-
-    // finish with trailing comma in argument list.
-    if (match_any_type_p(parser, 5, terminator, YP_TOKEN_KEYWORD_DO, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON, YP_TOKEN_EOF) ||
-        context_terminator(parser->current_context->context, &parser->current)) {
-      break;
-    }
-
+  while (!match_type_p(parser, YP_TOKEN_EOF)) {
     if (parsed_block_argument) {
       yp_diagnostic_list_append(&parser->error_list, "Unexpected argument after block argument.", parser->current.start - parser->start);
     }
@@ -4394,9 +4391,23 @@ parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t termi
       }
     }
 
-    if (terminator != YP_TOKEN_EOF) accept(parser, YP_TOKEN_NEWLINE);
     yp_arguments_node_append(arguments, argument);
-    if (argument->type == YP_NODE_MISSING_NODE) break;
+
+    // If parsing the argument failed, we need to stop parsing arguments.
+    if (argument->type == YP_NODE_MISSING_NODE || parser->recovering) break;
+
+    // If the terminator of these arguments is not EOF, then we have a specific
+    // token we're looking for. In that case we can accept a newline here
+    // because it is not functioning as a statement terminator.
+    if (terminator != YP_TOKEN_EOF) accept(parser, YP_TOKEN_NEWLINE);
+
+    // If there is no comma at the end of the argument list then we're done
+    // parsing arguments and can break out of this loop.
+    if (!accept(parser, YP_TOKEN_COMMA)) break;
+
+    // If we hit the terminator, then that means we have a trailing comma so we
+    // can accept that output as well.
+    if (match_type_p(parser, terminator)) break;
   }
 }
 
@@ -4805,8 +4816,10 @@ static inline yp_node_t *
 parse_conditional(yp_parser_t *parser, yp_context_t context) {
   yp_token_t keyword = parser->previous;
 
+  context_push(parser, YP_CONTEXT_PREDICATE);
   yp_node_t *predicate = parse_expression(parser, BINDING_POWER_COMPOSITION, "Expected to find a predicate for the conditional.");
   accept_any(parser, 3, YP_TOKEN_KEYWORD_THEN, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
+  context_pop(parser);
 
   yp_node_t *statements = parse_statements(parser, context);
   accept_any(parser, 2, YP_TOKEN_NEWLINE, YP_TOKEN_SEMICOLON);
@@ -6845,7 +6858,6 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, binding_power_t pre
 
       yp_node_t *predicate = parse_expression(parser, binding_power, "Expected a predicate after 'if'");
       yp_token_t end_keyword = not_provided(parser);
-
       return yp_node_if_node_create(parser, &token, predicate, statements, NULL, &end_keyword);
     }
     case YP_TOKEN_KEYWORD_UNLESS: {

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -311,31 +311,38 @@ class ErrorsTest < Test::Unit::TestCase
 
   test "splat argument after keyword argument" do
     expected = CallNode(
-      nil,
-      nil,
-      IDENTIFIER("a"),
-      PARENTHESIS_LEFT("("),
-      ArgumentsNode(
-        [HashNode(
-           nil,
-           [AssocNode(
+      CallNode(
+        nil,
+        nil,
+        IDENTIFIER("a"),
+        PARENTHESIS_LEFT("("),
+        ArgumentsNode([
+          HashNode(
+            nil,
+            [AssocNode(
               SymbolNode(nil, LABEL("foo"), LABEL_END(":")),
               CallNode(nil, nil, IDENTIFIER("bar"), nil, nil, nil, nil, "bar"),
               nil
             )],
-           nil
-         ),
-         StarNode(
-           STAR("*"),
-           CallNode(nil, nil, IDENTIFIER("args"), nil, nil, nil, nil, "args")
-         )]
+            nil
+          )
+        ]),
+        MISSING(""),
+        nil,
+        "a"
       ),
-      PARENTHESIS_RIGHT(")"),
       nil,
-      "a"
+      STAR("*"),
+      nil,
+      ArgumentsNode([
+        CallNode(nil, nil, IDENTIFIER("args"), nil, nil, nil, nil, "args")
+      ]),
+      nil,
+      nil,
+      "*"
     )
 
-    assert_errors expected, "a(foo: bar, *args)", ["Expected a key in the hash literal.", "Expected a ',' to delimit arguments."]
+    assert_errors expected, "a(foo: bar, *args)", ["Expected a key in the hash literal.", "Expected a ')' to close the argument list."]
   end
 
   private


### PR DESCRIPTION
For arguments, we only need to check the subsequent tokens to determine if we should _start_ parsing arguments. For continuing to parse, we should check for the presence of a comma. This hopefully simplifies our logic and makes it a little easier to reason about.