### PR TITLE
Implement our own strpbrk

### DIFF
--- a/src/util/yp_strpbrk.c
+++ b/src/util/yp_strpbrk.c
@@ -1,0 +1,27 @@
+#include "yp_strpbrk.h"
+
+// Here we have rolled our own version of strpbrk. The standard library strpbrk
+// has undefined behavior when the source string is not null-terminated. We want
+// to support strings that are not null-terminated because yp_parse does not
+// have the contract that the string is null-terminated. (This is desirable
+// because it means the extension can call yp_parse with the result of a call to
+// mmap).
+//
+// The standard library strpbrk also does not support passing a maximum length
+// to search. We want to support this for the reason mentioned above, but we
+// also don't want it to stop on null bytes. Ruby actually allows null bytes
+// within strings, comments, regular expressions, etc. So we need to be able to
+// skip past them.
+const char *
+yp_strpbrk(const char *source, const char *charset, int maximum) {
+  int index = 0;
+
+  while (index < maximum) {
+    if (strchr(charset, source[index]) != NULL) {
+      return &source[index];
+    }
+    index++;
+  }
+
+  return NULL;
+}

--- a/src/util/yp_strpbrk.h
+++ b/src/util/yp_strpbrk.h
@@ -1,0 +1,22 @@
+#ifndef YP_STRPBRK_H
+#define YP_STRPBRK_H
+
+#include <stddef.h>
+#include <string.h>
+
+// Here we have rolled our own version of strpbrk. The standard library strpbrk
+// has undefined behavior when the source string is not null-terminated. We want
+// to support strings that are not null-terminated because yp_parse does not
+// have the contract that the string is null-terminated. (This is desirable
+// because it means the extension can call yp_parse with the result of a call to
+// mmap).
+//
+// The standard library strpbrk also does not support passing a maximum length
+// to search. We want to support this for the reason mentioned above, but we
+// also don't want it to stop on null bytes. Ruby actually allows null bytes
+// within strings, comments, regular expressions, etc. So we need to be able to
+// skip past them.
+const char *
+yp_strpbrk(const char *source, const char *charset, int maximum);
+
+#endif

--- a/src/yarp.h
+++ b/src/yarp.h
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "util/yp_buffer.h"
+#include "util/yp_strpbrk.h"
 #include "util/yp_strspn.h"
 #include "ast.h"
 #include "diagnostic.h"


### PR DESCRIPTION
Here we have rolled our own version of `strpbrk`. The standard library `strpbrk`
has undefined behavior when the source string is not null-terminated. We want
to support strings that are not null-terminated because `yp_parse` does not
have the contract that the string is null-terminated. (This is desirable
because it means the extension can call `yp_parse` with the result of a call to
mmap).

The standard library `strpbrk` also does not support passing a maximum length
to search. We want to support this for the reason mentioned above, but we
also don't want it to stop on null bytes. Ruby actually allows null bytes
within strings, comments, regular expressions, etc. So we need to be able to
skip past them.

Fixes #406