### PR TITLE
Endless method binding power (do not merge)

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6260,7 +6260,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
         context_push(parser, YP_CONTEXT_DEF);
         statements = yp_node_statements_create(parser);
 
-        yp_node_t *statement = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected to be able to parse body of endless method definition.");
+        yp_node_t *statement = parse_expression(parser, YP_BINDING_POWER_STATEMENT, "Expected to be able to parse body of endless method definition.");
         yp_node_list_append(parser, statements, &statements->as.statements.body, statement);
 
         context_pop(parser);


### PR DESCRIPTION
For the example code:

```ruby
public def test = foo and bar
```

Current we get the AST:

```ruby
Program(
  Scope([]),
  Statements(
    [AndNode(
        CallNode(
          nil,
          nil,
          IDENTIFIER("public"),
          nil,
          ArgumentsNode(
            [DefNode(
              IDENTIFIER("test"),
              nil,
              ParametersNode([], [], nil, [], nil, nil),
              Statements([CallNode(nil, nil, IDENTIFIER("foo"), nil, nil, nil, nil, "foo")]),
              Scope([]),
              (7..10),
              nil,
              nil,
              nil,
              (16..17),
              nil
            )]
          ),
          nil,
          nil,
          "public"
        ),
        CallNode(nil, nil, IDENTIFIER("bar"), nil, nil, nil, nil, "bar"),
        KEYWORD_AND("and")
      )]
  )
)
```

by changing the binding power that we're parsing the endless method definition with, we instead get

```ruby
Program(
  Scope([]),
  Statements(
    [CallNode(
        nil,
        nil,
        IDENTIFIER("public"),
        nil,
        ArgumentsNode(
          [DefNode(
            IDENTIFIER("test"),
            nil,
            ParametersNode([], [], nil, [], nil, nil),
            Statements([AndNode(CallNode(nil, nil, IDENTIFIER("foo"), nil, nil, nil, nil, "foo"), CallNode(nil, nil, IDENTIFIER("bar"), nil, nil, nil, nil, "bar"), KEYWORD_AND("and"))]),
            Scope([]),
            (7..10),
            nil,
            nil,
            nil,
            (16..17),
            nil
          )]
        ),
        nil,
        nil,
        "public"
      )]
  )
)
```