### PR TITLE
Emit error messages for "bad" parameter types

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5289,6 +5289,14 @@ parse_parameters(yp_parser_t *parser, bool uses_parentheses, yp_binding_power_t 
         parser_lex(parser);
         yp_diagnostic_list_append(&parser->error_list, "Formal argument cannot be an instance variable", parser->previous.start - parser->start);
         break;
+      case YP_TOKEN_GLOBAL_VARIABLE:
+        parser_lex(parser);
+        yp_diagnostic_list_append(&parser->error_list, "Formal argument cannot be a global variable", parser->previous.start - parser->start);
+        break;
+      case YP_TOKEN_CLASS_VARIABLE:
+        parser_lex(parser);
+        yp_diagnostic_list_append(&parser->error_list, "Formal argument cannot be a class variable", parser->previous.start - parser->start);
+        break;
       default:
         return params;
     }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5285,6 +5285,10 @@ parse_parameters(yp_parser_t *parser, bool uses_parentheses, yp_binding_power_t 
         parser_lex(parser);
         yp_diagnostic_list_append(&parser->error_list, "Formal argument cannot be a constant", parser->previous.start - parser->start);
         break;
+      case YP_TOKEN_INSTANCE_VARIABLE:
+        parser_lex(parser);
+        yp_diagnostic_list_append(&parser->error_list, "Formal argument cannot be an instance variable", parser->previous.start - parser->start);
+        break;
       default:
         return params;
     }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5281,6 +5281,10 @@ parse_parameters(yp_parser_t *parser, bool uses_parentheses, yp_binding_power_t 
         params->as.parameters_node.keyword_rest = param;
         break;
       }
+      case YP_TOKEN_CONSTANT:
+        parser_lex(parser);
+        yp_diagnostic_list_append(&parser->error_list, "Formal argument cannot be a constant", parser->previous.start - parser->start);
+        break;
       default:
         return params;
     }

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -422,7 +422,7 @@ class ErrorsTest < Test::Unit::TestCase
     ", ["Module definition in method body"]
   end
 
-  test "constants in method parameters" do
+  test "bad arguments" do
     expected = DefNode(
       IDENTIFIER("foo"),
       nil,
@@ -437,29 +437,11 @@ class ErrorsTest < Test::Unit::TestCase
       Location()
     )
 
-    assert_errors expected, "def foo(A, B);end", [
+    assert_errors expected, "def foo(A, @a, $A, @@a);end", [
       "Formal argument cannot be a constant",
-      "Formal argument cannot be a constant",
-    ]
-  end
-
-  test "instance variables in method parameters" do
-    expected = DefNode(
-      IDENTIFIER("foo"),
-      nil,
-      ParametersNode([], [], nil, [], nil, nil),
-      StatementsNode([]),
-      Scope([]),
-      Location(),
-      nil,
-      Location(),
-      Location(),
-      nil,
-      Location()
-    )
-
-    assert_errors expected, "def foo(@a);end", [
       "Formal argument cannot be an instance variable",
+      "Formal argument cannot be a global variable",
+      "Formal argument cannot be a class variable",
     ]
   end
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -443,6 +443,26 @@ class ErrorsTest < Test::Unit::TestCase
     ]
   end
 
+  test "instance variables in method parameters" do
+    expected = DefNode(
+      IDENTIFIER("foo"),
+      nil,
+      ParametersNode([], [], nil, [], nil, nil),
+      StatementsNode([]),
+      Scope([]),
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
+    )
+
+    assert_errors expected, "def foo(@a);end", [
+      "Formal argument cannot be an instance variable",
+    ]
+  end
+
   private
 
   def assert_errors(expected, source, errors)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -422,6 +422,27 @@ class ErrorsTest < Test::Unit::TestCase
     ", ["Module definition in method body"]
   end
 
+  test "constants in method parameters" do
+    expected = DefNode(
+      IDENTIFIER("foo"),
+      nil,
+      ParametersNode([], [], nil, [], nil, nil),
+      StatementsNode([]),
+      Scope([]),
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      nil,
+      Location()
+    )
+
+    assert_errors expected, "def foo(A, B);end", [
+      "Formal argument cannot be a constant",
+      "Formal argument cannot be a constant",
+    ]
+  end
+
   private
 
   def assert_errors(expected, source, errors)


### PR DESCRIPTION
Emit an error message when we see a 

- constant 
- instance variable
- global variable
- class variable

in the parameters list like CRuby:

```
ruby -e "def foo(A);end"                                      
-e:1: formal argument cannot be a constant
def foo(A);end
-e: compile error (SyntaxError)
```

Ref https://github.com/ruby/ruby/blob/56b38fdd69d56e8ff2ae9032fa55f2eda8bb5d63/parse.y#L5599
