### PR TITLE
Heredoc fixes

### DIFF
--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -304,7 +304,7 @@ module YARP
           # anything to dedent. If there isn't, then we can return the tokens
           # directly since no on_ignored_sp tokens need to be inserted.
           tokens.last.state = state
-          return tokens if dedent.nil? || dedent == 0
+          return tokens if dedent.nil?
 
           # Otherwise, we're going to run through each token in the list and
           # insert on_ignored_sp tokens for the amount of dedent that we need to
@@ -339,7 +339,7 @@ module YARP
                     # Blank lines do not count toward common leading whitespace
                     # calculation and do not need to be dedented.
                     column = 0
-                  else
+                  elsif dedent > 0
                     deleting = 0
                     deleted_chars = []
 

--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -285,17 +285,22 @@ module YARP
         # whitespace on plain string content tokens. This allows us to later
         # remove that amount of whitespace from the beginning of each line.
         def <<(token)
-          if dedent_next && token.event == :on_tstring_content && token.value.start_with?(/\s/)
-            token.value.split("\n").each do |line|
+          if token.event == :on_tstring_content
+            token.value.split("\n").each_with_index do |line, index|
               # Blank lines don't count toward the dedent.
               next if line.empty?
 
-              leading = line[/\A\s*/]
-              @dedent = [dedent, leading.length + (leading.count("\t") * (TAB_WIDTH - 1))].compact.min
+              if dedent_next || index > 0
+                leading = line[/\A\s*/]
+                @dedent = [dedent, leading.length + (leading.count("\t") * (TAB_WIDTH - 1))].compact.min
+              end
             end
+
+            @dedent_next = true
+          else
+            @dedent_next = false
           end
 
-          @dedent_next = token.event == :on_tstring_content
           tokens << token
         end
 

--- a/targets.yml
+++ b/targets.yml
@@ -57,7 +57,6 @@ ruby:
     - test/csv/test_encodings.rb
     - test/csv/test_patterns.rb
     - test/io/console/test_io_console.rb
-    - test/irb/test_ruby_lex.rb
     - test/openssl/test_x509name.rb
     - test/psych/test_parser.rb
     - test/psych/test_yaml.rb
@@ -123,7 +122,6 @@ rails:
     - activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
     - activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
     - activesupport/test/core_ext/string_ext_test.rb
-    - railties/test/commands/routes_test.rb
     - railties/test/isolation/abstract_unit.rb
 
 discourse:
@@ -133,13 +131,9 @@ discourse:
     - app/controllers/admin/api_controller.rb
     - app/controllers/composer_controller.rb
     - app/jobs/scheduled/enqueue_suspect_users.rb
-    - app/models/about.rb
-    - app/models/category_tag_stat.rb
     - app/models/global_setting.rb
     - app/models/post.rb
-    - app/models/tag.rb
     - app/models/topic_thumbnail.rb
-    - app/services/badge_granter.rb
     - app/services/hashtag_autocomplete_service.rb
     - lib/discourse_dev/record.rb
     - lib/slug.rb
@@ -149,9 +143,6 @@ discourse:
     - plugins/chat/lib/chat_channel_fetcher.rb
     - plugins/chat/lib/chat_mailer.rb
     - plugins/chat/lib/extensions/user_notifications_extension.rb
-    - plugins/chat/spec/plugin_spec.rb
     - script/import_scripts/yahoogroup.rb
     - spec/lib/discourse_spec.rb
-    - spec/lib/tiny_japanese_segmenter_spec.rb
     - spec/models/reviewable_spec.rb
-    - spec/requests/tags_controller_spec.rb


### PR DESCRIPTION
* Properly match ripper when dedent is 0
* Correct the lex_compat whitespace calculation for blank lines
* Gather up remaining splits of tstring_content to match ripper

Fixes #478
Fixes #491