### PR TITLE
Add a callback for when the encoding changes

### DIFF
--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -13,18 +13,22 @@ If the file is not encoded in UTF-8, the user must specify the encoding in a "ma
 The key of the comment can be either "encoding" or "coding". The value of the comment must be a string that is a valid encoding name. The encodings that YARP supports by default are:
 
 * `ascii`
+* `ascii-8bit`
+* `big5`
 * `binary`
 * `iso-8859-9`
+* `iso-8859-15`
 * `us-ascii`
 * `utf-8`
+* `windows-1252`
 
 For each of these encodings, YARP provides a function for checking if the subsequent bytes form an alphabetic or alphanumeric character.
 
-If an encoding is encountered that is not supported by YARP, YARP will call a user-provided callback function with the name of the encoding. The user-provided callback function can then provide a pointer to an encoding struct that contains the requisite functions that YARP will use those to parse identifiers going forward.
+## Support for other encodings
+
+If an encoding is encountered that is not supported by YARP, YARP will call a user-provided callback function with the name of the encoding if one is provided. That function can be registered with `yp_parser_register_encoding_decode_callback`. The user-provided callback function can then provide a pointer to an encoding struct that contains the requisite functions that YARP will use those to parse identifiers going forward.
 
 If the user-provided callback function returns `NULL` (the value also provided by the default implementation in case a callback was not registered), an error will be added to the parser's error list and parsing will continue on using the default UTF-8 encoding.
-
-The relevant APIs, struct definitions, and typedefs are listed below:
 
 ```c
 // This struct defines the functions necessary to implement the encoding
@@ -32,21 +36,38 @@ The relevant APIs, struct definitions, and typedefs are listed below:
 // Each callback should return the number of bytes, or 0 if the next bytes are
 // invalid for the encoding and type.
 typedef struct {
-  size_t (*alpha_char)(const char *);
-  size_t (*alnum_char)(const char *);
+  const char *name;
+  size_t (*alpha_char)(const char *c);
+  size_t (*alnum_char)(const char *c);
+  bool (*isupper_char)(const char *c);
 } yp_encoding_t;
 
 // When an encoding is encountered that isn't understood by YARP, we provide
 // the ability here to call out to a user-defined function to get an encoding
 // struct. If the function returns something that isn't NULL, we set that to
 // our encoding and use it to parse identifiers.
-typedef yp_encoding_t *(*yp_encoding_decode_callback_t)(const char *, size_t);
+typedef yp_encoding_t *(*yp_encoding_decode_callback_t)(yp_parser_t *parser, const char *name, size_t width);
 
 // Register a callback that will be called when YARP encounters a magic comment
 // with an encoding referenced that it doesn't understand. The callback should
 // return NULL if it also doesn't understand the encoding or it should return a
 // pointer to a yp_encoding_t struct that contains the functions necessary to
 // parse identifiers.
-void
-yp_parser_register_encoding_decode_callback(yp_parser_t *, yp_encoding_decode_callback_t);
+__attribute__((__visibility__("default"))) extern void
+yp_parser_register_encoding_decode_callback(yp_parser_t *parser, yp_encoding_decode_callback_t callback);
+```
+
+## Getting notified when the encoding changes
+
+You may want to get notified when the encoding changes based on the result of parsing an encoding comment. We use this internally for our `lex` function in order to provide the correct encodings for the tokens that are returned. For that you can register a callback with `yp_parser_register_encoding_changed_callback`. The callback will be called with a pointer to the parser. The encoding can be accessed through `parser->encoding`.
+
+```c
+// When the encoding that is being used to parse the source is changed by YARP,
+// we provide the ability here to call out to a user-defined function.
+typedef void (*yp_encoding_changed_callback_t)(yp_parser_t *parser);
+
+// Register a callback that will be called whenever YARP changes the encoding it
+// is using to parse based on the magic comment.
+__attribute__((__visibility__("default"))) extern void
+yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback);
 ```

--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -109,9 +109,9 @@ dump_file(VALUE self, VALUE filepath) {
 static VALUE
 parser_comments(yp_parser_t *parser) {
   VALUE comments = rb_ary_new();
+  yp_comment_t *comment;
 
-  for (yp_comment_t *comment = (yp_comment_t *) parser->comment_list.head; comment != NULL;
-       comment = (yp_comment_t *) comment->node.next) {
+  for (comment = (yp_comment_t *) parser->comment_list.head; comment != NULL; comment = (yp_comment_t *) comment->node.next) {
     VALUE location_argv[] = { LONG2FIX(comment->start - parser->start), LONG2FIX(comment->end - parser->start) };
     VALUE type;
 
@@ -143,11 +143,16 @@ parser_errors(yp_parser_t *parser, rb_encoding *encoding) {
   VALUE errors = rb_ary_new();
   yp_diagnostic_t *error;
 
-  for (error = (yp_diagnostic_t *) parser->error_list.head; error != NULL;
-       error = (yp_diagnostic_t *) error->node.next) {
-    VALUE location_argv[] = { LONG2FIX(error->start - parser->start), LONG2FIX(error->end - parser->start) };
-    VALUE error_argv[] = { rb_enc_str_new_cstr(error->message, encoding),
-                           rb_class_new_instance(2, location_argv, rb_cYARPLocation) };
+  for (error = (yp_diagnostic_t *) parser->error_list.head; error != NULL; error = (yp_diagnostic_t *) error->node.next) {
+    VALUE location_argv[] = {
+      LONG2FIX(error->start - parser->start),
+      LONG2FIX(error->end - parser->start)
+    };
+
+    VALUE error_argv[] = {
+      rb_enc_str_new_cstr(error->message, encoding),
+      rb_class_new_instance(2, location_argv, rb_cYARPLocation)
+    };
 
     rb_ary_push(errors, rb_class_new_instance(2, error_argv, rb_cYARPParseError));
   }
@@ -161,11 +166,16 @@ parser_warnings(yp_parser_t *parser, rb_encoding *encoding) {
   VALUE warnings = rb_ary_new();
   yp_diagnostic_t *warning;
 
-  for (warning = (yp_diagnostic_t *) parser->warning_list.head; warning != NULL;
-       warning = (yp_diagnostic_t *) warning->node.next) {
-    VALUE location_argv[] = { LONG2FIX(warning->start - parser->start), LONG2FIX(warning->end - parser->start) };
-    VALUE warning_argv[] = { rb_enc_str_new_cstr(warning->message, encoding),
-                             rb_class_new_instance(2, location_argv, rb_cYARPLocation) };
+  for (warning = (yp_diagnostic_t *) parser->warning_list.head; warning != NULL; warning = (yp_diagnostic_t *) warning->node.next) {
+    VALUE location_argv[] = {
+      LONG2FIX(warning->start - parser->start),
+      LONG2FIX(warning->end - parser->start)
+    };
+
+    VALUE warning_argv[] = {
+      rb_enc_str_new_cstr(warning->message, encoding),
+      rb_class_new_instance(2, location_argv, rb_cYARPLocation)
+    };
 
     rb_ary_push(warnings, rb_class_new_instance(2, warning_argv, rb_cYARPParseWarning));
   }
@@ -178,43 +188,6 @@ typedef struct {
   rb_encoding *encoding;
 } lex_data_t;
 
-static yp_encoding_t yp_encoding_ascii = { .name = "ascii",
-                                           .alnum_char = yp_encoding_ascii_alnum_char,
-                                           .alpha_char = yp_encoding_ascii_alpha_char,
-                                           .isupper_char = yp_encoding_ascii_isupper_char };
-
-static yp_encoding_t yp_encoding_ascii_8bit = {
-  .name = "ascii-8bit",
-  .alnum_char = yp_encoding_ascii_alnum_char,
-  .alpha_char = yp_encoding_ascii_alpha_char,
-  .isupper_char = yp_encoding_ascii_isupper_char,
-};
-
-static yp_encoding_t yp_encoding_big5 = { .name = "big5",
-                                          .alnum_char = yp_encoding_big5_alnum_char,
-                                          .alpha_char = yp_encoding_big5_alpha_char,
-                                          .isupper_char = yp_encoding_big5_isupper_char };
-
-static yp_encoding_t yp_encoding_iso_8859_9 = { .name = "iso-8859-9",
-                                                .alnum_char = yp_encoding_iso_8859_9_alnum_char,
-                                                .alpha_char = yp_encoding_iso_8859_9_alpha_char,
-                                                .isupper_char = yp_encoding_iso_8859_9_isupper_char };
-
-static yp_encoding_t yp_encoding_iso_8859_15 = { .name = "iso-8859-15",
-                                                 .alnum_char = yp_encoding_iso_8859_15_alnum_char,
-                                                 .alpha_char = yp_encoding_iso_8859_15_alpha_char,
-                                                 .isupper_char = yp_encoding_iso_8859_15_isupper_char };
-
-static yp_encoding_t yp_encoding_utf_8 = { .name = "utf-8",
-                                           .alnum_char = yp_encoding_utf_8_alnum_char,
-                                           .alpha_char = yp_encoding_utf_8_alpha_char,
-                                           .isupper_char = yp_encoding_utf_8_isupper_char };
-
-static yp_encoding_t yp_encoding_windows_1252 = { .name = "windows-1252",
-                                                  .alnum_char = yp_encoding_windows_1252_alnum_char,
-                                                  .alpha_char = yp_encoding_windows_1252_alpha_char,
-                                                  .isupper_char = yp_encoding_windows_1252_isupper_char };
-
 static void
 lex_token(void *data, yp_parser_t *parser, yp_token_t *token) {
   lex_data_t *lex_data = (lex_data_t *) parser->lex_callback->data;
@@ -226,31 +199,10 @@ lex_token(void *data, yp_parser_t *parser, yp_token_t *token) {
   rb_ary_push(lex_data->tokens, yields);
 }
 
-static yp_encoding_t *
-lex_encoding_callback(yp_parser_t *parser, const char *start, size_t width) {
-  char compare[width + 1];
-  sprintf(compare, "%.*s", (int) width, start);
-
-#define ENCODING(value, prebuilt)                                                                                      \
-  if (width == sizeof(value) - 1 && strncasecmp(compare, value, sizeof(value) - 1) == 0) {                             \
-    lex_data_t *lex_data = (lex_data_t *) parser->lex_callback->data;                                                  \
-    lex_data->encoding = rb_enc_find(prebuilt.name);                                                                   \
-    return &prebuilt;                                                                                                  \
-  }
-
-  ENCODING("ascii", yp_encoding_ascii);
-  ENCODING("ascii-8bit", yp_encoding_ascii_8bit);
-  ENCODING("big5", yp_encoding_big5);
-  ENCODING("binary", yp_encoding_ascii_8bit);
-  ENCODING("iso-8859-9", yp_encoding_iso_8859_9);
-  ENCODING("iso-8859-15", yp_encoding_iso_8859_15);
-  ENCODING("us-ascii", yp_encoding_ascii);
-  ENCODING("utf-8", yp_encoding_utf_8);
-  ENCODING("windows-1252", yp_encoding_windows_1252);
-
-#undef ENCODING
-
-  return NULL;
+static void
+lex_encoding_changed_callback(yp_parser_t *parser) {
+  lex_data_t *lex_data = (lex_data_t *) parser->lex_callback->data;
+  lex_data->encoding = rb_enc_find(parser->encoding.name);
 }
 
 // Return an array of tokens corresponding to the given source.
@@ -258,9 +210,12 @@ static VALUE
 lex_source(source_t *source) {
   yp_parser_t parser;
   yp_parser_init(&parser, source->source, source->size);
-  yp_parser_register_encoding_decode_callback(&parser, lex_encoding_callback);
+  yp_parser_register_encoding_changed_callback(&parser, lex_encoding_changed_callback);
 
-  lex_data_t lex_data = { .tokens = rb_ary_new(), .encoding = rb_utf8_encoding() };
+  lex_data_t lex_data = {
+    .tokens = rb_ary_new(),
+    .encoding = rb_utf8_encoding()
+  };
 
   void *data = (void *) &lex_data;
   yp_lex_callback_t lex_callback = (yp_lex_callback_t) {
@@ -271,8 +226,12 @@ lex_source(source_t *source) {
   parser.lex_callback = &lex_callback;
   yp_node_t *node = yp_parse(&parser);
 
-  VALUE result_argv[] = { lex_data.tokens, parser_comments(&parser), parser_errors(&parser, lex_data.encoding),
-                          parser_warnings(&parser, lex_data.encoding) };
+  VALUE result_argv[] = {
+    lex_data.tokens,
+    parser_comments(&parser),
+    parser_errors(&parser, lex_data.encoding),
+    parser_warnings(&parser, lex_data.encoding)
+  };
 
   VALUE result = rb_class_new_instance(4, result_argv, rb_cYARPParseResult);
 
@@ -309,8 +268,12 @@ parse_source(source_t *source) {
   yp_node_t *node = yp_parse(&parser);
   rb_encoding *encoding = rb_enc_find(parser.encoding.name);
 
-  VALUE result_argv[] = { yp_node_new(&parser, node, encoding), parser_comments(&parser),
-                          parser_errors(&parser, encoding), parser_warnings(&parser, encoding) };
+  VALUE result_argv[] = {
+    yp_node_new(&parser, node, encoding),
+    parser_comments(&parser),
+    parser_errors(&parser, encoding),
+    parser_warnings(&parser, encoding)
+  };
 
   VALUE result = rb_class_new_instance(4, result_argv, rb_cYARPParseResult);
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -236,6 +236,10 @@ typedef struct {
   bool (*isupper_char)(const char *c);
 } yp_encoding_t;
 
+// When the encoding that is being used to parse the source is changed by YARP,
+// we provide the ability here to call out to a user-defined function.
+typedef void (*yp_encoding_changed_callback_t)(yp_parser_t *parser);
+
 // When an encoding is encountered that isn't understood by YARP, we provide
 // the ability here to call out to a user-defined function to get an encoding
 // struct. If the function returns something that isn't NULL, we set that to
@@ -332,6 +336,10 @@ struct yp_parser {
   // The encoding functions for the current file is attached to the parser as
   // it's parsing so that it can change with a magic comment.
   yp_encoding_t encoding;
+
+  // When the encoding that is being used to parse the source is changed by
+  // YARP, we provide the ability here to call out to a user-defined function.
+  yp_encoding_changed_callback_t encoding_changed_callback;
 
   // When an encoding is encountered that isn't understood by YARP, we provide
   // the ability here to call out to a user-defined function to get an encoding

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1728,6 +1728,7 @@ parser_lex_magic_comments(yp_parser_t *parser) {
 #define ENCODING(value, prebuilt) \
     if (width == sizeof(value) - 1 && strncasecmp(start, value, sizeof(value) - 1) == 0) { \
       parser->encoding = prebuilt; \
+      if (parser->encoding_changed_callback != NULL) parser->encoding_changed_callback(parser); \
       return; \
     }
 
@@ -8352,12 +8353,11 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size) {
     .enclosure_nesting = 0,
     .lambda_enclosure_nesting = -1,
     .brace_nesting = 0,
-    .lex_modes =
-      {
-        .index = 0,
-        .stack = {{.mode = YP_LEX_DEFAULT}},
-        .current = &parser->lex_modes.stack[0],
-      },
+    .lex_modes = {
+      .index = 0,
+      .stack = {{ .mode = YP_LEX_DEFAULT }},
+      .current = &parser->lex_modes.stack[0],
+    },
     .start = source,
     .end = source + size,
     .current = { .start = source, .end = source },
@@ -8385,6 +8385,13 @@ yp_parser_init(yp_parser_t *parser, const char *source, size_t size) {
   if (size >= 3 && (unsigned char) source[0] == 0xef && (unsigned char) source[1] == 0xbb && (unsigned char) source[2] == 0xbf) {
     parser->current.end += 3;
   }
+}
+
+// Register a callback that will be called whenever YARP changes the encoding it
+// is using to parse based on the magic comment.
+__attribute__((__visibility__("default"))) extern void
+yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback) {
+  parser->encoding_changed_callback = callback;
 }
 
 // Register a callback that will be called when YARP encounters a magic comment

--- a/src/yarp.h
+++ b/src/yarp.h
@@ -38,6 +38,11 @@ yp_version(void);
 __attribute__((__visibility__("default"))) extern void
 yp_parser_init(yp_parser_t *parser, const char *source, size_t size);
 
+// Register a callback that will be called whenever YARP changes the encoding it
+// is using to parse based on the magic comment.
+__attribute__((__visibility__("default"))) extern void
+yp_parser_register_encoding_changed_callback(yp_parser_t *parser, yp_encoding_changed_callback_t callback);
+
 // Register a callback that will be called when YARP encounters a magic comment
 // with an encoding referenced that it doesn't understand. The callback should
 // return NULL if it also doesn't understand the encoding or it should return a


### PR DESCRIPTION
Previously we were using the callback to support additional encodings to also handle getting notified when the encoding changed.

This simplifies that flow by providing a different callback for when the encoding changes.