### PR TITLE
Split on Ruby layer into different tokens on "\\\n" for non-tilde her…

### DIFF
--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -231,7 +231,24 @@ module YARP
 
         def to_a
           tokens.last.state = state
-          tokens
+          results = []
+          tokens.each do |token|
+            if token.event == :on_tstring_content
+              # Split on "\\\n" to mimic Ripper's behavior
+              values = token.value.split("\\\n")
+              values.each_with_index do |value, index|
+                lineno = token[0][0] + index
+                column = token[0][1]
+                if index < values.length - 1 # Not the last string
+                  value = value + "\\\n" # Add the "\\\n" back to the string
+                end
+                results << Token.new([[lineno, column], :on_tstring_content, value, token.state])
+              end
+            else
+              results << token
+            end
+          end
+          tokens = results
         end
       end
 


### PR DESCRIPTION
…edocs

In Ripper, any "\\\n" generates a token split for non-tilde heredocs. This PR mimics Ripper's behavior on the comparison layer.

Closes #476 