### PR TITLE
Emit error message for module definition in method body

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6205,6 +6205,11 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
       yp_parser_scope_pop(parser);
 
       expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `module` statement.");
+
+      if (parser->current_context->context == YP_CONTEXT_DEF) {
+        yp_diagnostic_list_append(&parser->error_list, "Module definition in method body", parser->current.start - parser->start);
+      }
+
       return yp_node_module_node_create(parser, scope, &module_keyword, name, statements, &parser->previous);
     }
     case YP_TOKEN_KEYWORD_NIL:

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3775,6 +3775,18 @@ context_pop(yp_parser_t *parser) {
   }
 }
 
+static bool
+context_p(yp_parser_t *parser, yp_context_t context) {
+  yp_context_node_t *context_node = parser->current_context;
+
+  while (context_node != NULL) {
+    if (context_node->context == context) return true;
+    context_node = context_node->prev;
+  }
+
+  return false;
+}
+
 // These are the various precedence rules. Because we are using a Pratt parser,
 // they are named binding power to represent the manner in which nodes are bound
 // together in the stack.
@@ -6206,7 +6218,7 @@ parse_expression_prefix(yp_parser_t *parser, binding_power_t binding_power) {
 
       expect(parser, YP_TOKEN_KEYWORD_END, "Expected `end` to close `module` statement.");
 
-      if (parser->current_context->context == YP_CONTEXT_DEF) {
+      if (context_p(parser, YP_CONTEXT_DEF)) {
         yp_diagnostic_list_append(&parser->error_list, "Module definition in method body", parser->current.start - parser->start);
       }
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -351,6 +351,32 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expected, "a(foo: bar, *args)", ["Expected a key in the hash literal.", "Unexpected splat argument after double splat."]
   end
 
+  test "module definition in method body" do
+    expected = DefNode(
+      IDENTIFIER("foo"),
+      nil,
+      ParametersNode([], [], nil, [], nil, nil),
+      Statements(
+        [ModuleNode(
+           Scope([]),
+           KEYWORD_MODULE("module"),
+           ConstantRead(CONSTANT("A")),
+           Statements([]),
+           KEYWORD_END("end")
+         )]
+      ),
+      Scope([]),
+      Location(),
+      nil,
+      nil,
+      nil,
+      nil,
+      Location()
+    )
+
+    assert_errors expected, "def foo;module A;end;end", ["Module definition in method body"]
+  end
+
   private
 
   def assert_errors(expected, source, errors)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -377,6 +377,54 @@ class ErrorsTest < Test::Unit::TestCase
     assert_errors expected, "def foo;module A;end;end", ["Module definition in method body"]
   end
 
+  test "module definition in method body within block" do
+    expected = DefNode(
+      IDENTIFIER("foo"),
+      nil,
+      ParametersNode([], [], nil, [], nil, nil),
+      Statements(
+        [CallNode(
+           nil,
+           nil,
+           IDENTIFIER("bar"),
+           nil,
+           nil,
+           nil,
+           BlockNode(
+             KEYWORD_DO("do"),
+             nil,
+             Statements(
+               [ModuleNode(
+                  Scope([]),
+                  KEYWORD_MODULE("module"),
+                  ConstantRead(CONSTANT("Foo")),
+                  Statements([]),
+                  KEYWORD_END("end")
+                )]
+             ),
+             KEYWORD_END("end")
+           ),
+           "bar"
+         )]
+      ),
+      Scope([]),
+      Location(),
+      nil,
+      nil,
+      nil,
+      nil,
+      Location()
+    )
+
+    assert_errors expected, "
+      def foo
+        bar do
+          module Foo;end
+        end
+      end
+    ", ["Module definition in method body"]
+  end
+
   private
 
   def assert_errors(expected, source, errors)


### PR DESCRIPTION
Ruby does not allow defining a module in a method body https://github.com/ruby/ruby/blob/22d944c8b76be04dc437100c46626db5fe9dd7f0/parse.y#L3514

This PR emits an error message for this case.