### PR TITLE
More bug fixes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -349,7 +349,7 @@ nodes:
       - name: key
         type: node
       - name: value
-        type: node
+        type: node?
       - name: operator
         type: token?
     comment: |

--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -111,6 +111,7 @@ module YARP
       KEYWORD_WHILE: :on_kw,
       KEYWORD_YIELD: :on_kw,
       LABEL: :on_label,
+      LABEL_END: :on_label_end,
       LAMBDA_BEGIN: :on_tlambeg,
       LESS: :on_op,
       LESS_EQUAL: :on_op,

--- a/src/parser.h
+++ b/src/parser.h
@@ -133,6 +133,10 @@ typedef struct yp_lex_mode {
 
       // Whether or not interpolation is allowed in this string.
       bool interpolation;
+
+      // Whether or not at the end of the string we should allow a :, which
+      // would indicate this was a dynamic symbol instead of a string.
+      bool label_allowed;
     } string;
 
     struct {

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -244,10 +244,15 @@ yp_regexp_parse_character_set(yp_regexp_parser_t *parser) {
 // A left bracket can either mean a POSIX class or a character set.
 static bool
 yp_regexp_parse_lbracket(yp_regexp_parser_t *parser) {
+  const char *reset = parser->cursor;
+
   if ((parser->cursor + 2 < parser->end) && parser->cursor[0] == '[' && parser->cursor[1] == ':') {
     parser->cursor++;
-    return yp_regexp_parse_posix_class(parser);
+    if (yp_regexp_parse_posix_class(parser)) return true;
+
+    parser->cursor = reset;
   }
+
   return yp_regexp_parse_character_set(parser);
 }
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2134,7 +2134,7 @@ lex_interpolation(yp_parser_t *parser, const char *pound) {
         // At this point we're sure that we've either hit an embedded instance
         // or class variable. In this case we'll first need to check if we've
         // already consumed content.
-        if (pound > parser->current.end) {
+        if (pound > parser->current.start) {
           parser->current.end = pound;
           lex_state_set(parser, YP_LEX_STATE_BEG);
           return YP_TOKEN_STRING_CONTENT;
@@ -2158,7 +2158,7 @@ lex_interpolation(yp_parser_t *parser, const char *pound) {
       // In this case we've hit an embedded global variable. First check to see
       // if we've already consumed content. If we have, then we need to return
       // that content as string content first.
-      if (pound > parser->current.end) {
+      if (pound > parser->current.start) {
         parser->current.end = pound;
         lex_state_set(parser, YP_LEX_STATE_BEG);
         return YP_TOKEN_STRING_CONTENT;
@@ -2176,7 +2176,7 @@ lex_interpolation(yp_parser_t *parser, const char *pound) {
       // In this case it's the start of an embedded expression. If we have
       // already consumed content, then we need to return that content as string
       // content first.
-      if (pound > parser->current.end) {
+      if (pound > parser->current.start) {
         parser->current.end = pound;
         return YP_TOKEN_STRING_CONTENT;
       }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -299,12 +299,21 @@ yp_array_node_close_set(yp_node_t *node, const yp_token_t *closing) {
 static yp_node_t *
 yp_assoc_node_create(yp_parser_t *parser, yp_node_t *key, const yp_token_t *operator, yp_node_t *value) {
   yp_node_t *node = yp_node_alloc(parser);
+  const char *end;
+
+  if (value != NULL) {
+    end = value->location.end;
+  } else if (operator->type != YP_TOKEN_NOT_PROVIDED) {
+    end = operator->end;
+  } else {
+    end = key->location.end;
+  }
 
   *node = (yp_node_t) {
     .type = YP_NODE_ASSOC_NODE,
     .location = {
       .start = key->location.start,
-      .end = value->location.end
+      .end = end
     },
     .as.assoc_node = {
       .key = key,
@@ -954,6 +963,48 @@ yp_integer_node_create(yp_parser_t *parser, const yp_token_t *token) {
   return node;
 }
 
+// Allocate and initialize a new InterpolatedStringNode node.
+static yp_node_t *
+yp_interpolated_string_node_create(yp_parser_t *parser, const yp_token_t *opening, const yp_node_list_t *parts, const yp_token_t *closing) {
+  yp_node_t *node = yp_node_alloc(parser);
+
+  *node = (yp_node_t) {
+    .type = YP_NODE_INTERPOLATED_STRING_NODE,
+    .location = {
+      .start = opening->start,
+      .end = closing->end,
+    },
+    .as.interpolated_string_node = {
+      .opening = *opening,
+      .parts = *parts,
+      .closing = *closing
+    }
+  };
+
+  return node;
+}
+
+// Allocate and initialize a new InterpolatedSymbolNode node.
+static yp_node_t *
+yp_interpolated_symbol_node_create(yp_parser_t *parser, const yp_token_t *opening, const yp_node_list_t *parts, const yp_token_t *closing) {
+  yp_node_t *node = yp_node_alloc(parser);
+
+  *node = (yp_node_t) {
+    .type = YP_NODE_INTERPOLATED_SYMBOL_NODE,
+    .location = {
+      .start = opening->start,
+      .end = closing->end,
+    },
+    .as.interpolated_symbol_node = {
+      .opening = *opening,
+      .parts = *parts,
+      .closing = *closing
+    }
+  };
+
+  return node;
+}
+
 // Allocate and initialize a new NextNode node.
 static yp_node_t *
 yp_next_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_node_t *arguments) {
@@ -1227,6 +1278,15 @@ yp_source_line_node_create(yp_parser_t *parser, const yp_token_t *token) {
   };
 
   return node;
+}
+
+// Check if the given node is a label in a hash.
+static bool
+yp_symbol_node_label_p(yp_node_t *node) {
+  return (
+    (node->type == YP_NODE_SYMBOL_NODE && node->as.symbol_node.closing.type == YP_TOKEN_LABEL_END) ||
+    (node->type == YP_NODE_INTERPOLATED_SYMBOL_NODE && node->as.interpolated_symbol_node.closing.type == YP_TOKEN_LABEL_END)
+  );
 }
 
 // Allocate and initialize a new SuperNode node.
@@ -2797,7 +2857,8 @@ lex_token_type(yp_parser_t *parser) {
             .as.string.incrementor = '\0',
             .as.string.terminator = '"',
             .as.string.nesting = 0,
-            .as.string.interpolation = true
+            .as.string.interpolation = true,
+            .as.string.label_allowed = (lex_state_p(parser, YP_LEX_STATE_LABEL | YP_LEX_STATE_ENDFN) && !previous_command_start) || lex_state_arg_p(parser)
           };
 
           lex_mode_push(parser, lex_mode);
@@ -2826,7 +2887,8 @@ lex_token_type(yp_parser_t *parser) {
             .as.string.incrementor = '\0',
             .as.string.terminator = '`',
             .as.string.nesting = 0,
-            .as.string.interpolation = true
+            .as.string.interpolation = true,
+            .as.string.label_allowed = false
           };
 
           lex_mode_push(parser, lex_mode);
@@ -2840,7 +2902,8 @@ lex_token_type(yp_parser_t *parser) {
             .as.string.incrementor = '\0',
             .as.string.terminator = '\'',
             .as.string.nesting = 0,
-            .as.string.interpolation = false
+            .as.string.interpolation = false,
+            .as.string.label_allowed = (lex_state_p(parser, YP_LEX_STATE_LABEL | YP_LEX_STATE_ENDFN) && !previous_command_start) || lex_state_arg_p(parser)
           };
 
           lex_mode_push(parser, lex_mode);
@@ -3021,7 +3084,8 @@ lex_token_type(yp_parser_t *parser) {
               .as.string.incrementor = '\0',
               .as.string.terminator = *parser->current.end,
               .as.string.nesting = 0,
-              .as.string.interpolation = *parser->current.end == '"'
+              .as.string.interpolation = *parser->current.end == '"',
+              .as.string.label_allowed = false
             };
 
             lex_mode_push(parser, lex_mode);
@@ -3102,7 +3166,8 @@ lex_token_type(yp_parser_t *parser) {
                 .as.string.incrementor = incrementor(*parser->current.end),
                 .as.string.terminator = terminator(*parser->current.end),
                 .as.string.nesting = 0,
-                .as.string.interpolation = true
+                .as.string.interpolation = true,
+                .as.string.label_allowed = false
               });
 
               parser->current.end++;
@@ -3158,7 +3223,8 @@ lex_token_type(yp_parser_t *parser) {
                   .as.string.incrementor = incrementor(*parser->current.end),
                   .as.string.terminator = terminator(*parser->current.end),
                   .as.string.nesting = 0,
-                  .as.string.interpolation = false
+                  .as.string.interpolation = false,
+                  .as.string.label_allowed = false
                 };
 
                 lex_mode_push(parser, lex_mode);
@@ -3174,7 +3240,8 @@ lex_token_type(yp_parser_t *parser) {
                   .as.string.incrementor = incrementor(*parser->current.end),
                   .as.string.terminator = terminator(*parser->current.end),
                   .as.string.nesting = 0,
-                  .as.string.interpolation = true
+                  .as.string.interpolation = true,
+                  .as.string.label_allowed = false
                 };
 
                 lex_mode_push(parser, lex_mode);
@@ -3190,7 +3257,8 @@ lex_token_type(yp_parser_t *parser) {
                   .as.string.incrementor = incrementor(*parser->current.end),
                   .as.string.terminator = terminator(*parser->current.end),
                   .as.string.nesting = 0,
-                  .as.string.interpolation = false
+                  .as.string.interpolation = false,
+                  .as.string.label_allowed = false
                 };
 
                 lex_mode_push(parser, lex_mode);
@@ -3237,7 +3305,8 @@ lex_token_type(yp_parser_t *parser) {
                   .as.string.incrementor = incrementor(*parser->current.end),
                   .as.string.terminator = terminator(*parser->current.end),
                   .as.string.nesting = 0,
-                  .as.string.interpolation = true
+                  .as.string.interpolation = true,
+                  .as.string.label_allowed = false
                 };
 
                 lex_mode_push(parser, lex_mode);
@@ -3572,9 +3641,20 @@ lex_token_type(yp_parser_t *parser) {
           // Otherwise we need to switch back to the parent lex mode and
           // return the end of the string.
           parser->current.end = breakpoint + 1;
-          lex_mode_pop(parser);
+
+          if (
+            parser->lex_modes.current->as.string.label_allowed &&
+            parser->current.end < parser->end && parser->current.end[0] == ':' &&
+            (parser->current.end + 1 >= parser->end || parser->current.end[1] != ':')
+          ) {
+            parser->current.end++;
+            lex_state_set(parser, YP_LEX_STATE_ARG | YP_LEX_STATE_LABELED);
+            lex_mode_pop(parser);
+            return YP_TOKEN_LABEL_END;
+          }
 
           lex_state_set(parser, YP_LEX_STATE_END);
+          lex_mode_pop(parser);
           return YP_TOKEN_STRING_END;
         }
 
@@ -4575,16 +4655,25 @@ parse_assocs(yp_parser_t *parser, yp_node_t *node) {
 
         yp_node_t *key = yp_node_symbol_node_create(parser, &opening, &label, &closing);
         yp_token_t operator = not_provided(parser);
-        yp_node_t *value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected an expression after the label in hash.");
+        yp_node_t *value = NULL;
+
+        if (token_begins_expression_p(parser->current.type)) {
+          value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected an expression after the label in hash.");
+        }
 
         element = yp_assoc_node_create(parser, key, &operator, value);
         break;
       }
       default: {
         yp_node_t *key = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected a key in the hash literal.");
+        yp_token_t operator;
 
-        expect(parser, YP_TOKEN_EQUAL_GREATER, "Expected a => between the key and the value in the hash.");
-        yp_token_t operator = parser->previous;
+        if (yp_symbol_node_label_p(key)) {
+          operator = not_provided(parser);
+        } else {
+          expect(parser, YP_TOKEN_EQUAL_GREATER, "Expected a => between the key and the value in the hash.");
+          operator = parser->previous;
+        }
 
         yp_node_t *value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected a value in the hash literal.");
         element = yp_assoc_node_create(parser, key, &operator, value);
@@ -4692,22 +4781,27 @@ parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t termi
       default: {
         argument = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected to be able to parse an argument.");
 
-        if (accept(parser, YP_TOKEN_EQUAL_GREATER)) {
-          // finish parsing the one we are part way through
-          yp_token_t operator = parser->previous;
+        if (yp_symbol_node_label_p(argument) || accept(parser, YP_TOKEN_EQUAL_GREATER)) {
+          yp_token_t opening = not_provided(parser);
+          yp_token_t closing = not_provided(parser);
+          yp_node_t *bare_hash = yp_node_hash_node_create(parser, &opening, &closing);
+
+          yp_token_t operator;
+          if (parser->previous.type == YP_TOKEN_EQUAL_GREATER) {
+            operator = parser->previous;
+          } else {
+            operator = not_provided(parser);
+          }
+
+          // Finish parsing the one we are part way through
           yp_node_t *value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected a value in the hash literal.");
+
           argument = yp_assoc_node_create(parser, argument, &operator, value);
+          yp_node_list_append(parser, bare_hash, &bare_hash->as.hash_node.elements, argument);
+          argument = bare_hash;
 
           // Then parse more if we have a comma
-          if (accept(parser, YP_TOKEN_COMMA)) {
-            yp_token_t opening = not_provided(parser);
-            yp_token_t closing = not_provided(parser);
-
-            yp_node_t *bare_hash = yp_node_hash_node_create(parser, &opening, &closing);
-            yp_node_list_append(parser, bare_hash, &bare_hash->as.hash_node.elements, argument);
-            argument = bare_hash;
-            parse_assocs(parser, argument);
-          }
+          if (accept(parser, YP_TOKEN_COMMA)) parse_assocs(parser, argument);
 
           parsed_bare_hash = true;
         }
@@ -5629,12 +5723,18 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
         } else {
           element = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected an element for the array.");
 
-          if (accept(parser, YP_TOKEN_EQUAL_GREATER)) {
+          if (yp_symbol_node_label_p(element) || accept(parser, YP_TOKEN_EQUAL_GREATER)) {
             yp_token_t opening = not_provided(parser);
             yp_token_t closing = not_provided(parser);
             yp_node_t *hash = yp_node_hash_node_create(parser, &opening, &closing);
 
-            yp_token_t operator = parser->previous;
+            yp_token_t operator;
+            if (parser->previous.type == YP_TOKEN_EQUAL_GREATER) {
+              operator = parser->previous;
+            } else {
+              operator = not_provided(parser);
+            }
+
             yp_node_t *value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected a value in the hash literal.");
             yp_node_t *assoc = yp_assoc_node_create(parser, element, &operator, value);
             yp_node_list_append(parser, hash, &hash->as.hash_node.elements, assoc);
@@ -7162,11 +7262,26 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
         };
 
         node = yp_node_string_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_NONE);
+      } else if (accept(parser, YP_TOKEN_LABEL_END)) {
+        // If we get here, then we have an end of a label immediately after a
+        // start. In that case we'll create an empty symbol node.
+        yp_token_t opening = not_provided(parser);
+        yp_token_t content = (yp_token_t) {
+          .type = YP_TOKEN_STRING_CONTENT,
+          .start = parser->previous.start,
+          .end = parser->previous.start
+        };
+
+        return yp_node_symbol_node_create(parser, &opening, &content, &parser->previous);
       } else if (!lex_mode->as.string.interpolation) {
         // If we don't accept interpolation then we only expect there to be a
         // single string content token immediately after the opening delimiter.
         expect(parser, YP_TOKEN_STRING_CONTENT, "Expected string content after opening delimiter.");
         yp_token_t content = parser->previous;
+
+        if (accept(parser, YP_TOKEN_LABEL_END)) {
+          return yp_node_symbol_node_create(parser, &opening, &content, &parser->previous);
+        }
 
         expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for a string literal.");
         node = yp_node_string_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_MINIMAL);
@@ -7180,39 +7295,49 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
         if (accept(parser, YP_TOKEN_STRING_END)) {
           node = yp_node_string_node_create_and_unescape(parser, &opening, &content, &parser->previous, YP_UNESCAPE_ALL);
+        } else if (accept(parser, YP_TOKEN_LABEL_END)) {
+          return yp_node_symbol_node_create(parser, &opening, &content, &parser->previous);
         } else {
           // If we get here, then we have interpolation so we'll need to create
-          // a string node with interpolation.
-          node = yp_node_interpolated_string_node_create(parser, &opening, &opening);
+          // a string or symbol node with interpolation.
+          yp_node_list_t parts;
+          yp_node_list_init(&parts);
 
-          yp_token_t opening = not_provided(parser);
-          yp_token_t closing = not_provided(parser);
-          yp_node_t *part = yp_node_string_node_create_and_unescape(parser, &opening, &parser->previous, &closing, YP_UNESCAPE_ALL);
-          yp_node_list_append(parser, node, &node->as.interpolated_string_node.parts, part);
+          yp_token_t string_opening = not_provided(parser);
+          yp_token_t string_closing = not_provided(parser);
+          yp_node_t *part = yp_node_string_node_create_and_unescape(parser, &string_opening, &parser->previous, &string_closing, YP_UNESCAPE_ALL);
+          yp_node_list_append2(&parts, part);
 
-          while (!match_any_type_p(parser, 2, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+          while (!match_any_type_p(parser, 3, YP_TOKEN_STRING_END, YP_TOKEN_LABEL_END, YP_TOKEN_EOF)) {
             yp_node_t *part = parse_string_part(parser);
-            if (part != NULL) yp_node_list_append(parser, node, &node->as.interpolated_string_node.parts, part);
+            if (part != NULL) yp_node_list_append2(&parts, part);
+          }
+
+          if (accept(parser, YP_TOKEN_LABEL_END)) {
+            return yp_interpolated_symbol_node_create(parser, &opening, &parts, &parser->previous);
           }
 
           expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for an interpolated string.");
-          node->as.interpolated_string_node.closing = parser->previous;
-          node->location.end = parser->previous.end;
+          node = yp_interpolated_string_node_create(parser, &opening, &parts, &parser->previous);
         }
       } else {
         // If we get here, then the first part of the string is not plain string
         // content, in which case we need to parse the string as an interpolated
         // string.
-        node = yp_node_interpolated_string_node_create(parser, &opening, &opening);
+        yp_node_list_t parts;
+        yp_node_list_init(&parts);
 
-        while (!match_any_type_p(parser, 2, YP_TOKEN_STRING_END, YP_TOKEN_EOF)) {
+        while (!match_any_type_p(parser, 3, YP_TOKEN_STRING_END, YP_TOKEN_LABEL_END, YP_TOKEN_EOF)) {
           yp_node_t *part = parse_string_part(parser);
-          if (part != NULL) yp_node_list_append(parser, node, &node->as.interpolated_string_node.parts, part);
+          if (part != NULL) yp_node_list_append2(&parts, part);
+        }
+
+        if (accept(parser, YP_TOKEN_LABEL_END)) {
+          return yp_interpolated_symbol_node_create(parser, &opening, &parts, &parser->previous);
         }
 
         expect(parser, YP_TOKEN_STRING_END, "Expected a closing delimiter for an interpolated string.");
-        node->as.interpolated_string_node.closing = parser->previous;
-        node->location.end = parser->previous.end;
+        node = yp_interpolated_string_node_create(parser, &opening, &parts, &parser->previous);
       }
 
       // If there's a string immediately following this string, then it's a

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4657,7 +4657,7 @@ parse_assocs(yp_parser_t *parser, yp_node_t *node) {
         yp_token_t operator = not_provided(parser);
         yp_node_t *value = NULL;
 
-        if (token_begins_expression_p(parser->current.type)) {
+        if (token_begins_expression_p(parser->current.type) || parser->current.type == YP_TOKEN_BRACE_LEFT) {
           value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected an expression after the label in hash.");
         }
 
@@ -4782,16 +4782,16 @@ parse_arguments(yp_parser_t *parser, yp_node_t *arguments, yp_token_type_t termi
         argument = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected to be able to parse an argument.");
 
         if (yp_symbol_node_label_p(argument) || accept(parser, YP_TOKEN_EQUAL_GREATER)) {
-          yp_token_t opening = not_provided(parser);
-          yp_token_t closing = not_provided(parser);
-          yp_node_t *bare_hash = yp_node_hash_node_create(parser, &opening, &closing);
-
           yp_token_t operator;
           if (parser->previous.type == YP_TOKEN_EQUAL_GREATER) {
             operator = parser->previous;
           } else {
             operator = not_provided(parser);
           }
+
+          yp_token_t opening = not_provided(parser);
+          yp_token_t closing = not_provided(parser);
+          yp_node_t *bare_hash = yp_node_hash_node_create(parser, &opening, &closing);
 
           // Finish parsing the one we are part way through
           yp_node_t *value = parse_expression(parser, YP_BINDING_POWER_DEFINED, "Expected a value in the hash literal.");

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4313,6 +4313,7 @@ token_begins_expression_p(yp_token_type_t type) {
       // and let it be handled by the default case below.
       assert(yp_binding_powers[type].left == YP_BINDING_POWER_UNSET);
       return false;
+    case YP_TOKEN_COLON_COLON:
     case YP_TOKEN_UMINUS:
     case YP_TOKEN_UPLUS:
     case YP_TOKEN_BANG:
@@ -5263,7 +5264,7 @@ parse_arguments_list(yp_parser_t *parser, yp_arguments_t *arguments, bool accept
 
       arguments->closing = parser->previous;
     }
-  } else if (token_begins_expression_p(parser->current.type) && !match_type_p(parser, YP_TOKEN_BRACE_LEFT)) {
+  } else if (token_begins_expression_p(parser->current.type) && !match_any_type_p(parser, 2, YP_TOKEN_COLON_COLON, YP_TOKEN_BRACE_LEFT)) {
     yp_state_stack_push(&parser->accepts_block_stack, false);
 
     // If we get here, then the subsequent token cannot be used as an infix
@@ -5880,7 +5881,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       // fact a method call, not a constant read.
       if (
         match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT) ||
-        (binding_power <= YP_BINDING_POWER_ASSIGNMENT && token_begins_expression_p(parser->current.type) && !match_type_p(parser, YP_TOKEN_BRACE_LEFT))
+        (binding_power <= YP_BINDING_POWER_ASSIGNMENT && token_begins_expression_p(parser->current.type) && !match_any_type_p(parser, 2, YP_TOKEN_BRACE_LEFT, YP_TOKEN_COLON_COLON))
       ) {
         yp_arguments_t arguments = yp_arguments();
         parse_arguments_list(parser, &arguments, true);

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1679,10 +1679,16 @@ class ParseTest < Test::Unit::TestCase
       nil,
       ArgumentsNode(
         [
-          AssocNode(
-            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("there"), nil),
-            SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("friend"), nil),
-            EQUAL_GREATER("=>")
+          HashNode(
+            nil,
+            [
+              AssocNode(
+                SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("there"), nil),
+                SymbolNode(SYMBOL_BEGIN(":"), IDENTIFIER("friend"), nil),
+                EQUAL_GREATER("=>")
+              )
+            ],
+            nil
           )
         ]
       ),

--- a/test/regexp_test.rb
+++ b/test/regexp_test.rb
@@ -57,8 +57,8 @@ class RegexpTest < Test::Unit::TestCase
     refute_nil(YARP.named_captures("[[:^digit:]]"))
   end
 
-  test "invalid character classes" do
-    assert_nil(YARP.named_captures("[[:foo]]"))
+  test "invalid posix character classes should fall back to regular classes" do
+    refute_nil(YARP.named_captures("[[:foo]]"))
   end
 
   test "character sets" do


### PR DESCRIPTION
* Handle hash value omissions, i.e., `{ foo: }`
* Don't crash on POSIX classes that are unclosed in regular expression parsing, i.e., `/[[:foo:]-]/`
* Handle all places where interpolated labels can go, i.e., `foo("": bar)`, `["": bar]`, and `{ "": bar }`
* Count `{` as beginning an expression, and handle the requisite changes
* Count `::` as beginning an expression, and handle the requisite changes