### PR TITLE
First string content being split on $#

### DIFF
--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -165,7 +165,27 @@ module YARP
   # This lexes with the Ripper lex. It drops any space events but otherwise
   # returns the same tokens.
   def self.lex_ripper(source)
-    Ripper.lex(source).reject { |token| token[1] == :on_sp }
+    previous = []
+    results = []
+
+    Ripper.lex(source).each do |token|
+      case token[1]
+      when :on_sp
+        # skip
+      when :on_tstring_content
+        if previous[1] == :on_tstring_content && token[2].start_with?("\#$")
+          previous[2] << token[2]
+        else
+          results << token
+        end
+      else
+        results << token
+      end
+
+      previous = token
+    end
+
+    results
   end
 
   # Load the serialized AST using the source as a reference into a tree.

--- a/targets.yml
+++ b/targets.yml
@@ -11,15 +11,12 @@ ruby:
     - spec/ruby/command_line/fixtures/bad_syntax.rb
   todos:
     - benchmark/app_lc_fizzbuzz.rb
-    - ext/psych/lib/psych/scalar_scanner.rb
     - lib/ruby_vm/rjit/assembler.rb
     - lib/ruby_vm/rjit/insn_compiler.rb
     - test/csv/test_patterns.rb
     - test/psych/visitors/test_to_ruby.rb
     - test/ruby/enc/test_euc_jp.rb
     - test/ruby/enc/test_shift_jis.rb
-    - test/ruby/enc/test_windows_1251.rb
-    - test/ruby/enc/test_windows_1252.rb
     - test/ruby/test_mixed_unicode_escapes.rb
     - test/ruby/test_pattern_matching.rb
     - test/ruby/test_string.rb
@@ -31,8 +28,6 @@ ruby:
 rails:
   repo: https://github.com/rails/rails
   sha: 8e3449908c59858384ae230d1416c7dcabc8c2dc
-  todos:
-    - actionpack/test/dispatch/content_disposition_test.rb
 
 discourse:
   repo: https://github.com/discourse/discourse
@@ -47,5 +42,4 @@ discourse:
     - plugins/chat/lib/chat_channel_fetcher.rb
     - plugins/chat/lib/chat_mailer.rb
     - plugins/chat/lib/extensions/user_notifications_extension.rb
-    - script/import_scripts/yahoogroup.rb
     - spec/models/reviewable_spec.rb


### PR DESCRIPTION
In Ripper.lex, two string content nodes are created right after another if the string contains $#, even if it doesn't result in interpolation. This doesn't always happen though, and depends on both state and other content in the string.

Replicating this behavior exactly in YARP would require more effort than it's worth. Instead, we're going to just change this in our own ripper lex function since we have semantically equivalent tokens and no one is actually relying on this behavior.

Fixes #488