### PR TITLE
Rework comments tests into their own file

### DIFF
--- a/test/comments_test.rb
+++ b/test/comments_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CommentsTest < Test::Unit::TestCase
+  include YARP::DSL
+
+  test "comment inline" do
+    assert_comment "# comment", :inline
+  end
+
+  test "comment __END__" do
+    source = <<~RUBY
+      __END__
+      comment
+    RUBY
+
+    assert_comment source, :__END__
+  end
+
+  test "comment embedded document" do
+    source = <<~RUBY
+      =begin
+      comment
+      =end
+    RUBY
+
+    assert_comment source, :embdoc
+  end
+
+  test "comment embedded document with content on same line" do
+    source = <<~RUBY
+      =begin other stuff
+      =end
+    RUBY
+
+    assert_comment source, :embdoc
+  end
+
+  private
+
+  def assert_comment(source, type)
+    YARP.parse(source) => YARP::ParseResult[comments: [YARP::Comment[type: type]]]
+  end
+end

--- a/test/fixtures/comments.rb
+++ b/test/fixtures/comments.rb
@@ -1,3 +1,0 @@
-=begin
-=end other stuff
-1

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -9,38 +9,6 @@ class ParseTest < Test::Unit::TestCase
     YARP.parse("") => YARP::ParseResult[value: YARP::ProgramNode[statements: YARP::StatementsNode[body: []]]]
   end
 
-  test "comment inline" do
-    YARP.parse("# comment") => YARP::ParseResult[comments: [YARP::Comment[type: :inline]]]
-  end
-
-  test "comment __END__" do
-    source = <<~RUBY
-      __END__
-      comment
-    RUBY
-
-    YARP.parse(source) => YARP::ParseResult[comments: [YARP::Comment[type: :__END__]]]
-  end
-
-  test "comment embedded document" do
-    source = <<~RUBY
-      =begin
-      comment
-      =end
-    RUBY
-
-    YARP.parse(source) => YARP::ParseResult[comments: [YARP::Comment[type: :embdoc]]]
-  end
-
-  test "comment embedded document with content on same line" do
-    source = <<~RUBY
-      =begin other stuff
-      =end
-    RUBY
-
-    YARP.parse(source) => YARP::ParseResult[comments: [YARP::Comment[type: :embdoc]]]
-  end
-
   Dir[File.expand_path("fixtures/**/*.rb", __dir__)].each do |filepath|
     test filepath do
       assert_parses(filepath)

--- a/test/snapshots/comments.rb
+++ b/test/snapshots/comments.rb
@@ -1,1 +1,0 @@
-IntegerNode()


### PR DESCRIPTION
Fit comments_tests into the existing structure, instead of leaving them in `test/parse_test.rb`