### PR TITLE
Heredocs with comment on the same line

### DIFF
--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -166,24 +166,24 @@ module YARP
       def location
         self[0]
       end
-  
+
       def event
         self[1]
       end
-  
+
       def value
         self[2]
       end
-  
+
       def state
         self[3]
       end
-  
+
       def state=(val)
         self[3] = val
       end
     end
-  
+
     # Ripper doesn't include the rest of the token in the event, so we need to
     # trim it down to just the content on the first line when comparing.
     class EndContentToken < Token
@@ -191,7 +191,7 @@ module YARP
         [self[0], self[1], self[2][0..self[2].index("\n")], self[3]] == other
       end
     end
-  
+
     # It is extremely non obvious which state the parser is in when comments get
     # dispatched. Because of this we don't both comparing state when comparing
     # against other comment tokens.
@@ -407,7 +407,7 @@ module YARP
             # output the state as the previous state, solely for the sake of
             # comparison.
             previous_token = result_value[index - 1][0]
-            lex_state = 
+            lex_state =
               if RIPPER.fetch(previous_token.type) == :on_embexpr_end
                 # If the previous token is embexpr_end, then we have to do even
                 # more processing. The end of an embedded expression sets the
@@ -459,7 +459,7 @@ module YARP
           tokens << token
 
           case event
-          when :on_nl, :on_ignored_nl
+          when :on_nl, :on_ignored_nl, :on_comment
             heredocs.each do |heredoc|
               tokens.concat(heredoc.to_a)
             end

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -2778,6 +2778,19 @@ class ParseTest < Test::Unit::TestCase
     assert_parses expected, "<<-FIRST + <<-SECOND\n  a\nFIRST\n  b\nSECOND\n"
   end
 
+  test "heredocs with comment on the same line" do
+    expected = HeredocNode(
+      HEREDOC_START("<<-EOF"),
+      [
+        StringNode(nil, STRING_CONTENT("  a\n"), nil, "  a\n"),
+      ],
+      HEREDOC_END("EOF\n"),
+      0
+    )
+
+    assert_parses expected, "<<-EOF #comment\n  a\nEOF\n"
+  end
+
   test "identifier" do
     assert_parses CallNode(nil, nil, IDENTIFIER("a"), nil, nil, nil, nil, "a"), "a"
   end


### PR DESCRIPTION
Closes https://github.com/Shopify/yarp/issues/404

I believe the parsing of heredocs with comments on the initialiser line was already correct. I only made `lex_compat` generate the correct tokens for the comparison with ripper.