### PR TITLE
Fix segfault for invalid syntax

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6275,6 +6275,11 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       parser_lex(parser);
       yp_node_t *node = parse_identifier(parser);
 
+      // If we already have a call node, then we cannot convert it to a fcall.
+      if (node->type == YP_NODE_CALL_NODE) {
+        return node;
+      }
+
       // If an identifier is followed by something that looks like an argument,
       // then this is in fact a method call, not a local read.
       if (


### PR DESCRIPTION
yarp creates a segfault when we see an unexpected token after method call:

```ruby
foo() @foo
foo() 123
foo() "bar"
```

This PR fixes the segfault but it basically just eats up the unexpected tokens after the method call. I think we should emit some kind of error message for those cases.
