### PR TITLE
Fix up command start on blocks with trailing newlines

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -5661,8 +5661,9 @@ parse_block(yp_parser_t *parser) {
 
   if (accept(parser, YP_TOKEN_PIPE)) {
     parameters = parse_block_parameters(parser);
-    parser->command_start = true;
     accept(parser, YP_TOKEN_NEWLINE);
+
+    parser->command_start = true;
     expect(parser, YP_TOKEN_PIPE, "Expected block parameters to end with '|'.");
   }
 


### PR DESCRIPTION
Fixes #598