### PR TITLE
A bunch of stuff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,15 @@ jobs:
         ruby-version: 3.2
         bundler-cache: true
 
+    - name: Lint config.yml
+      run: bundle exec rake lint
+
     - name: Run Ruby tests
       run: bundle exec rake
 
     - name: Run lex comparison
       run: bundle exec rake lex
+
   memcheck:
     runs-on: ubuntu-latest
 

--- a/Rakefile
+++ b/Rakefile
@@ -137,3 +137,31 @@ task lex: :compile do
 
   exit(1) if failing > 0
 end
+
+desc "Lint config.yml"
+task :lint do
+  require "yaml"
+  config = YAML.safe_load_file("config.yml")
+
+  tokens = config.fetch("tokens")[4..].map { |token| token.fetch("name") }
+  if tokens.sort != tokens
+    warn("Tokens are not sorted alphabetically")
+
+    tokens.sort.zip(tokens).each do |(sorted, unsorted)|
+      warn("Expected #{sorted} got #{unsorted}") if sorted != unsorted
+    end
+
+    exit(1)
+  end
+
+  nodes = config.fetch("nodes").map { |node| node.fetch("name") }
+  if nodes.sort != nodes
+    warn("Nodes are not sorted alphabetically")
+
+    nodes.sort.zip(nodes).each do |(sorted, unsorted)|
+      warn("Expected #{sorted} got #{unsorted}") if sorted != unsorted
+    end
+
+    exit(1)
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -99,8 +99,7 @@ task lex: :compile do
       Dir["vendor/spec/**/*.rb"] - [
         "vendor/spec/command_line/fixtures/bad_syntax.rb",
         "vendor/spec/core/regexp/shared/new.rb",
-        "vendor/spec/language/regexp/interpolation_spec.rb",
-        "vendor/spec/language/string_spec.rb"
+        "vendor/spec/language/regexp/interpolation_spec.rb"
       ]
     end
 

--- a/config.yml
+++ b/config.yml
@@ -286,6 +286,8 @@ tokens:
     comment: "the beginning of a symbol"
   - name: TILDE
     comment: "~ or ~@"
+  - name: UCOLON_COLON
+    comment: "unary ::"
   - name: UMINUS
     comment: "-@"
   - name: UPLUS

--- a/config.yml
+++ b/config.yml
@@ -392,6 +392,18 @@ nodes:
             foo
           end
           ^^^^^
+  - name: BlockArgumentNode
+    child_nodes:
+      - name: operator
+        type: token
+      - name: expression
+        type: node
+    location: operator->expression
+    comment: |
+      Represents block method arguments.
+
+          bar(&args)
+          ^^^^^^^^^^
   - name: BlockNode
     child_nodes:
       - name: start_keyword
@@ -475,6 +487,26 @@ nodes:
 
           foo.bar
           ^^^^^^^
+  - name: CaseNode
+    child_nodes:
+      - name: case_keyword
+        type: token
+      - name: predicate
+        type: node?
+      - name: conditions
+        type: node[]
+      - name: consequent
+        type: node?
+      - name: end_keyword
+        type: token
+    location: case_keyword->end_keyword
+    comment: |
+      Represents the use of a case statement.
+
+      case true
+      ^^^^^^^^^
+      when false
+      end
   - name: ClassNode
     child_nodes:
       - name: scope
@@ -676,30 +708,6 @@ nodes:
             bar(...)
             ^^^^^^^^
           end
-  - name: KeywordStarNode
-    child_nodes:
-      - name: operator
-        type: token
-      - name: expression
-        type: node
-    location: operator->expression
-    comment: |
-      Represents keyword splat method arguments.
-
-          bar(**kwargs)
-          ^^^^^^^^^^^
-  - name: BlockArgumentNode
-    child_nodes:
-      - name: operator
-        type: token
-      - name: expression
-        type: node
-    location: operator->expression
-    comment: |
-      Represents block method arguments.
-
-          bar(&args)
-          ^^^^^^^^^^
   - name: ForwardingParameterNode
     comment: |
       Represents the use of the forwarding parameter in a method, block, or lambda declaration.
@@ -793,40 +801,6 @@ nodes:
 
           if foo then bar end
           ^^^^^^^^^^^^^^^^^^^
-  - name: CaseNode
-    child_nodes:
-      - name: case_keyword
-        type: token
-      - name: predicate
-        type: node?
-      - name: conditions
-        type: node[]
-      - name: consequent
-        type: node?
-      - name: end_keyword
-        type: token
-    location: case_keyword->end_keyword
-    comment: |
-      Represents the use of a case statement.
-
-      case true
-      ^^^^^^^^^
-      when false
-      end
-  - name: WhenNode
-    child_nodes:
-      - name: when_keyword
-        type: token
-      - name: conditions
-        type: node[]
-      - name: statements
-        type: node?
-    location: when_keyword->statements|conditions
-    comment: |
-      case true
-      when true
-      ^^^^^^^^^
-      end
   - name: ImaginaryNode
     comment: |
       Represents an imaginary number literal.
@@ -872,20 +846,6 @@ nodes:
 
           /foo #{bar} baz/
           ^^^^^^^^^^^^^^^^
-  - name: InterpolatedXStringNode
-    child_nodes:
-      - name: opening
-        type: token
-      - name: parts
-        type: node[]
-      - name: closing
-        type: token
-    location: opening->closing
-    comment: |
-      Represents an xstring literal that contains interpolation.
-
-          `foo #{bar} baz`
-          ^^^^^^^^^^^^^^^^
   - name: InterpolatedStringNode
     child_nodes:
       - name: opening
@@ -914,6 +874,20 @@ nodes:
 
           :"foo #{bar} baz"
           ^^^^^^^^^^^^^^^^^
+  - name: InterpolatedXStringNode
+    child_nodes:
+      - name: opening
+        type: token
+      - name: parts
+        type: node[]
+      - name: closing
+        type: token
+    location: opening->closing
+    comment: |
+      Represents an xstring literal that contains interpolation.
+
+          `foo #{bar} baz`
+          ^^^^^^^^^^^^^^^^
   - name: KeywordParameterNode
     child_nodes:
       - name: name
@@ -944,6 +918,18 @@ nodes:
           def a(**b)
                 ^^^
           end
+  - name: KeywordStarNode
+    child_nodes:
+      - name: operator
+        type: token
+      - name: expression
+        type: node
+    location: operator->expression
+    comment: |
+      Represents keyword splat method arguments.
+
+          bar(**kwargs)
+          ^^^^^^^^^^^
   - name: LambdaNode
     child_nodes:
       - name: scope
@@ -1243,17 +1229,6 @@ nodes:
 
           /foo/i
           ^^^^^^
-  - name: RequiredParameterNode
-    child_nodes:
-      - name: name
-        type: token
-    location: name
-    comment: |
-      Represents a required parameter to a method, block, or lambda definition.
-
-          def a(b)
-                ^
-          end
   - name: RequiredDestructuredParameterNode
     child_nodes:
       - name: parameters
@@ -1268,6 +1243,17 @@ nodes:
 
           def foo((bar, baz))
                   ^^^^^^^^^^
+          end
+  - name: RequiredParameterNode
+    child_nodes:
+      - name: name
+        type: token
+    location: name
+    comment: |
+      Represents a required parameter to a method, block, or lambda definition.
+
+          def a(b)
+                ^
           end
   - name: RescueModifierNode
     child_nodes:
@@ -1319,18 +1305,6 @@ nodes:
           def a(*b)
                 ^^
           end
-  - name: SplatNode
-    child_nodes:
-      - name: operator
-        type: token
-      - name: expression
-        type: node?
-    location: operator->expression|operator
-    comment: |
-      Represents array splats.
-
-          [*a]
-           ^^
   - name: RetryNode
     comment: |
       Represents the use of the `retry` keyword.
@@ -1401,6 +1375,18 @@ nodes:
 
           __LINE__
           ^^^^^^^^
+  - name: SplatNode
+    child_nodes:
+      - name: operator
+        type: token
+      - name: expression
+        type: node?
+    location: operator->expression|operator
+    comment: |
+      Represents the use of the splat operator.
+
+          [*a]
+           ^^
   - name: StatementsNode
     child_nodes:
       - name: body
@@ -1411,6 +1397,18 @@ nodes:
 
           foo; bar; baz
           ^^^^^^^^^^^^^
+  - name: StringConcatNode
+    child_nodes:
+      - name: left
+        type: node
+      - name: right
+        type: node
+    location: left->right
+    comment: |
+      Represents the use of compile-time string concatenation.
+
+          "foo" "bar"
+          ^^^^^^^^^^^
   - name: StringInterpolatedNode
     child_nodes:
       - name: opening
@@ -1448,18 +1446,6 @@ nodes:
 
           "foo #{bar} baz"
            ^^^^      ^^^^
-  - name: StringConcatNode
-    child_nodes:
-      - name: left
-        type: node
-      - name: right
-        type: node
-    location: left->right
-    comment: |
-      Represents the use of compile-time string concatenation.
-
-          "foo" "bar"
-          ^^^^^^^^^^^
   - name: SuperNode
     child_nodes:
       - name: keyword
@@ -1571,6 +1557,20 @@ nodes:
 
           until foo do bar end
           ^^^^^^^^^^^^^^^^^^^^
+  - name: WhenNode
+    child_nodes:
+      - name: when_keyword
+        type: token
+      - name: conditions
+        type: node[]
+      - name: statements
+        type: node?
+    location: when_keyword->statements|conditions
+    comment: |
+      case true
+      when true
+      ^^^^^^^^^
+      end
   - name: WhileNode
     child_nodes:
       - name: keyword

--- a/config.yml
+++ b/config.yml
@@ -18,10 +18,10 @@ tokens:
     comment: "&."
   - name: AMPERSAND_EQUAL
     comment: "&="
-  - name: BACK_REFERENCE
-    comment: "a back reference"
   - name: BACKTICK
     comment: "`"
+  - name: BACK_REFERENCE
+    comment: "a back reference"
   - name: BANG
     comment: "! or !@"
   - name: BANG_EQUAL
@@ -90,6 +90,8 @@ tokens:
     comment: "=~"
   - name: FLOAT
     comment: "a floating point number"
+  - name: GLOBAL_VARIABLE
+    comment: "a global variable"
   - name: GREATER
     comment: ">"
   - name: GREATER_EQUAL
@@ -98,8 +100,6 @@ tokens:
     comment: ">>"
   - name: GREATER_GREATER_EQUAL
     comment: ">>="
-  - name: GLOBAL_VARIABLE
-    comment: "a global variable"
   - name: HEREDOC_END
     comment: "the end of a heredoc"
   - name: HEREDOC_START
@@ -114,12 +114,6 @@ tokens:
     comment: "an instance variable"
   - name: INTEGER
     comment: "an integer (any base)"
-  - name: KEYWORD___ENCODING__
-    comment: "__ENCODING__"
-  - name: KEYWORD___LINE__
-    comment: "__LINE__"
-  - name: KEYWORD___FILE__
-    comment: "__FILE__"
   - name: KEYWORD_ALIAS
     comment: "alias"
   - name: KEYWORD_AND
@@ -198,6 +192,12 @@ tokens:
     comment: "while"
   - name: KEYWORD_YIELD
     comment: "yield"
+  - name: KEYWORD___ENCODING__
+    comment: "__ENCODING__"
+  - name: KEYWORD___FILE__
+    comment: "__FILE__"
+  - name: KEYWORD___LINE__
+    comment: "__LINE__"
   - name: LABEL
     comment: "a label"
   - name: LABEL_END
@@ -1323,6 +1323,20 @@ nodes:
 
           return 1
           ^^^^^^^^
+  - name: Scope
+    child_nodes:
+      - name: locals
+        type: token[]
+    location: locals
+    comment: |
+      Represents the local variables within a given lexical scope. These are
+      attached to nodes where a new scope is created.
+  - name: SelfNode
+    comment: |
+      Represents the `self` keyword.
+
+          self
+          ^^^^
   - name: SingletonClassNode
     child_nodes:
       - name: scope
@@ -1343,20 +1357,6 @@ nodes:
 
           class << self end
           ^^^^^^^^^^^^^^^^^
-  - name: Scope
-    child_nodes:
-      - name: locals
-        type: token[]
-    location: locals
-    comment: |
-      Represents the local variables within a given lexical scope. These are
-      attached to nodes where a new scope is created.
-  - name: SelfNode
-    comment: |
-      Represents the `self` keyword.
-
-          self
-          ^^^^
   - name: SourceEncodingNode
     comment: |
       Represents the use of the `__ENCODING__` keyword.

--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -154,6 +154,7 @@ module YARP
       STRING_END: :on_tstring_end,
       SYMBOL_BEGIN: :on_symbeg,
       TILDE: :on_op,
+      UCOLON_COLON: :on_op,
       UMINUS: :on_op,
       UPLUS: :on_op,
       WORDS_SEP: :on_words_sep,

--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -303,30 +303,40 @@ module YARP
                 lineno = token[0][0] + index
                 column = token[0][1]
 
+                if line == "\n" && (dedent_next || index > 0)
+                  column = 0
+                end
+
                 # If we are supposed to dedent this line or if this is not the
                 # first line of the string and this line isn't entirely blank,
                 # then we need to insert an on_ignored_sp token and remove the
                 # dedent from the beginning of the line.
-                if line != "\n" && (dedent_next || index > 0)
-                  deleting = 0
-                  deleted_chars = []
+                if dedent_next || index > 0
+                  if line == "\n"
+                    # Blank lines do not count toward common leading whitespace
+                    # calculation and do not need to be dedented.
+                    column = 0
+                  else
+                    deleting = 0
+                    deleted_chars = []
 
-                  # Gather up all of the characters that we're going to delete,
-                  # stopping when you hit a character that would put you over
-                  # the dedent amount.
-                  line.each_char do |char|
-                    break if (deleting += char == "\t" ? TAB_WIDTH : 1) > dedent
-                    deleted_chars << char
-                  end
+                    # Gather up all of the characters that we're going to
+                    # delete, stopping when you hit a character that would put
+                    # you over the dedent amount.
+                    line.each_char do |char|
+                      break if (deleting += char == "\t" ? TAB_WIDTH : 1) > dedent
+                      deleted_chars << char
+                    end
 
-                  # If we have something to delete, then delete it from the
-                  # string and insert an on_ignored_sp token.
-                  if deleted_chars.any?
-                    ignored = deleted_chars.join
-                    line.delete_prefix!(ignored)
+                    # If we have something to delete, then delete it from the
+                    # string and insert an on_ignored_sp token.
+                    if deleted_chars.any?
+                      ignored = deleted_chars.join
+                      line.delete_prefix!(ignored)
 
-                    results << Token.new([[lineno, 0], :on_ignored_sp, ignored, token[3]])
-                    column = ignored.length
+                      results << Token.new([[lineno, 0], :on_ignored_sp, ignored, token[3]])
+                      column = ignored.length
+                    end
                   end
                 end
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -290,6 +290,10 @@ struct yp_parser {
   // the beginning of a lambda following the parameters of a lambda.
   int lambda_enclosure_nesting;
 
+  // Used to track the nesting of braces to ensure we get the correct value when
+  // we are interpolating blocks with braces.
+  int brace_nesting;
+
   // the stack used to determine if a do keyword belongs to the predicate of a
   // while, until, or for loop
   yp_state_stack_t do_loop_stack;

--- a/src/parser.h
+++ b/src/parser.h
@@ -342,6 +342,11 @@ struct yp_parser {
   // This is an optional callback that can be attached to the parser that will
   // be called whenever a new token is lexed by the parser.
   yp_lex_callback_t *lex_callback;
+
+  // A boolean that tracks whether or not we should potentially consider comment
+  // tokens to be magic comments. This becomes false after anything other than
+  // comment tokens have been seen.
+  bool consider_magic_comments;
 };
 
 #endif // YARP_PARSER_H

--- a/src/parser.h
+++ b/src/parser.h
@@ -115,8 +115,15 @@ typedef struct yp_lex_mode {
     } list;
 
     struct {
+      // When lexing a regular expression, it takes into account balancing the
+      // terminator if the terminator is one of (), [], {}, or <>.
+      char incrementor;
+
       // This is the terminator of the regular expression.
       char terminator;
+
+      // This keeps track of the nesting level of the regular expression.
+      size_t nesting;
     } regexp;
 
     struct {
@@ -138,14 +145,6 @@ typedef struct yp_lex_mode {
       // would indicate this was a dynamic symbol instead of a string.
       bool label_allowed;
     } string;
-
-    struct {
-      // This is the terminator of the symbol.
-      char terminator;
-
-      // Whether or not interpolation is allowed in this symbol.
-      bool interpolation;
-    } symbol;
 
     struct {
       // These pointers point to the beginning and end of the heredoc

--- a/src/util/yp_strspn.c
+++ b/src/util/yp_strspn.c
@@ -1,57 +1,32 @@
 #include "yp_strspn.h"
 
-const char yp_strspn_octal_number_table[128] = {
-  ['0'] = 1,
-  ['1'] = 1,
-  ['2'] = 1,
-  ['3'] = 1,
-  ['4'] = 1,
-  ['5'] = 1,
-  ['6'] = 1,
-  ['7'] = 1,
-  ['_'] = 1
-};
+#define YP_STRSPN_BIT_WHITESPACE (1 << 0)
+#define YP_STRSPN_BIT_INLINE_WHITESPACE (1 << 1)
+#define YP_STRSPN_BIT_DECIMAL_DIGIT (1 << 2)
+#define YP_STRSPN_BIT_HEXIDECIMAL_DIGIT (1 << 3)
+#define YP_STRSPN_BIT_BINARY_NUMBER (1 << 4)
+#define YP_STRSPN_BIT_OCTAL_NUMBER (1 << 5)
+#define YP_STRSPN_BIT_DECIMAL_NUMBER (1 << 6)
+#define YP_STRSPN_BIT_HEXIDECIMAL_NUMBER (1 << 7)
 
-const char yp_strspn_decimal_number_table[128] = {
-  ['0'] = 1,
-  ['1'] = 1,
-  ['2'] = 1,
-  ['3'] = 1,
-  ['4'] = 1,
-  ['5'] = 1,
-  ['6'] = 1,
-  ['7'] = 1,
-  ['8'] = 1,
-  ['9'] = 1,
-  ['_'] = 1
-};
-
-const char yp_strspn_whitespace_table[128] = {
-  [' '] = 1,
-  ['\t'] = 1,
-  ['\v'] = 1,
-  ['\f'] = 1,
-  ['\r'] = 1,
-  ['\n'] = 1
+const unsigned char yp_strspn_table[128] = {
+  //       0           1           2           3           4           5           6           7           8           9           A           B           C           D           E           F
+  0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000011, 0b00000001, 0b00000011, 0b00000011, 0b00000011, 0b00000000, 0b00000000, // 0x
+  0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, // 1x
+  0b00000011, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, // 2x
+  0b11111100, 0b11111100, 0b11101100, 0b11101100, 0b11101100, 0b11101100, 0b11101100, 0b11101100, 0b11001100, 0b11001100, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, // 3x
+  0b00000000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, // 4x
+  0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b11110000, // 5x
+  0b00000000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, // 6x
+  0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b10001000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, // 7x
 };
 
 // Returns the number of characters at the start of the string string that are
-// octal numbers or underscores. Disallows searching past the given maximum
-// number of characters.
+// whitespace. Disallows searching past the given maximum number of characters.
 size_t
-yp_strspn_octal_number(const char *string, size_t maximum) {
+yp_strspn_whitespace(const char *string, size_t maximum) {
   size_t size = 0;
-  while (size < maximum && yp_strspn_octal_number_table[(unsigned char) string[size]]) size++;
-  return size;
-}
-
-// Returns the number of characters at the start of the string string that are
-// decimal numbers or underscores. Disallows searching past the given maximum
-// number of characters.
-size_t
-yp_strspn_decimal_number(const char *string, size_t maximum) {
-  size_t size = 0;
-  while (size < maximum && yp_strspn_decimal_number_table[(unsigned char) string[size]]) size++;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_WHITESPACE)) size++;
   return size;
 }
 
@@ -61,15 +36,75 @@ yp_strspn_decimal_number(const char *string, size_t maximum) {
 size_t
 yp_strspn_inline_whitespace(const char *string, size_t maximum) {
   size_t size = 0;
-  while (size < maximum && string[size] != '\n' && yp_strspn_whitespace_table[(unsigned char) string[size]]) size++;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_INLINE_WHITESPACE)) size++;
   return size;
 }
 
 // Returns the number of characters at the start of the string string that are
-// whitespace. Disallows searching past the given maximum number of characters.
+// decimal digits. Disallows searching past the given maximum number of
+// characters.
 size_t
-yp_strspn_whitespace(const char *string, size_t maximum) {
+yp_strspn_decimal_digit(const char *string, size_t maximum) {
   size_t size = 0;
-  while (size < maximum && yp_strspn_whitespace_table[(unsigned char) string[size]]) size++;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_DECIMAL_DIGIT)) size++;
   return size;
 }
+
+// Returns the number of characters at the start of the string string that are
+// hexidecimal digits. Disallows searching past the given maximum number of
+// characters.
+size_t
+yp_strspn_hexidecimal_digit(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_HEXIDECIMAL_DIGIT)) size++;
+  return size;
+}
+
+// Returns the number of characters at the start of the string string that are
+// binary digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_binary_number(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_BINARY_NUMBER)) size++;
+  return size;
+}
+
+// Returns the number of characters at the start of the string string that are
+// octal digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_octal_number(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_OCTAL_NUMBER)) size++;
+  return size;
+}
+
+// Returns the number of characters at the start of the string string that are
+// decimal digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_decimal_number(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_DECIMAL_NUMBER)) size++;
+  return size;
+}
+
+// Returns the number of characters at the start of the string string that are
+// hexidecimal digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_hexidecimal_number(const char *string, size_t maximum) {
+  size_t size = 0;
+  while (size < maximum && (yp_strspn_table[(unsigned char) string[size]] & YP_STRSPN_BIT_HEXIDECIMAL_NUMBER)) size++;
+  return size;
+}
+
+#undef YP_STRSPN_BIT_WHITESPACE
+#undef YP_STRSPN_BIT_INLINE_WHITESPACE
+#undef YP_STRSPN_BIT_DECIMAL_DIGIT
+#undef YP_STRSPN_BIT_HEXIDECIMAL_DIGIT
+#undef YP_STRSPN_BIT_BINARY_NUMBER
+#undef YP_STRSPN_BIT_OCTAL_NUMBER
+#undef YP_STRSPN_BIT_DECIMAL_NUMBER
+#undef YP_STRSPN_BIT_HEXIDECIMAL_NUMBER

--- a/src/util/yp_strspn.h
+++ b/src/util/yp_strspn.h
@@ -4,16 +4,9 @@
 #include <stddef.h>
 
 // Returns the number of characters at the start of the string string that are
-// octal numbers or underscores. Disallows searching past the given maximum
-// number of characters.
+// whitespace. Disallows searching past the given maximum number of characters.
 size_t
-yp_strspn_octal_number(const char *string, size_t maximum);
-
-// Returns the number of characters at the start of the string string that are
-// decimal numbers or underscores. Disallows searching past the given maximum
-// number of characters.
-size_t
-yp_strspn_decimal_number(const char *string, size_t maximum);
+yp_strspn_whitespace(const char *string, size_t maximum);
 
 // Returns the number of characters at the start of the string string that are
 // whitespace excluding newline characters. Disallows searching past the given
@@ -22,8 +15,39 @@ size_t
 yp_strspn_inline_whitespace(const char *string, size_t maximum);
 
 // Returns the number of characters at the start of the string string that are
-// whitespace. Disallows searching past the given maximum number of characters.
+// decimal digits. Disallows searching past the given maximum number of
+// characters.
 size_t
-yp_strspn_whitespace(const char *string, size_t maximum);
+yp_strspn_decimal_digit(const char *string, size_t maximum);
+
+// Returns the number of characters at the start of the string string that are
+// hexidecimal digits. Disallows searching past the given maximum number of
+// characters.
+size_t
+yp_strspn_hexidecimal_digit(const char *string, size_t maximum);
+
+// Returns the number of characters at the start of the string string that are
+// binary digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_binary_number(const char *string, size_t maximum);
+
+// Returns the number of characters at the start of the string string that are
+// octal digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_octal_number(const char *string, size_t maximum);
+
+// Returns the number of characters at the start of the string string that are
+// decimal digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_decimal_number(const char *string, size_t maximum);
+
+// Returns the number of characters at the start of the string string that are
+// hexidecimal digits or underscores. Disallows searching past the given maximum
+// number of characters.
+size_t
+yp_strspn_hexidecimal_number(const char *string, size_t maximum);
 
 #endif

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2003,6 +2003,17 @@ lex_identifier(yp_parser_t *parser, bool previous_command_start) {
       // check if we're returning the defined? keyword or just an identifier.
       width++;
 
+      if (
+        ((lex_state_p(parser, YP_LEX_STATE_LABEL | YP_LEX_STATE_ENDFN) && !previous_command_start) || lex_state_arg_p(parser)) &&
+        parser->current.end[0] == ':' && parser->current.end[1] != ':'
+      ) {
+        // If we're in a position where we can accept a : at the end of an
+        // identifier, then we'll optionally accept it.
+        lex_state_set(parser, YP_LEX_STATE_ARG | YP_LEX_STATE_LABELED);
+        (void) match(parser, ':');
+        return YP_TOKEN_LABEL;
+      }
+
       if (parser->lex_state != YP_LEX_STATE_DOT) {
         if (width == 8 && lex_keyword(parser, "defined?", YP_LEX_STATE_ARG, false)) {
           return YP_TOKEN_KEYWORD_DEFINED;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6061,13 +6061,13 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       // If an identifier is followed by something that looks like an argument,
       // then this is in fact a method call, not a local read.
       if (
-        node->type == YP_NODE_LOCAL_VARIABLE_READ &&
+        node->type == YP_NODE_LOCAL_VARIABLE_READ_NODE &&
         (binding_power <= YP_BINDING_POWER_ASSIGNMENT && token_begins_expression_p(parser->current.type) && !match_type_p(parser, YP_TOKEN_BRACE_LEFT))
       ) {
         yp_arguments_t arguments = yp_arguments();
         parse_arguments_list(parser, &arguments, true);
 
-        yp_node_t *fcall = yp_call_node_fcall_create(parser, &node->as.local_variable_read.name, &arguments);
+        yp_node_t *fcall = yp_call_node_fcall_create(parser, &node->as.local_variable_read_node.name, &arguments);
         yp_node_destroy(parser, node);
         return fcall;
       }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3067,9 +3067,10 @@ lex_token_type(yp_parser_t *parser) {
           if (match(parser, ':')) {
             if (lex_state_beg_p(parser) || lex_state_p(parser, YP_LEX_STATE_CLASS) || (lex_state_p(parser, YP_LEX_STATE_ARG_ANY) && space_seen)) {
               lex_state_set(parser, YP_LEX_STATE_BEG);
-            } else {
-              lex_state_set(parser, YP_LEX_STATE_DOT);
+              return YP_TOKEN_UCOLON_COLON;
             }
+
+            lex_state_set(parser, YP_LEX_STATE_DOT);
             return YP_TOKEN_COLON_COLON;
           }
 
@@ -4313,7 +4314,7 @@ token_begins_expression_p(yp_token_type_t type) {
       // and let it be handled by the default case below.
       assert(yp_binding_powers[type].left == YP_BINDING_POWER_UNSET);
       return false;
-    case YP_TOKEN_COLON_COLON:
+    case YP_TOKEN_UCOLON_COLON:
     case YP_TOKEN_UMINUS:
     case YP_TOKEN_UPLUS:
     case YP_TOKEN_BANG:
@@ -5264,7 +5265,7 @@ parse_arguments_list(yp_parser_t *parser, yp_arguments_t *arguments, bool accept
 
       arguments->closing = parser->previous;
     }
-  } else if (token_begins_expression_p(parser->current.type) && !match_any_type_p(parser, 2, YP_TOKEN_COLON_COLON, YP_TOKEN_BRACE_LEFT)) {
+  } else if (token_begins_expression_p(parser->current.type) && !match_type_p(parser, YP_TOKEN_BRACE_LEFT)) {
     yp_state_stack_push(&parser->accepts_block_stack, false);
 
     // If we get here, then the subsequent token cannot be used as an infix
@@ -5881,7 +5882,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       // fact a method call, not a constant read.
       if (
         match_type_p(parser, YP_TOKEN_PARENTHESIS_LEFT) ||
-        (binding_power <= YP_BINDING_POWER_ASSIGNMENT && token_begins_expression_p(parser->current.type) && !match_any_type_p(parser, 2, YP_TOKEN_BRACE_LEFT, YP_TOKEN_COLON_COLON))
+        (binding_power <= YP_BINDING_POWER_ASSIGNMENT && token_begins_expression_p(parser->current.type) && !match_type_p(parser, YP_TOKEN_BRACE_LEFT))
       ) {
         yp_arguments_t arguments = yp_arguments();
         parse_arguments_list(parser, &arguments, true);
@@ -5898,7 +5899,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
 
       return node;
     }
-    case YP_TOKEN_COLON_COLON: {
+    case YP_TOKEN_UCOLON_COLON: {
       parser_lex(parser);
 
       yp_token_t delimiter = parser->previous;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -81,17 +81,30 @@ debug_node(const char *message, yp_parser_t *parser, yp_node_t *node) {
 __attribute__((unused)) static void
 debug_lex_mode(yp_parser_t *parser) {
   yp_lex_mode_t *lex_mode = parser->lex_modes.current;
+  bool first = true;
 
-  switch (lex_mode->mode) {
-    case YP_LEX_DEFAULT: fprintf(stderr, "lexing in DEFAULT mode\n"); return;
-    case YP_LEX_EMBDOC: fprintf(stderr, "lexing in EMBDOC mode\n"); return;
-    case YP_LEX_EMBEXPR: fprintf(stderr, "lexing in EMBEXPR mode\n"); return;
-    case YP_LEX_EMBVAR: fprintf(stderr, "lexing in EMBVAR mode\n"); return;
-    case YP_LEX_HEREDOC: fprintf(stderr, "lexing in HEREDOC mode\n"); return;
-    case YP_LEX_LIST: fprintf(stderr, "lexing in LIST mode (terminator=%c, interpolation=%d)\n", lex_mode->as.list.terminator, lex_mode->as.list.interpolation); return;
-    case YP_LEX_REGEXP: fprintf(stderr, "lexing in REGEXP mode (terminator=%c)\n", lex_mode->as.regexp.terminator); return;
-    case YP_LEX_STRING: fprintf(stderr, "lexing in STRING mode (terminator=%c, interpolation=%d)\n", lex_mode->as.string.terminator, lex_mode->as.string.interpolation); return;
+  while (lex_mode != NULL) {
+    if (first) {
+      first = false;
+    } else {
+      fprintf(stderr, " <- ");
+    }
+
+    switch (lex_mode->mode) {
+      case YP_LEX_DEFAULT: fprintf(stderr, "DEFAULT"); break;
+      case YP_LEX_EMBDOC: fprintf(stderr, "EMBDOC"); break;
+      case YP_LEX_EMBEXPR: fprintf(stderr, "EMBEXPR"); break;
+      case YP_LEX_EMBVAR: fprintf(stderr, "EMBVAR"); break;
+      case YP_LEX_HEREDOC: fprintf(stderr, "HEREDOC"); break;
+      case YP_LEX_LIST: fprintf(stderr, "LIST (terminator=%c, interpolation=%d)", lex_mode->as.list.terminator, lex_mode->as.list.interpolation); break;
+      case YP_LEX_REGEXP: fprintf(stderr, "REGEXP (terminator=%c)", lex_mode->as.regexp.terminator); break;
+      case YP_LEX_STRING: fprintf(stderr, "STRING (terminator=%c, interpolation=%d)", lex_mode->as.string.terminator, lex_mode->as.string.interpolation); break;
+    }
+
+    lex_mode = lex_mode->prev;
   }
+
+  fprintf(stderr, "\n");
 }
 
 __attribute__((unused)) static void

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1812,7 +1812,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
       case 'b':
       case 'B':
         if (char_is_binary_number(*++parser->current.end)) {
-          parser->current.end += strspn(parser->current.end, "01_");
+          parser->current.end += yp_strspn_binary_number(parser->current.end, parser->end - parser->current.end);
         } else {
           yp_diagnostic_list_append(&parser->error_list, "invalid binary number", parser->current.start - parser->start);
         }
@@ -1847,7 +1847,7 @@ lex_numeric_prefix(yp_parser_t *parser) {
       case 'x':
       case 'X':
         if (char_is_hexadecimal_number(*++parser->current.end)) {
-          parser->current.end += strspn(parser->current.end, "0123456789abcdefABCDEF_");
+          parser->current.end += yp_strspn_hexidecimal_number(parser->current.end, parser->end - parser->current.end);
         } else {
           yp_diagnostic_list_append(&parser->error_list, "invalid hexadecimal number", parser->current.start - parser->start);
         }
@@ -1933,7 +1933,7 @@ lex_global_variable(yp_parser_t *parser) {
     case '7':
     case '8':
     case '9':
-      parser->current.end += strspn(parser->current.end, "0123456789");
+      parser->current.end += yp_strspn_decimal_digit(parser->current.end, parser->end - parser->current.end);
       return YP_TOKEN_NTH_REFERENCE;
 
     case '-':
@@ -2318,7 +2318,7 @@ lex_question_mark(yp_parser_t *parser) {
           if (match(parser, '{')) {
             parser->current.end += yp_strspn_whitespace(parser->current.end, parser->current.end - parser->end);
             while (!match(parser, '}')) {
-              parser->current.end += strspn(parser->current.end, "0123456789abcdefABCDEF");
+              parser->current.end += yp_strspn_hexidecimal_digit(parser->current.end, parser->current.end - parser->end);
               parser->current.end += yp_strspn_whitespace(parser->current.end, parser->current.end - parser->end);
             }
           } else {

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -177,12 +177,12 @@ class ErrorsTest < Test::Unit::TestCase
   end
 
   test "top level constant with downcased identifier" do
-    expected = ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(MISSING("")))
+    expected = ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(MISSING("")))
     assert_errors expected, "::foo", ["Expected a constant after ::."]
   end
 
   test "top level constant starting with downcased identifier" do
-    expected = ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(MISSING("")))
+    expected = ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(MISSING("")))
     assert_errors expected, "::foo::A", ["Expected a constant after ::."]
   end
 

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1365,9 +1365,12 @@ class ParseTest < Test::Unit::TestCase
       nil,
       ParametersNode(
         [],
-        [KeywordParameterNode(LABEL("c:"), expression("1"))],
+        [],
         nil,
-        [KeywordParameterNode(LABEL("b:"), nil)],
+        [
+          KeywordParameterNode(LABEL("b:"), nil),
+          KeywordParameterNode(LABEL("c:"), expression("1"))
+        ],
         nil,
         nil
       ),
@@ -1390,9 +1393,12 @@ class ParseTest < Test::Unit::TestCase
       nil,
       ParametersNode(
         [],
-        [KeywordParameterNode(LABEL("c:"), expression("1"))],
+        [],
         nil,
-        [KeywordParameterNode(LABEL("b:"), nil)],
+        [
+          KeywordParameterNode(LABEL("b:"), nil),
+          KeywordParameterNode(LABEL("c:"), expression("1"))
+        ],
         nil,
         nil
       ),
@@ -1415,9 +1421,12 @@ class ParseTest < Test::Unit::TestCase
       nil,
       ParametersNode(
         [],
-        [KeywordParameterNode(LABEL("b:"), expression("1"))],
+        [],
         nil,
-        [KeywordParameterNode(LABEL("c:"), nil)],
+        [
+          KeywordParameterNode(LABEL("b:"), expression("1")),
+          KeywordParameterNode(LABEL("c:"), nil)
+        ],
         nil,
         nil
       ),

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -1052,12 +1052,12 @@ class ParseTest < Test::Unit::TestCase
   end
 
   test "top-level constant read" do
-    assert_parses ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(CONSTANT("A"))), "::A"
+    assert_parses ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(CONSTANT("A"))), "::A"
   end
 
   test "top-level constant assignment" do
     expected = ConstantPathWriteNode(
-      ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
+      ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
       EQUAL("="),
       IntegerNode()
     )
@@ -1067,7 +1067,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "top-level constant path read" do
     expected = ConstantPathNode(
-      ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
+      ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
       COLON_COLON("::"),
       ConstantReadNode(CONSTANT("B"))
     )
@@ -1078,7 +1078,7 @@ class ParseTest < Test::Unit::TestCase
   test "top-level constant path assignment" do
     expected = ConstantPathWriteNode(
       ConstantPathNode(
-        ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
+        ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
         COLON_COLON("::"),
         ConstantReadNode(CONSTANT("B"))
       ),
@@ -1091,7 +1091,7 @@ class ParseTest < Test::Unit::TestCase
 
   test "top level constant with method inside" do
     expected = CallNode(
-      ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
+      ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
       COLON_COLON("::"),
       IDENTIFIER("foo"),
       nil,
@@ -2987,7 +2987,7 @@ class ParseTest < Test::Unit::TestCase
     expected = ModuleNode(
       Scope([]),
       KEYWORD_MODULE("module"),
-      ConstantPathNode(nil, COLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
+      ConstantPathNode(nil, UCOLON_COLON("::"), ConstantReadNode(CONSTANT("A"))),
       StatementsNode([]),
       KEYWORD_END("end")
     )


### PR DESCRIPTION
These changes now bring us up to:

```
ruby/spec
PASSING=4661
FAILING=2
PERCENT=99.96%

rails/rails
PASSING=3049
FAILING=24
PERCENT=99.22%

ruby/ruby
PASSING=8025
FAILING=205
PERCENT=97.51%
```

Here is a list of the changes:

* Previously we only had one token for `::`, which led to some ambiguity with `foo :: Bar` (is that a constant lookup or a method call?). Now we delineate between unary `::` and binary `::` by checking the lex state (which mirrors what CRuby does).
* `lex_compat` had a bug where it wouldn't properly handle blank lines, which do not count toward common leading whitespace calculation in tilde heredocs.
* Magic comments should only be considered at the top of the file. (Previously we were checking magic comments on every comment.)
* Regular expressions now check their nesting properly. e.g., `%r[abc[]]` will parse correctly now. Fixes #386.
* `debug_lex_mode` will now show the whole lex mode stack instead of just the current mode.
* Brace blocks within interpolation need to track their nesting to avoid ambiguity. For example, `"#{foo {}}"` would previously have ended the embedded expression on the first `}` not the second. This is now fixed by tracking brace nesting, which is how CRuby solves this.
* Local variable reads can still become method calls if they are followed by arguments without parentheses. For example, `foo = 1; foo 1`. The second statement there should be a method call. This is now fixed in the same way it is fixed for constants of checking the binding power of the subsequent token. Fixes #420.
* We now have a simplified version of parsing parameters, continuing when we see a comma. If parentheses are used, we now accept trailing newlines after parameters. Fixes #472.
* Labels can potentially end with `?`, as in `{ frozen?: frozen? }`.
* We now roll our own `strspn` instead of using the standard library one. This is because we want to be able to pass a maximum number of characters to check to ensure we don't read off the end of the string.
* We now check for embedded global variables in string-like values correctly using the same hashing function as CRuby. Fixes #397.
* `config.yml` is now alphabetized and linted in CI.