### PR TITLE
ParseTest requires Ruby 3.2+

### DIFF
--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class ParseTest < Test::Unit::TestCase
+  test "Ruby 3.2+" do
+    assert_operator Gem::Version.new(RUBY_VERSION), :>=, Gem::Version.new("3.2.0"), "ParseTest requires Ruby 3.2+"
+  end
+
   test "empty string" do
     YARP.parse("") => YARP::ParseResult[value: YARP::ProgramNode[statements: YARP::StatementsNode[body: []]]]
   end


### PR DESCRIPTION
On 3.1 it fails like:
```
.............................................................F
==============================================================================================================================
Failure: test: /home/eregon/code/yarp/test/fixtures/hashes.rb(ParseTest)
/home/eregon/code/yarp/test/parse_test.rb:57:in `block (3 levels) in <class:ParseTest>'
     54:       # Ripper.
     55:       YARP.lex_compat(source) => { errors: [], value: tokens }
     56:       YARP.lex_ripper(source).zip(tokens).each do |(ripper, yarp)|
  => 57:         assert_equal ripper, yarp
     58:       end
     59:     end
     60:   end
/home/eregon/code/yarp/test/parse_test.rb:56:in `each'
/home/eregon/code/yarp/test/parse_test.rb:56:in `block (2 levels) in <class:ParseTest>'
<[[20, 4], :on_label_end, "\":", BEG|LABEL]> expected but was
<[[20, 4], :on_label_end, "\":", ARG|LABELED]>

diff:
? [[20, 4], :on_label_end, "\":", BEG|LABEL  ]
?                                 AR       ED 
?                                 ??       ++ 
==============================================================================================================================
....F
==============================================================================================================================
Failure: test: /home/eregon/code/yarp/test/fixtures/method_calls.rb(ParseTest)
/home/eregon/code/yarp/test/parse_test.rb:57:in `block (3 levels) in <class:ParseTest>'
     54:       # Ripper.
     55:       YARP.lex_compat(source) => { errors: [], value: tokens }
     56:       YARP.lex_ripper(source).zip(tokens).each do |(ripper, yarp)|
  => 57:         assert_equal ripper, yarp
     58:       end
     59:     end
     60:   end
/home/eregon/code/yarp/test/parse_test.rb:56:in `each'
/home/eregon/code/yarp/test/parse_test.rb:56:in `block (2 levels) in <class:ParseTest>'
<[[97, 6], :on_label_end, "\":", BEG|LABEL]> expected but was
<[[97, 6], :on_label_end, "\":", ARG|LABELED]>

diff:
? [[97, 6], :on_label_end, "\":", BEG|LABEL  ]
?                                 AR       ED 
?                                 ??       ++ 
==============================================================================================================================
F
==============================================================================================================================
Failure: test: /home/eregon/code/yarp/test/fixtures/methods.rb(ParseTest): <nil> was expected to not be nil.
/home/eregon/code/yarp/test/parse_test.rb:20:in `block (2 levels) in <class:ParseTest>'
     17:       # correctly parsed by Ripper. If it can't, then we have a fixture that is
     18:       # invalid Ruby.
     19:       source = File.read(filepath)
  => 20:       refute_nil Ripper.sexp_raw(source)
     21: 
     22:       # Next, parse the source and print the value.
     23:       result = YARP.parse(source)
==============================================================================================================================
............................F
```

With this it's more obvious as it ends with:
```
==============================================================================================================================
Failure: test: Ruby 3.2+(ParseTest):
  ParseTest requires Ruby 3.2+.
  <Gem::Version.new("3.1.3")> was expected to be
  >=
  <Gem::Version.new("3.2.0")>.
/home/eregon/code/yarp/test/parse_test.rb:7:in `block in <class:ParseTest>'
      4: 
      5: class ParseTest < Test::Unit::TestCase
      6:   test "Ruby 3.2+" do
  =>  7:     assert_operator Gem::Version.new(RUBY_VERSION), :>=, Gem::Version.new("3.2.0"), "ParseTest requires Ruby 3.2+"
      8:   end
      9: 
     10:   test "empty string" do
==============================================================================================================================
...........................................................................................................................
Finished in 0.355106381 seconds.
```