### PR TITLE
Replace a lot of places we're looping with strspn

### DIFF
--- a/src/util/yp_strspn.c
+++ b/src/util/yp_strspn.c
@@ -1,0 +1,53 @@
+#include "yp_strspn.h"
+
+const char yp_strspn_decimal_number_table[128] = {
+  ['0'] = 1,
+  ['1'] = 1,
+  ['2'] = 1,
+  ['3'] = 1,
+  ['4'] = 1,
+  ['5'] = 1,
+  ['6'] = 1,
+  ['7'] = 1,
+  ['8'] = 1,
+  ['9'] = 1,
+  ['_'] = 1
+};
+
+const char yp_strspn_whitespace_table[128] = {
+  [' '] = 1,
+  ['\t'] = 1,
+  ['\v'] = 1,
+  ['\f'] = 1,
+  ['\r'] = 1,
+  ['\n'] = 1
+};
+
+// Returns the number of characters at the start of the string string that are
+// decimal numbers or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_decimal_number(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && yp_strspn_decimal_number_table[(unsigned char) string[size]]) size++;
+  return size;
+}
+
+// Returns the number of characters at the start of the string string that are
+// whitespace excluding newline characters. Disallows searching past the given
+// maximum number of characters.
+size_t
+yp_strspn_inline_whitespace(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && string[size] != '\n' && yp_strspn_whitespace_table[(unsigned char) string[size]]) size++;
+  return size;
+}
+
+// Returns the number of characters at the start of the string string that are
+// whitespace. Disallows searching past the given maximum number of characters.
+size_t
+yp_strspn_whitespace(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && yp_strspn_whitespace_table[(unsigned char) string[size]]) size++;
+  return size;
+}

--- a/src/util/yp_strspn.h
+++ b/src/util/yp_strspn.h
@@ -1,0 +1,23 @@
+#ifndef YP_STRSPN_H
+#define YP_STRSPN_H
+
+#include <stddef.h>
+
+// Returns the number of characters at the start of the string string that are
+// decimal numbers or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_decimal_number(const char *string, size_t maximum);
+
+// Returns the number of characters at the start of the string string that are
+// whitespace excluding newline characters. Disallows searching past the given
+// maximum number of characters.
+size_t
+yp_strspn_inline_whitespace(const char *string, size_t maximum);
+
+// Returns the number of characters at the start of the string string that are
+// whitespace. Disallows searching past the given maximum number of characters.
+size_t
+yp_strspn_whitespace(const char *string, size_t maximum);
+
+#endif

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1575,11 +1575,7 @@ lex_optional_float_suffix(yp_parser_t *parser) {
   if (*parser->current.end == '.') {
     if ((parser->current.end + 1 < parser->end) && char_is_decimal_number(parser->current.end[1])) {
       parser->current.end += 2;
-      while (char_is_decimal_number(*parser->current.end)) {
-        parser->current.end++;
-        match(parser, '_');
-      }
-
+      parser->current.end += strspn(parser->current.end, "0123456789_");
       type = YP_TOKEN_FLOAT;
     } else {
       // If we had a . and then something else, then it's not a float suffix on
@@ -1595,11 +1591,7 @@ lex_optional_float_suffix(yp_parser_t *parser) {
 
     if (char_is_decimal_number(*parser->current.end)) {
       parser->current.end++;
-      while (char_is_decimal_number(*parser->current.end)) {
-        parser->current.end++;
-        match(parser, '_');
-      }
-
+      parser->current.end += strspn(parser->current.end, "0123456789_");
       type = YP_TOKEN_FLOAT;
     } else {
       return YP_TOKEN_INVALID;
@@ -1618,27 +1610,30 @@ lex_numeric_prefix(yp_parser_t *parser) {
       // 0d1111 is a decimal number
       case 'd':
       case 'D':
-        if (!char_is_decimal_number(*++parser->current.end)) return YP_TOKEN_INVALID;
-        while (char_is_decimal_number(*parser->current.end)) {
-          parser->current.end++;
-          match(parser, '_');
+        if (!char_is_decimal_number(*++parser->current.end)) {
+          yp_diagnostic_list_append(&parser->error_list, "invalid decimal number", parser->current.start - parser->start);
         }
+
+        parser->current.end += strspn(parser->current.end, "0123456789_");
         break;
 
       // 0b1111 is a binary number
       case 'b':
       case 'B':
-        if (!char_is_binary_number(*++parser->current.end)) return YP_TOKEN_INVALID;
-        while (char_is_binary_number(*parser->current.end)) {
-          parser->current.end++;
-          match(parser, '_');
+        if (!char_is_binary_number(*++parser->current.end)) {
+          yp_diagnostic_list_append(&parser->error_list, "invalid binary number", parser->current.start - parser->start);
         }
+
+        parser->current.end += strspn(parser->current.end, "01_");
         break;
 
       // 0o1111 is an octal number
       case 'o':
       case 'O':
-        if (!char_is_octal_number(*++parser->current.end)) return YP_TOKEN_INVALID;
+        if (!char_is_octal_number(*++parser->current.end)) {
+          yp_diagnostic_list_append(&parser->error_list, "invalid octal number", parser->current.start - parser->start);
+        }
+
         // fall through
 
       // 01111 is an octal number
@@ -1651,21 +1646,17 @@ lex_numeric_prefix(yp_parser_t *parser) {
       case '5':
       case '6':
       case '7':
-        match(parser, '_');
-        while (char_is_octal_number(*parser->current.end)) {
-          parser->current.end++;
-          match(parser, '_');
-        }
+        parser->current.end += strspn(parser->current.end, "01234567_");
         break;
 
       // 0x1111 is a hexadecimal number
       case 'x':
       case 'X':
-        if (!char_is_hexadecimal_number(*++parser->current.end)) return YP_TOKEN_INVALID;
-        while (char_is_hexadecimal_number(*parser->current.end)) {
-          parser->current.end++;
-          match(parser, '_');
+        if (!char_is_hexadecimal_number(*++parser->current.end)) {
+          yp_diagnostic_list_append(&parser->error_list, "invalid hexadecimal number", parser->current.start - parser->start);
         }
+
+        parser->current.end += strspn(parser->current.end, "0123456789abcdefABCDEF_");
         break;
 
       // 0.xxx is a float
@@ -1684,11 +1675,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
   } else {
     // If it didn't start with a 0, then we'll lex as far as we can into a
     // decimal number.
-    match(parser, '_');
-    while (char_is_decimal_number(*parser->current.end)) {
-      parser->current.end++;
-      match(parser, '_');
-    }
+    parser->current.end += strspn(parser->current.end, "0123456789_");
 
     // Afterward, we'll lex as far as we can into an optional float suffix.
     type = lex_optional_float_suffix(parser);
@@ -1696,7 +1683,10 @@ lex_numeric_prefix(yp_parser_t *parser) {
 
   // If the last character that we consumed was an underscore, then this is
   // actually an invalid integer value, and we should return an invalid token.
-  if (parser->current.end[-1] == '_') return YP_TOKEN_INVALID;
+  if (parser->current.end[-1] == '_') {
+    yp_diagnostic_list_append(&parser->error_list, "number literal cannot end with a `_`", (parser->current.end - 1) - parser->start);
+  }
+
   return type;
 }
 
@@ -1704,10 +1694,8 @@ static yp_token_type_t
 lex_numeric(yp_parser_t *parser) {
   yp_token_type_t type = lex_numeric_prefix(parser);
 
-  if (type != YP_TOKEN_INVALID) {
-    if (match(parser, 'r')) type = YP_TOKEN_RATIONAL_NUMBER;
-    if (match(parser, 'i')) type = YP_TOKEN_IMAGINARY_NUMBER;
-  }
+  if (match(parser, 'r')) type = YP_TOKEN_RATIONAL_NUMBER;
+  if (match(parser, 'i')) type = YP_TOKEN_IMAGINARY_NUMBER;
 
   return type;
 }
@@ -1750,9 +1738,7 @@ lex_global_variable(yp_parser_t *parser) {
     case '7':
     case '8':
     case '9':
-      do {
-        parser->current.end++;
-      } while (parser->current.end < parser->end && char_is_decimal_number(*parser->current.end));
+      parser->current.end += strspn(parser->current.end, "0123456789");
       return YP_TOKEN_NTH_REFERENCE;
 
     case '-':
@@ -2124,10 +2110,10 @@ lex_question_mark(yp_parser_t *parser) {
           // \u{nnnn ...}   Unicode character(s), where each nnnn is 1-6 hexadecimal digits ([0-9a-fA-F])
           parser->current.end++;
           if (match(parser, '{')) {
-            while (parser->current.end < parser->end && char_is_whitespace(*parser->current.end)) parser->current.end++;
+            parser->current.end += strspn(parser->current.end, " \t\v\f\r\n");
             while (!match(parser, '}')) {
-              while (parser->current.end < parser->end && char_is_hexadecimal_number(*parser->current.end)) parser->current.end++;
-              while (parser->current.end < parser->end && char_is_whitespace(*parser->current.end)) parser->current.end++;
+              parser->current.end += strspn(parser->current.end, "0123456789abcdefABCDEF");
+              parser->current.end += strspn(parser->current.end, " \t\v\f\r\n");
             }
           } else {
             for (size_t index = 0; index < 4; index++) {
@@ -3187,7 +3173,8 @@ lex_token_type(yp_parser_t *parser) {
 
       // Otherwise, we'll parse until the end of the line and return a line of
       // embedded documentation.
-      while ((parser->current.end < parser->end) && (*parser->current.end++ != '\n'));
+      const char *newline = memchr(parser->current.end, '\n', parser->end - parser->current.end);
+      parser->current.end = newline == NULL ? parser->end : newline + 1;
 
       // If we've still got content, then we'll return a line of embedded
       // documentation.
@@ -3342,26 +3329,8 @@ lex_token_type(yp_parser_t *parser) {
 
             // Since we've hit the terminator of the regular expression, we now
             // need to parse the options.
-            bool options = true;
             parser->current.end = breakpoint + 1;
-
-            while (options) {
-              switch (*parser->current.end) {
-                case 'e':
-                case 'i':
-                case 'm':
-                case 'n':
-                case 'o':
-                case 's':
-                case 'u':
-                case 'x':
-                  parser->current.end++;
-                  break;
-                default:
-                  options = false;
-                  break;
-              }
-            }
+            parser->current.end += strspn(parser->current.end, "eimnosux");
 
             lex_mode_pop(parser);
             lex_state_set(parser, YP_LEX_STATE_END);
@@ -3456,9 +3425,7 @@ lex_token_type(yp_parser_t *parser) {
       if (parser->current.start[-1] == '\n') {
         const char *start = parser->current.start;
         if (parser->lex_modes.current->as.heredoc.indent != YP_HEREDOC_INDENT_NONE) {
-          while (start < parser->end && char_is_non_newline_whitespace(*start)) {
-            start++;
-          }
+          start += strspn(start, " \t\f\r\v");
         }
 
         if (strncmp(start, ident_start, ident_length) == 0) {
@@ -3498,9 +3465,7 @@ lex_token_type(yp_parser_t *parser) {
           case '\n': {
             const char *start = breakpoint + 1;
             if (parser->lex_modes.current->as.heredoc.indent != YP_HEREDOC_INDENT_NONE) {
-              while (start < parser->end && char_is_non_newline_whitespace(*start)) {
-                start++;
-              }
+              start += strspn(start, " \t\f\r\v");
             }
 
             // If we have hit a newline that is followed by a valid terminator,
@@ -3611,29 +3576,21 @@ static yp_encoding_t yp_encoding_utf_8 = {
 static void
 parser_lex_magic_comments(yp_parser_t *parser) {
   const char *start = parser->current.start + 1;
-  while (char_is_non_newline_whitespace(*start) && start < parser->end) {
-    start++;
-  }
+  start += strspn(start, " \t\f\r\v");
 
   if (strncmp(start, "-*-", 3) == 0) {
     start += 3;
-    while (char_is_non_newline_whitespace(*start) && start < parser->end) {
-      start++;
-    }
+    start += strspn(start, " \t\f\r\v");
   }
 
   // There is a lot TODO here to make it more accurately reflect encoding
   // parsing, but for now this gets us closer.
   if (strncmp(start, "encoding:", 9) == 0) {
     start += 9;
-    while (char_is_non_newline_whitespace(*start) && start < parser->end) {
-      start++;
-    }
+    start += strspn(start, " \t\f\r\v");
 
-    const char *end = start;
-    while (!char_is_whitespace(*end) && end < parser->end) {
-      end++;
-    }
+    const char *end = strpbrk(start, " \t\f\r\v\n");
+    end = end == NULL ? parser->end : end;
     size_t width = end - start;
 
     // First, we're going to call out to a user-defined callback if one was

--- a/src/yarp.h
+++ b/src/yarp.h
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "util/yp_buffer.h"
+#include "util/yp_strspn.h"
 #include "ast.h"
 #include "diagnostic.h"
 #include "pack.h"


### PR DESCRIPTION
A lot of places we're currently looping through the input can be made more clear by using `strspn`. We can make some specialized `strspn` calls to use lookup tables with known charsets for common cases.

Also, we shouldn't return invalid tokens for numbers if they are malformed, we should just add errors to the list. Folks are going to be typing numbers from the beginning like `0x` and we know it's _going_ to be a number, so we shouldn't hurt our ability to recover.