### PR TITLE
More pattern matching

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -4,5 +4,4 @@
 $:.unshift(File.expand_path("../lib", __dir__))
 require "yarp"
 
-source = File.read(ARGV[0])
-pp YARP.load(source, YARP.dump(source))
+pp YARP.parse_file_dup(ARGV[0])

--- a/config.yml
+++ b/config.yml
@@ -1195,6 +1195,22 @@ nodes:
 
           (10 + 34)
           ^^^^^^^^^
+  - name: PinnedExpressionNode
+    child_nodes:
+      - name: expression
+        type: node
+      - name: operator_loc
+        type: location
+      - name: lparen_loc
+        type: location
+      - name: rparen_loc
+        type: location
+    comment: |
+      Represents the use of the `^` operator for pinning an expression in a
+      pattern matching expression.
+
+          foo in ^(bar)
+                 ^^^^^^
   - name: PinnedVariableNode
     child_nodes:
       - name: variable
@@ -1205,8 +1221,8 @@ nodes:
       Represents the use of the `^` operator for pinning a variable in a pattern
       matching expression.
 
-          case foo in ^bar
-                      ^^^^
+          foo in ^bar
+                 ^^^^
   - name: PostExecutionNode
     child_nodes:
       - name: statements

--- a/config.yml
+++ b/config.yml
@@ -362,6 +362,37 @@ nodes:
 
           [1, 2, 3]
           ^^^^^^^^^
+  - name: ArrayPatternNode
+    child_nodes:
+      - name: constant
+        type: node?
+      - name: requireds
+        type: node[]
+      - name: rest
+        type: node?
+      - name: posts
+        type: node[]
+      - name: opening_loc
+        type: location?
+      - name: closing_loc
+        type: location?
+    comment: |
+      Represents an array pattern in pattern matching.
+
+          foo in 1, 2
+          ^^^^^^^^^^^
+
+          foo in [1, 2]
+          ^^^^^^^^^^^^^
+
+          foo in *1
+          ^^^^^^^^^
+
+          foo in Bar[]
+          ^^^^^^^^^^^^
+
+          foo in Bar[1, 2, 3]
+          ^^^^^^^^^^^^^^^^^^^
   - name: AssocNode
     child_nodes:
       - name: key
@@ -681,6 +712,31 @@ nodes:
 
           false
           ^^^^^
+  - name: FindPatternNode
+    child_nodes:
+      - name: constant
+        type: node?
+      - name: left
+        type: node
+      - name: requireds
+        type: node[]
+      - name: right
+        type: node
+      - name: opening_loc
+        type: location?
+      - name: closing_loc
+        type: location?
+    comment: |
+      Represents a find pattern in pattern matching.
+
+          foo in *bar, baz, *qux
+          ^^^^^^^^^^^^^^^^^^^^^^
+
+          foo in [*bar, baz, *qux]
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+
+          foo in Foo(*bar, baz, *qux)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   - name: FloatNode
     comment: |
       Represents a floating point number literal.

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -6685,6 +6685,9 @@ p_value -> pinned expression
 p_value -> p_const
 */
 
+static yp_node_t *
+parse_pattern(yp_parser_t *parser, bool root_pattern, const char *message);
+
 // Accept any number of constants joined by :: delimiters.
 static yp_node_t *
 parse_pattern_constant_path(yp_parser_t *parser, yp_node_t *node) {

--- a/test/fixtures/patterns.rb
+++ b/test/fixtures/patterns.rb
@@ -56,6 +56,10 @@ foo => ^@bar
 foo => ^@@bar
 foo => ^$bar
 
+foo => ^(1)
+foo => ^(nil)
+foo => ^("bar" + "baz")
+
 foo => Foo
 foo => Foo::Bar::Baz
 foo => ::Foo

--- a/test/fixtures/patterns.rb
+++ b/test/fixtures/patterns.rb
@@ -58,6 +58,8 @@ foo => ^$bar
 
 foo => Foo
 foo => Foo::Bar::Baz
+foo => ::Foo
+foo => ::Foo::Bar::Baz
 
 foo in bar
 foo in 1

--- a/test/fixtures/patterns.rb
+++ b/test/fixtures/patterns.rb
@@ -65,6 +65,37 @@ foo => Foo::Bar::Baz
 foo => ::Foo
 foo => ::Foo::Bar::Baz
 
+foo => Foo()
+foo => Foo(1)
+foo => Foo(1, 2, 3)
+foo => Foo(bar)
+foo => Foo(*bar, baz)
+foo => Foo(bar, *baz)
+foo => Foo(*bar, baz, *qux)
+
+foo => Foo[]
+foo => Foo[1]
+foo => Foo[1, 2, 3]
+foo => Foo[bar]
+foo => Foo[*bar, baz]
+foo => Foo[bar, *baz]
+foo => Foo[*bar, baz, *qux]
+
+foo => *bar
+foo => *bar, baz, qux
+foo => bar, *baz, qux
+foo => bar, baz, *qux
+foo => *bar, baz, *qux
+
+foo => []
+foo => [[[[[]]]]]
+
+foo => [*bar]
+foo => [*bar, baz, qux]
+foo => [bar, *baz, qux]
+foo => [bar, baz, *qux]
+foo => [*bar, baz, *qux]
+
 foo in bar
 foo in 1
 foo in 1.0

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...3089)(
+ProgramNode(0...3140)(
   Scope(0...0)([IDENTIFIER(7...10)("bar")]),
-  StatementsNode(0...3089)(
+  StatementsNode(0...3140)(
     [MatchRequiredNode(0...10)(
        CallNode(0...3)(
          nil,
@@ -1165,7 +1165,7 @@ ProgramNode(0...3089)(
        ),
        (985...987)
      ),
-     MatchRequiredNode(995...1005)(
+     MatchRequiredNode(995...1006)(
        CallNode(995...998)(
          nil,
          nil,
@@ -1176,150 +1176,154 @@ ProgramNode(0...3089)(
          nil,
          "foo"
        ),
-       ConstantReadNode(1002...1005)(),
+       PinnedExpressionNode(1002...1006)(
+         IntegerNode(1004...1005)(),
+         (1002...1003),
+         (1003...1004),
+         (1005...1006)
+       ),
        (999...1001)
      ),
-     MatchRequiredNode(1006...1026)(
-       CallNode(1006...1009)(
+     MatchRequiredNode(1007...1020)(
+       CallNode(1007...1010)(
          nil,
          nil,
-         IDENTIFIER(1006...1009)("foo"),
+         IDENTIFIER(1007...1010)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ConstantPathNode(1013...1026)(
-         ConstantPathNode(1013...1021)(
-           ConstantReadNode(1013...1016)(),
-           ConstantReadNode(1018...1021)(),
-           (1016...1018)
-         ),
-         ConstantReadNode(1023...1026)(),
-         (1021...1023)
+       PinnedExpressionNode(1014...1020)(
+         NilNode(1016...1019)(),
+         (1014...1015),
+         (1015...1016),
+         (1019...1020)
        ),
-       (1010...1012)
+       (1011...1013)
      ),
-     MatchRequiredNode(1027...1039)(
-       CallNode(1027...1030)(
+     MatchRequiredNode(1021...1044)(
+       CallNode(1021...1024)(
          nil,
          nil,
-         IDENTIFIER(1027...1030)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       ConstantPathNode(1034...1039)(
-         nil,
-         ConstantReadNode(1036...1039)(),
-         (1034...1036)
-       ),
-       (1031...1033)
-     ),
-     MatchRequiredNode(1040...1062)(
-       CallNode(1040...1043)(
-         nil,
-         nil,
-         IDENTIFIER(1040...1043)("foo"),
+         IDENTIFIER(1021...1024)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ConstantPathNode(1047...1062)(
-         ConstantPathNode(1047...1057)(
-           ConstantPathNode(1047...1052)(
-             nil,
-             ConstantReadNode(1049...1052)(),
-             (1047...1049)
+       PinnedExpressionNode(1028...1044)(
+         CallNode(1030...1043)(
+           StringNode(1030...1035)(
+             STRING_BEGIN(1030...1031)("\""),
+             STRING_CONTENT(1031...1034)("bar"),
+             STRING_END(1034...1035)("\""),
+             "bar"
            ),
-           ConstantReadNode(1054...1057)(),
-           (1052...1054)
+           nil,
+           PLUS(1036...1037)("+"),
+           nil,
+           ArgumentsNode(1038...1043)(
+             [StringNode(1038...1043)(
+                STRING_BEGIN(1038...1039)("\""),
+                STRING_CONTENT(1039...1042)("baz"),
+                STRING_END(1042...1043)("\""),
+                "baz"
+              )]
+           ),
+           nil,
+           nil,
+           "+"
          ),
-         ConstantReadNode(1059...1062)(),
-         (1057...1059)
+         (1028...1029),
+         (1029...1030),
+         (1043...1044)
        ),
-       (1044...1046)
+       (1025...1027)
      ),
-     MatchPredicateNode(1064...1074)(
-       CallNode(1064...1067)(
+     MatchRequiredNode(1046...1056)(
+       CallNode(1046...1049)(
          nil,
          nil,
-         IDENTIFIER(1064...1067)("foo"),
+         IDENTIFIER(1046...1049)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       LocalVariableWriteNode(1071...1074)(
-         IDENTIFIER(1071...1074)("bar"),
-         nil,
-         nil
-       ),
-       (1068...1070)
+       ConstantReadNode(1053...1056)(),
+       (1050...1052)
      ),
-     MatchPredicateNode(1075...1083)(
-       CallNode(1075...1078)(
+     MatchRequiredNode(1057...1077)(
+       CallNode(1057...1060)(
          nil,
          nil,
-         IDENTIFIER(1075...1078)("foo"),
+         IDENTIFIER(1057...1060)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       IntegerNode(1082...1083)(),
-       (1079...1081)
+       ConstantPathNode(1064...1077)(
+         ConstantPathNode(1064...1072)(
+           ConstantReadNode(1064...1067)(),
+           ConstantReadNode(1069...1072)(),
+           (1067...1069)
+         ),
+         ConstantReadNode(1074...1077)(),
+         (1072...1074)
+       ),
+       (1061...1063)
      ),
-     MatchPredicateNode(1084...1094)(
-       CallNode(1084...1087)(
+     MatchRequiredNode(1078...1090)(
+       CallNode(1078...1081)(
          nil,
          nil,
-         IDENTIFIER(1084...1087)("foo"),
+         IDENTIFIER(1078...1081)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       FloatNode(1091...1094)(),
-       (1088...1090)
+       ConstantPathNode(1085...1090)(
+         nil,
+         ConstantReadNode(1087...1090)(),
+         (1085...1087)
+       ),
+       (1082...1084)
      ),
-     MatchPredicateNode(1095...1104)(
-       CallNode(1095...1098)(
+     MatchRequiredNode(1091...1113)(
+       CallNode(1091...1094)(
          nil,
          nil,
-         IDENTIFIER(1095...1098)("foo"),
+         IDENTIFIER(1091...1094)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ImaginaryNode(1102...1104)(),
-       (1099...1101)
-     ),
-     MatchPredicateNode(1105...1114)(
-       CallNode(1105...1108)(
-         nil,
-         nil,
-         IDENTIFIER(1105...1108)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
+       ConstantPathNode(1098...1113)(
+         ConstantPathNode(1098...1108)(
+           ConstantPathNode(1098...1103)(
+             nil,
+             ConstantReadNode(1100...1103)(),
+             (1098...1100)
+           ),
+           ConstantReadNode(1105...1108)(),
+           (1103...1105)
+         ),
+         ConstantReadNode(1110...1113)(),
+         (1108...1110)
        ),
-       RationalNode(1112...1114)(),
-       (1109...1111)
+       (1095...1097)
      ),
-     MatchPredicateNode(1115...1126)(
+     MatchPredicateNode(1115...1125)(
        CallNode(1115...1118)(
          nil,
          nil,
@@ -1330,57 +1334,56 @@ ProgramNode(0...3089)(
          nil,
          "foo"
        ),
-       SymbolNode(1122...1126)(
-         SYMBOL_BEGIN(1122...1123)(":"),
-         IDENTIFIER(1123...1126)("foo"),
+       LocalVariableWriteNode(1122...1125)(
+         IDENTIFIER(1122...1125)("bar"),
          nil,
-         "foo"
+         nil
        ),
        (1119...1121)
      ),
-     MatchPredicateNode(1127...1141)(
-       CallNode(1127...1130)(
+     MatchPredicateNode(1126...1134)(
+       CallNode(1126...1129)(
          nil,
          nil,
-         IDENTIFIER(1127...1130)("foo"),
+         IDENTIFIER(1126...1129)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SymbolNode(1134...1141)(
-         SYMBOL_BEGIN(1134...1137)("%s["),
-         STRING_CONTENT(1137...1140)("foo"),
-         STRING_END(1140...1141)("]"),
-         "foo"
-       ),
-       (1131...1133)
+       IntegerNode(1133...1134)(),
+       (1130...1132)
      ),
-     MatchPredicateNode(1142...1154)(
-       CallNode(1142...1145)(
+     MatchPredicateNode(1135...1145)(
+       CallNode(1135...1138)(
          nil,
          nil,
-         IDENTIFIER(1142...1145)("foo"),
+         IDENTIFIER(1135...1138)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       InterpolatedSymbolNode(1151...1154)(
-         SYMBOL_BEGIN(1149...1151)(":\""),
-         [StringNode(1151...1154)(
-            nil,
-            STRING_CONTENT(1151...1154)("foo"),
-            nil,
-            "foo"
-          )],
-         STRING_END(1154...1155)("\"")
-       ),
-       (1146...1148)
+       FloatNode(1142...1145)(),
+       (1139...1141)
      ),
-     MatchPredicateNode(1156...1168)(
+     MatchPredicateNode(1146...1155)(
+       CallNode(1146...1149)(
+         nil,
+         nil,
+         IDENTIFIER(1146...1149)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ImaginaryNode(1153...1155)(),
+       (1150...1152)
+     ),
+     MatchPredicateNode(1156...1165)(
        CallNode(1156...1159)(
          nil,
          nil,
@@ -1391,230 +1394,239 @@ ProgramNode(0...3089)(
          nil,
          "foo"
        ),
-       RegularExpressionNode(1163...1168)(
-         REGEXP_BEGIN(1163...1164)("/"),
-         STRING_CONTENT(1164...1167)("foo"),
-         REGEXP_END(1167...1168)("/"),
-         "foo"
-       ),
+       RationalNode(1163...1165)(),
        (1160...1162)
      ),
-     MatchPredicateNode(1169...1181)(
-       CallNode(1169...1172)(
+     MatchPredicateNode(1166...1177)(
+       CallNode(1166...1169)(
          nil,
          nil,
-         IDENTIFIER(1169...1172)("foo"),
+         IDENTIFIER(1166...1169)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       XStringNode(1176...1181)(
-         BACKTICK(1176...1177)("`"),
-         STRING_CONTENT(1177...1180)("foo"),
-         STRING_END(1180...1181)("`"),
+       SymbolNode(1173...1177)(
+         SYMBOL_BEGIN(1173...1174)(":"),
+         IDENTIFIER(1174...1177)("foo"),
+         nil,
          "foo"
        ),
-       (1173...1175)
+       (1170...1172)
      ),
-     MatchPredicateNode(1182...1196)(
-       CallNode(1182...1185)(
+     MatchPredicateNode(1178...1192)(
+       CallNode(1178...1181)(
          nil,
          nil,
-         IDENTIFIER(1182...1185)("foo"),
+         IDENTIFIER(1178...1181)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       XStringNode(1189...1196)(
-         PERCENT_LOWER_X(1189...1192)("%x["),
-         STRING_CONTENT(1192...1195)("foo"),
-         STRING_END(1195...1196)("]"),
+       SymbolNode(1185...1192)(
+         SYMBOL_BEGIN(1185...1188)("%s["),
+         STRING_CONTENT(1188...1191)("foo"),
+         STRING_END(1191...1192)("]"),
          "foo"
        ),
-       (1186...1188)
+       (1182...1184)
      ),
-     MatchPredicateNode(1197...1211)(
-       CallNode(1197...1200)(
+     MatchPredicateNode(1193...1205)(
+       CallNode(1193...1196)(
          nil,
          nil,
-         IDENTIFIER(1197...1200)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       ArrayNode(1204...1211)(
-         [SymbolNode(1207...1210)(
-            nil,
-            STRING_CONTENT(1207...1210)("foo"),
-            nil,
-            "foo"
-          )],
-         PERCENT_LOWER_I(1204...1207)("%i["),
-         STRING_END(1210...1211)("]")
-       ),
-       (1201...1203)
-     ),
-     MatchPredicateNode(1212...1226)(
-       CallNode(1212...1215)(
-         nil,
-         nil,
-         IDENTIFIER(1212...1215)("foo"),
+         IDENTIFIER(1193...1196)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ArrayNode(1219...1226)(
-         [SymbolNode(1222...1225)(
+       InterpolatedSymbolNode(1202...1205)(
+         SYMBOL_BEGIN(1200...1202)(":\""),
+         [StringNode(1202...1205)(
             nil,
-            STRING_CONTENT(1222...1225)("foo"),
+            STRING_CONTENT(1202...1205)("foo"),
             nil,
             "foo"
           )],
-         PERCENT_UPPER_I(1219...1222)("%I["),
-         STRING_END(1225...1226)("]")
+         STRING_END(1205...1206)("\"")
        ),
-       (1216...1218)
+       (1197...1199)
      ),
-     MatchPredicateNode(1227...1241)(
-       CallNode(1227...1230)(
+     MatchPredicateNode(1207...1219)(
+       CallNode(1207...1210)(
          nil,
          nil,
-         IDENTIFIER(1227...1230)("foo"),
+         IDENTIFIER(1207...1210)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ArrayNode(1234...1241)(
-         [StringNode(1237...1240)(
+       RegularExpressionNode(1214...1219)(
+         REGEXP_BEGIN(1214...1215)("/"),
+         STRING_CONTENT(1215...1218)("foo"),
+         REGEXP_END(1218...1219)("/"),
+         "foo"
+       ),
+       (1211...1213)
+     ),
+     MatchPredicateNode(1220...1232)(
+       CallNode(1220...1223)(
+         nil,
+         nil,
+         IDENTIFIER(1220...1223)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       XStringNode(1227...1232)(
+         BACKTICK(1227...1228)("`"),
+         STRING_CONTENT(1228...1231)("foo"),
+         STRING_END(1231...1232)("`"),
+         "foo"
+       ),
+       (1224...1226)
+     ),
+     MatchPredicateNode(1233...1247)(
+       CallNode(1233...1236)(
+         nil,
+         nil,
+         IDENTIFIER(1233...1236)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       XStringNode(1240...1247)(
+         PERCENT_LOWER_X(1240...1243)("%x["),
+         STRING_CONTENT(1243...1246)("foo"),
+         STRING_END(1246...1247)("]"),
+         "foo"
+       ),
+       (1237...1239)
+     ),
+     MatchPredicateNode(1248...1262)(
+       CallNode(1248...1251)(
+         nil,
+         nil,
+         IDENTIFIER(1248...1251)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayNode(1255...1262)(
+         [SymbolNode(1258...1261)(
             nil,
-            STRING_CONTENT(1237...1240)("foo"),
+            STRING_CONTENT(1258...1261)("foo"),
             nil,
             "foo"
           )],
-         PERCENT_LOWER_W(1234...1237)("%w["),
-         STRING_END(1240...1241)("]")
+         PERCENT_LOWER_I(1255...1258)("%i["),
+         STRING_END(1261...1262)("]")
        ),
-       (1231...1233)
+       (1252...1254)
      ),
-     MatchPredicateNode(1242...1256)(
-       CallNode(1242...1245)(
+     MatchPredicateNode(1263...1277)(
+       CallNode(1263...1266)(
          nil,
          nil,
-         IDENTIFIER(1242...1245)("foo"),
+         IDENTIFIER(1263...1266)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ArrayNode(1249...1256)(
-         [StringNode(1252...1255)(
+       ArrayNode(1270...1277)(
+         [SymbolNode(1273...1276)(
             nil,
-            STRING_CONTENT(1252...1255)("foo"),
+            STRING_CONTENT(1273...1276)("foo"),
             nil,
             "foo"
           )],
-         PERCENT_UPPER_W(1249...1252)("%W["),
-         STRING_END(1255...1256)("]")
+         PERCENT_UPPER_I(1270...1273)("%I["),
+         STRING_END(1276...1277)("]")
        ),
-       (1246...1248)
+       (1267...1269)
      ),
-     MatchPredicateNode(1257...1271)(
-       CallNode(1257...1260)(
+     MatchPredicateNode(1278...1292)(
+       CallNode(1278...1281)(
          nil,
          nil,
-         IDENTIFIER(1257...1260)("foo"),
+         IDENTIFIER(1278...1281)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1264...1271)(
-         STRING_BEGIN(1264...1267)("%q["),
-         STRING_CONTENT(1267...1270)("foo"),
-         STRING_END(1270...1271)("]"),
-         "foo"
+       ArrayNode(1285...1292)(
+         [StringNode(1288...1291)(
+            nil,
+            STRING_CONTENT(1288...1291)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_LOWER_W(1285...1288)("%w["),
+         STRING_END(1291...1292)("]")
        ),
-       (1261...1263)
+       (1282...1284)
      ),
-     MatchPredicateNode(1272...1286)(
-       CallNode(1272...1275)(
+     MatchPredicateNode(1293...1307)(
+       CallNode(1293...1296)(
          nil,
          nil,
-         IDENTIFIER(1272...1275)("foo"),
+         IDENTIFIER(1293...1296)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1279...1286)(
-         STRING_BEGIN(1279...1282)("%Q["),
-         STRING_CONTENT(1282...1285)("foo"),
-         STRING_END(1285...1286)("]"),
-         "foo"
+       ArrayNode(1300...1307)(
+         [StringNode(1303...1306)(
+            nil,
+            STRING_CONTENT(1303...1306)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_UPPER_W(1300...1303)("%W["),
+         STRING_END(1306...1307)("]")
        ),
-       (1276...1278)
+       (1297...1299)
      ),
-     MatchPredicateNode(1287...1299)(
-       CallNode(1287...1290)(
+     MatchPredicateNode(1308...1322)(
+       CallNode(1308...1311)(
          nil,
          nil,
-         IDENTIFIER(1287...1290)("foo"),
+         IDENTIFIER(1308...1311)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1294...1299)(
-         STRING_BEGIN(1294...1295)("\""),
-         STRING_CONTENT(1295...1298)("foo"),
-         STRING_END(1298...1299)("\""),
+       StringNode(1315...1322)(
+         STRING_BEGIN(1315...1318)("%q["),
+         STRING_CONTENT(1318...1321)("foo"),
+         STRING_END(1321...1322)("]"),
          "foo"
        ),
-       (1291...1293)
+       (1312...1314)
      ),
-     MatchPredicateNode(1300...1310)(
-       CallNode(1300...1303)(
-         nil,
-         nil,
-         IDENTIFIER(1300...1303)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       NilNode(1307...1310)(),
-       (1304...1306)
-     ),
-     MatchPredicateNode(1311...1322)(
-       CallNode(1311...1314)(
-         nil,
-         nil,
-         IDENTIFIER(1311...1314)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       SelfNode(1318...1322)(),
-       (1315...1317)
-     ),
-     MatchPredicateNode(1323...1334)(
+     MatchPredicateNode(1323...1337)(
        CallNode(1323...1326)(
          nil,
          nil,
@@ -1625,177 +1637,201 @@ ProgramNode(0...3089)(
          nil,
          "foo"
        ),
-       TrueNode(1330...1334)(),
+       StringNode(1330...1337)(
+         STRING_BEGIN(1330...1333)("%Q["),
+         STRING_CONTENT(1333...1336)("foo"),
+         STRING_END(1336...1337)("]"),
+         "foo"
+       ),
        (1327...1329)
      ),
-     MatchPredicateNode(1335...1347)(
-       CallNode(1335...1338)(
+     MatchPredicateNode(1338...1350)(
+       CallNode(1338...1341)(
          nil,
          nil,
-         IDENTIFIER(1335...1338)("foo"),
+         IDENTIFIER(1338...1341)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       FalseNode(1342...1347)(),
-       (1339...1341)
+       StringNode(1345...1350)(
+         STRING_BEGIN(1345...1346)("\""),
+         STRING_CONTENT(1346...1349)("foo"),
+         STRING_END(1349...1350)("\""),
+         "foo"
+       ),
+       (1342...1344)
      ),
-     MatchPredicateNode(1348...1363)(
-       CallNode(1348...1351)(
+     MatchPredicateNode(1351...1361)(
+       CallNode(1351...1354)(
          nil,
          nil,
-         IDENTIFIER(1348...1351)("foo"),
+         IDENTIFIER(1351...1354)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceFileNode(1355...1363)(),
-       (1352...1354)
+       NilNode(1358...1361)(),
+       (1355...1357)
      ),
-     MatchPredicateNode(1364...1379)(
-       CallNode(1364...1367)(
+     MatchPredicateNode(1362...1373)(
+       CallNode(1362...1365)(
          nil,
          nil,
-         IDENTIFIER(1364...1367)("foo"),
+         IDENTIFIER(1362...1365)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceLineNode(1371...1379)(),
-       (1368...1370)
+       SelfNode(1369...1373)(),
+       (1366...1368)
      ),
-     MatchPredicateNode(1380...1399)(
-       CallNode(1380...1383)(
+     MatchPredicateNode(1374...1385)(
+       CallNode(1374...1377)(
          nil,
          nil,
-         IDENTIFIER(1380...1383)("foo"),
+         IDENTIFIER(1374...1377)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceEncodingNode(1387...1399)(),
-       (1384...1386)
+       TrueNode(1381...1385)(),
+       (1378...1380)
      ),
-     MatchPredicateNode(1400...1415)(
-       CallNode(1400...1403)(
+     MatchPredicateNode(1386...1398)(
+       CallNode(1386...1389)(
          nil,
          nil,
-         IDENTIFIER(1400...1403)("foo"),
+         IDENTIFIER(1386...1389)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       LambdaNode(1407...1415)(
-         Scope(1407...1409)([]),
-         MINUS_GREATER(1407...1409)("->"),
+       FalseNode(1393...1398)(),
+       (1390...1392)
+     ),
+     MatchPredicateNode(1399...1414)(
+       CallNode(1399...1402)(
+         nil,
+         nil,
+         IDENTIFIER(1399...1402)("foo"),
          nil,
          nil,
          nil,
-         StatementsNode(1412...1415)(
-           [LocalVariableReadNode(1412...1415)(IDENTIFIER(1412...1415)("bar"))]
+         nil,
+         "foo"
+       ),
+       SourceFileNode(1406...1414)(),
+       (1403...1405)
+     ),
+     MatchPredicateNode(1415...1430)(
+       CallNode(1415...1418)(
+         nil,
+         nil,
+         IDENTIFIER(1415...1418)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SourceLineNode(1422...1430)(),
+       (1419...1421)
+     ),
+     MatchPredicateNode(1431...1450)(
+       CallNode(1431...1434)(
+         nil,
+         nil,
+         IDENTIFIER(1431...1434)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SourceEncodingNode(1438...1450)(),
+       (1435...1437)
+     ),
+     MatchPredicateNode(1451...1466)(
+       CallNode(1451...1454)(
+         nil,
+         nil,
+         IDENTIFIER(1451...1454)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       LambdaNode(1458...1466)(
+         Scope(1458...1460)([]),
+         MINUS_GREATER(1458...1460)("->"),
+         nil,
+         nil,
+         nil,
+         StatementsNode(1463...1466)(
+           [LocalVariableReadNode(1463...1466)(IDENTIFIER(1463...1466)("bar"))]
          )
        ),
-       (1404...1406)
+       (1455...1457)
      ),
-     CaseNode(1419...1444)(
-       CallNode(1424...1427)(
+     CaseNode(1470...1495)(
+       CallNode(1475...1478)(
          nil,
          nil,
-         IDENTIFIER(1424...1427)("foo"),
+         IDENTIFIER(1475...1478)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1429...1440)(
-          LocalVariableWriteNode(1432...1435)(
-            IDENTIFIER(1432...1435)("bar"),
+       [InNode(1480...1491)(
+          LocalVariableWriteNode(1483...1486)(
+            IDENTIFIER(1483...1486)("bar"),
             nil,
             nil
           ),
           nil,
-          (1429...1431),
-          (1436...1440)
+          (1480...1482),
+          (1487...1491)
         )],
        nil,
-       (1419...1423),
-       (1441...1444)
+       (1470...1474),
+       (1492...1495)
      ),
-     CaseNode(1445...1468)(
-       CallNode(1450...1453)(
+     CaseNode(1496...1519)(
+       CallNode(1501...1504)(
          nil,
          nil,
-         IDENTIFIER(1450...1453)("foo"),
+         IDENTIFIER(1501...1504)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1455...1464)(
-          IntegerNode(1458...1459)(),
+       [InNode(1506...1515)(
+          IntegerNode(1509...1510)(),
           nil,
-          (1455...1457),
-          (1460...1464)
-        )],
-       nil,
-       (1445...1449),
-       (1465...1468)
-     ),
-     CaseNode(1469...1494)(
-       CallNode(1474...1477)(
-         nil,
-         nil,
-         IDENTIFIER(1474...1477)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       [InNode(1479...1490)(
-          FloatNode(1482...1485)(),
-          nil,
-          (1479...1481),
-          (1486...1490)
-        )],
-       nil,
-       (1469...1473),
-       (1491...1494)
-     ),
-     CaseNode(1495...1519)(
-       CallNode(1500...1503)(
-         nil,
-         nil,
-         IDENTIFIER(1500...1503)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       [InNode(1505...1515)(
-          ImaginaryNode(1508...1510)(),
-          nil,
-          (1505...1507),
+          (1506...1508),
           (1511...1515)
         )],
        nil,
-       (1495...1499),
+       (1496...1500),
        (1516...1519)
      ),
-     CaseNode(1520...1544)(
+     CaseNode(1520...1545)(
        CallNode(1525...1528)(
          nil,
          nil,
@@ -1806,580 +1842,622 @@ ProgramNode(0...3089)(
          nil,
          "foo"
        ),
-       [InNode(1530...1540)(
-          RationalNode(1533...1535)(),
+       [InNode(1530...1541)(
+          FloatNode(1533...1536)(),
           nil,
           (1530...1532),
-          (1536...1540)
+          (1537...1541)
         )],
        nil,
        (1520...1524),
-       (1541...1544)
+       (1542...1545)
      ),
-     CaseNode(1545...1571)(
-       CallNode(1550...1553)(
+     CaseNode(1546...1570)(
+       CallNode(1551...1554)(
          nil,
          nil,
-         IDENTIFIER(1550...1553)("foo"),
+         IDENTIFIER(1551...1554)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1555...1567)(
-          SymbolNode(1558...1562)(
-            SYMBOL_BEGIN(1558...1559)(":"),
-            IDENTIFIER(1559...1562)("foo"),
+       [InNode(1556...1566)(
+          ImaginaryNode(1559...1561)(),
+          nil,
+          (1556...1558),
+          (1562...1566)
+        )],
+       nil,
+       (1546...1550),
+       (1567...1570)
+     ),
+     CaseNode(1571...1595)(
+       CallNode(1576...1579)(
+         nil,
+         nil,
+         IDENTIFIER(1576...1579)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       [InNode(1581...1591)(
+          RationalNode(1584...1586)(),
+          nil,
+          (1581...1583),
+          (1587...1591)
+        )],
+       nil,
+       (1571...1575),
+       (1592...1595)
+     ),
+     CaseNode(1596...1622)(
+       CallNode(1601...1604)(
+         nil,
+         nil,
+         IDENTIFIER(1601...1604)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       [InNode(1606...1618)(
+          SymbolNode(1609...1613)(
+            SYMBOL_BEGIN(1609...1610)(":"),
+            IDENTIFIER(1610...1613)("foo"),
             nil,
             "foo"
           ),
           nil,
-          (1555...1557),
-          (1563...1567)
+          (1606...1608),
+          (1614...1618)
         )],
        nil,
-       (1545...1549),
-       (1568...1571)
+       (1596...1600),
+       (1619...1622)
      ),
-     CaseNode(1572...1601)(
-       CallNode(1577...1580)(
+     CaseNode(1623...1652)(
+       CallNode(1628...1631)(
          nil,
          nil,
-         IDENTIFIER(1577...1580)("foo"),
+         IDENTIFIER(1628...1631)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1582...1597)(
-          SymbolNode(1585...1592)(
-            SYMBOL_BEGIN(1585...1588)("%s["),
-            STRING_CONTENT(1588...1591)("foo"),
-            STRING_END(1591...1592)("]"),
+       [InNode(1633...1648)(
+          SymbolNode(1636...1643)(
+            SYMBOL_BEGIN(1636...1639)("%s["),
+            STRING_CONTENT(1639...1642)("foo"),
+            STRING_END(1642...1643)("]"),
             "foo"
           ),
           nil,
-          (1582...1584),
-          (1593...1597)
+          (1633...1635),
+          (1644...1648)
         )],
        nil,
-       (1572...1576),
-       (1598...1601)
+       (1623...1627),
+       (1649...1652)
      ),
-     CaseNode(1602...1630)(
-       CallNode(1607...1610)(
+     CaseNode(1653...1681)(
+       CallNode(1658...1661)(
          nil,
          nil,
-         IDENTIFIER(1607...1610)("foo"),
+         IDENTIFIER(1658...1661)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1612...1626)(
-          InterpolatedSymbolNode(1617...1620)(
-            SYMBOL_BEGIN(1615...1617)(":\""),
-            [StringNode(1617...1620)(
+       [InNode(1663...1677)(
+          InterpolatedSymbolNode(1668...1671)(
+            SYMBOL_BEGIN(1666...1668)(":\""),
+            [StringNode(1668...1671)(
                nil,
-               STRING_CONTENT(1617...1620)("foo"),
+               STRING_CONTENT(1668...1671)("foo"),
                nil,
                "foo"
              )],
-            STRING_END(1620...1621)("\"")
+            STRING_END(1671...1672)("\"")
           ),
           nil,
-          (1612...1614),
-          (1622...1626)
+          (1663...1665),
+          (1673...1677)
         )],
        nil,
-       (1602...1606),
-       (1627...1630)
+       (1653...1657),
+       (1678...1681)
      ),
-     CaseNode(1631...1658)(
-       CallNode(1636...1639)(
+     CaseNode(1682...1709)(
+       CallNode(1687...1690)(
          nil,
          nil,
-         IDENTIFIER(1636...1639)("foo"),
+         IDENTIFIER(1687...1690)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1641...1654)(
-          RegularExpressionNode(1644...1649)(
-            REGEXP_BEGIN(1644...1645)("/"),
-            STRING_CONTENT(1645...1648)("foo"),
-            REGEXP_END(1648...1649)("/"),
+       [InNode(1692...1705)(
+          RegularExpressionNode(1695...1700)(
+            REGEXP_BEGIN(1695...1696)("/"),
+            STRING_CONTENT(1696...1699)("foo"),
+            REGEXP_END(1699...1700)("/"),
             "foo"
           ),
           nil,
-          (1641...1643),
-          (1650...1654)
+          (1692...1694),
+          (1701...1705)
         )],
        nil,
-       (1631...1635),
-       (1655...1658)
+       (1682...1686),
+       (1706...1709)
      ),
-     CaseNode(1659...1686)(
-       CallNode(1664...1667)(
+     CaseNode(1710...1737)(
+       CallNode(1715...1718)(
          nil,
          nil,
-         IDENTIFIER(1664...1667)("foo"),
+         IDENTIFIER(1715...1718)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1669...1682)(
-          XStringNode(1672...1677)(
-            BACKTICK(1672...1673)("`"),
-            STRING_CONTENT(1673...1676)("foo"),
-            STRING_END(1676...1677)("`"),
+       [InNode(1720...1733)(
+          XStringNode(1723...1728)(
+            BACKTICK(1723...1724)("`"),
+            STRING_CONTENT(1724...1727)("foo"),
+            STRING_END(1727...1728)("`"),
             "foo"
           ),
           nil,
-          (1669...1671),
-          (1678...1682)
+          (1720...1722),
+          (1729...1733)
         )],
        nil,
-       (1659...1663),
-       (1683...1686)
+       (1710...1714),
+       (1734...1737)
      ),
-     CaseNode(1687...1716)(
-       CallNode(1692...1695)(
+     CaseNode(1738...1767)(
+       CallNode(1743...1746)(
          nil,
          nil,
-         IDENTIFIER(1692...1695)("foo"),
+         IDENTIFIER(1743...1746)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1697...1712)(
-          XStringNode(1700...1707)(
-            PERCENT_LOWER_X(1700...1703)("%x["),
-            STRING_CONTENT(1703...1706)("foo"),
-            STRING_END(1706...1707)("]"),
+       [InNode(1748...1763)(
+          XStringNode(1751...1758)(
+            PERCENT_LOWER_X(1751...1754)("%x["),
+            STRING_CONTENT(1754...1757)("foo"),
+            STRING_END(1757...1758)("]"),
             "foo"
           ),
           nil,
-          (1697...1699),
-          (1708...1712)
+          (1748...1750),
+          (1759...1763)
         )],
        nil,
-       (1687...1691),
-       (1713...1716)
+       (1738...1742),
+       (1764...1767)
      ),
-     CaseNode(1717...1746)(
-       CallNode(1722...1725)(
+     CaseNode(1768...1797)(
+       CallNode(1773...1776)(
          nil,
          nil,
-         IDENTIFIER(1722...1725)("foo"),
+         IDENTIFIER(1773...1776)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1727...1742)(
-          ArrayNode(1730...1737)(
-            [SymbolNode(1733...1736)(
+       [InNode(1778...1793)(
+          ArrayNode(1781...1788)(
+            [SymbolNode(1784...1787)(
                nil,
-               STRING_CONTENT(1733...1736)("foo"),
+               STRING_CONTENT(1784...1787)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_LOWER_I(1730...1733)("%i["),
-            STRING_END(1736...1737)("]")
+            PERCENT_LOWER_I(1781...1784)("%i["),
+            STRING_END(1787...1788)("]")
           ),
           nil,
-          (1727...1729),
-          (1738...1742)
+          (1778...1780),
+          (1789...1793)
         )],
        nil,
-       (1717...1721),
-       (1743...1746)
+       (1768...1772),
+       (1794...1797)
      ),
-     CaseNode(1747...1776)(
-       CallNode(1752...1755)(
+     CaseNode(1798...1827)(
+       CallNode(1803...1806)(
          nil,
          nil,
-         IDENTIFIER(1752...1755)("foo"),
+         IDENTIFIER(1803...1806)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1757...1772)(
-          ArrayNode(1760...1767)(
-            [SymbolNode(1763...1766)(
+       [InNode(1808...1823)(
+          ArrayNode(1811...1818)(
+            [SymbolNode(1814...1817)(
                nil,
-               STRING_CONTENT(1763...1766)("foo"),
-               nil,
-               "foo"
-             )],
-            PERCENT_UPPER_I(1760...1763)("%I["),
-            STRING_END(1766...1767)("]")
-          ),
-          nil,
-          (1757...1759),
-          (1768...1772)
-        )],
-       nil,
-       (1747...1751),
-       (1773...1776)
-     ),
-     CaseNode(1777...1806)(
-       CallNode(1782...1785)(
-         nil,
-         nil,
-         IDENTIFIER(1782...1785)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       [InNode(1787...1802)(
-          ArrayNode(1790...1797)(
-            [StringNode(1793...1796)(
-               nil,
-               STRING_CONTENT(1793...1796)("foo"),
+               STRING_CONTENT(1814...1817)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_LOWER_W(1790...1793)("%w["),
-            STRING_END(1796...1797)("]")
+            PERCENT_UPPER_I(1811...1814)("%I["),
+            STRING_END(1817...1818)("]")
           ),
           nil,
-          (1787...1789),
-          (1798...1802)
+          (1808...1810),
+          (1819...1823)
         )],
        nil,
-       (1777...1781),
-       (1803...1806)
+       (1798...1802),
+       (1824...1827)
      ),
-     CaseNode(1807...1836)(
-       CallNode(1812...1815)(
+     CaseNode(1828...1857)(
+       CallNode(1833...1836)(
          nil,
          nil,
-         IDENTIFIER(1812...1815)("foo"),
+         IDENTIFIER(1833...1836)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1817...1832)(
-          ArrayNode(1820...1827)(
-            [StringNode(1823...1826)(
+       [InNode(1838...1853)(
+          ArrayNode(1841...1848)(
+            [StringNode(1844...1847)(
                nil,
-               STRING_CONTENT(1823...1826)("foo"),
+               STRING_CONTENT(1844...1847)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_UPPER_W(1820...1823)("%W["),
-            STRING_END(1826...1827)("]")
+            PERCENT_LOWER_W(1841...1844)("%w["),
+            STRING_END(1847...1848)("]")
           ),
           nil,
-          (1817...1819),
-          (1828...1832)
+          (1838...1840),
+          (1849...1853)
         )],
        nil,
-       (1807...1811),
-       (1833...1836)
+       (1828...1832),
+       (1854...1857)
      ),
-     CaseNode(1837...1866)(
-       CallNode(1842...1845)(
+     CaseNode(1858...1887)(
+       CallNode(1863...1866)(
          nil,
          nil,
-         IDENTIFIER(1842...1845)("foo"),
+         IDENTIFIER(1863...1866)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1847...1862)(
-          StringNode(1850...1857)(
-            STRING_BEGIN(1850...1853)("%q["),
-            STRING_CONTENT(1853...1856)("foo"),
-            STRING_END(1856...1857)("]"),
+       [InNode(1868...1883)(
+          ArrayNode(1871...1878)(
+            [StringNode(1874...1877)(
+               nil,
+               STRING_CONTENT(1874...1877)("foo"),
+               nil,
+               "foo"
+             )],
+            PERCENT_UPPER_W(1871...1874)("%W["),
+            STRING_END(1877...1878)("]")
+          ),
+          nil,
+          (1868...1870),
+          (1879...1883)
+        )],
+       nil,
+       (1858...1862),
+       (1884...1887)
+     ),
+     CaseNode(1888...1917)(
+       CallNode(1893...1896)(
+         nil,
+         nil,
+         IDENTIFIER(1893...1896)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       [InNode(1898...1913)(
+          StringNode(1901...1908)(
+            STRING_BEGIN(1901...1904)("%q["),
+            STRING_CONTENT(1904...1907)("foo"),
+            STRING_END(1907...1908)("]"),
             "foo"
           ),
           nil,
-          (1847...1849),
-          (1858...1862)
+          (1898...1900),
+          (1909...1913)
         )],
        nil,
-       (1837...1841),
-       (1863...1866)
+       (1888...1892),
+       (1914...1917)
      ),
-     CaseNode(1867...1896)(
-       CallNode(1872...1875)(
+     CaseNode(1918...1947)(
+       CallNode(1923...1926)(
          nil,
          nil,
-         IDENTIFIER(1872...1875)("foo"),
+         IDENTIFIER(1923...1926)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1877...1892)(
-          StringNode(1880...1887)(
-            STRING_BEGIN(1880...1883)("%Q["),
-            STRING_CONTENT(1883...1886)("foo"),
-            STRING_END(1886...1887)("]"),
+       [InNode(1928...1943)(
+          StringNode(1931...1938)(
+            STRING_BEGIN(1931...1934)("%Q["),
+            STRING_CONTENT(1934...1937)("foo"),
+            STRING_END(1937...1938)("]"),
             "foo"
           ),
           nil,
-          (1877...1879),
-          (1888...1892)
+          (1928...1930),
+          (1939...1943)
         )],
        nil,
-       (1867...1871),
-       (1893...1896)
+       (1918...1922),
+       (1944...1947)
      ),
-     CaseNode(1897...1924)(
-       CallNode(1902...1905)(
+     CaseNode(1948...1975)(
+       CallNode(1953...1956)(
          nil,
          nil,
-         IDENTIFIER(1902...1905)("foo"),
+         IDENTIFIER(1953...1956)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1907...1920)(
-          StringNode(1910...1915)(
-            STRING_BEGIN(1910...1911)("\""),
-            STRING_CONTENT(1911...1914)("foo"),
-            STRING_END(1914...1915)("\""),
+       [InNode(1958...1971)(
+          StringNode(1961...1966)(
+            STRING_BEGIN(1961...1962)("\""),
+            STRING_CONTENT(1962...1965)("foo"),
+            STRING_END(1965...1966)("\""),
             "foo"
           ),
           nil,
-          (1907...1909),
-          (1916...1920)
+          (1958...1960),
+          (1967...1971)
         )],
        nil,
-       (1897...1901),
-       (1921...1924)
+       (1948...1952),
+       (1972...1975)
      ),
-     CaseNode(1925...1950)(
-       CallNode(1930...1933)(
+     CaseNode(1976...2001)(
+       CallNode(1981...1984)(
          nil,
          nil,
-         IDENTIFIER(1930...1933)("foo"),
+         IDENTIFIER(1981...1984)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1935...1946)(
-          NilNode(1938...1941)(),
+       [InNode(1986...1997)(
+          NilNode(1989...1992)(),
           nil,
-          (1935...1937),
-          (1942...1946)
+          (1986...1988),
+          (1993...1997)
         )],
        nil,
-       (1925...1929),
-       (1947...1950)
+       (1976...1980),
+       (1998...2001)
      ),
-     CaseNode(1951...1977)(
-       CallNode(1956...1959)(
+     CaseNode(2002...2028)(
+       CallNode(2007...2010)(
          nil,
          nil,
-         IDENTIFIER(1956...1959)("foo"),
+         IDENTIFIER(2007...2010)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1961...1973)(
-          SelfNode(1964...1968)(),
+       [InNode(2012...2024)(
+          SelfNode(2015...2019)(),
           nil,
-          (1961...1963),
-          (1969...1973)
+          (2012...2014),
+          (2020...2024)
         )],
        nil,
-       (1951...1955),
-       (1974...1977)
+       (2002...2006),
+       (2025...2028)
      ),
-     CaseNode(1978...2004)(
-       CallNode(1983...1986)(
+     CaseNode(2029...2055)(
+       CallNode(2034...2037)(
          nil,
          nil,
-         IDENTIFIER(1983...1986)("foo"),
+         IDENTIFIER(2034...2037)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1988...2000)(
-          TrueNode(1991...1995)(),
+       [InNode(2039...2051)(
+          TrueNode(2042...2046)(),
           nil,
-          (1988...1990),
-          (1996...2000)
+          (2039...2041),
+          (2047...2051)
         )],
        nil,
-       (1978...1982),
-       (2001...2004)
+       (2029...2033),
+       (2052...2055)
      ),
-     CaseNode(2005...2032)(
-       CallNode(2010...2013)(
+     CaseNode(2056...2083)(
+       CallNode(2061...2064)(
          nil,
          nil,
-         IDENTIFIER(2010...2013)("foo"),
+         IDENTIFIER(2061...2064)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2015...2028)(
-          FalseNode(2018...2023)(),
+       [InNode(2066...2079)(
+          FalseNode(2069...2074)(),
           nil,
-          (2015...2017),
-          (2024...2028)
+          (2066...2068),
+          (2075...2079)
         )],
        nil,
-       (2005...2009),
-       (2029...2032)
+       (2056...2060),
+       (2080...2083)
      ),
-     CaseNode(2033...2063)(
-       CallNode(2038...2041)(
+     CaseNode(2084...2114)(
+       CallNode(2089...2092)(
          nil,
          nil,
-         IDENTIFIER(2038...2041)("foo"),
+         IDENTIFIER(2089...2092)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2043...2059)(
-          SourceFileNode(2046...2054)(),
+       [InNode(2094...2110)(
+          SourceFileNode(2097...2105)(),
           nil,
-          (2043...2045),
-          (2055...2059)
+          (2094...2096),
+          (2106...2110)
         )],
        nil,
-       (2033...2037),
-       (2060...2063)
+       (2084...2088),
+       (2111...2114)
      ),
-     CaseNode(2064...2094)(
-       CallNode(2069...2072)(
+     CaseNode(2115...2145)(
+       CallNode(2120...2123)(
          nil,
          nil,
-         IDENTIFIER(2069...2072)("foo"),
+         IDENTIFIER(2120...2123)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2074...2090)(
-          SourceLineNode(2077...2085)(),
+       [InNode(2125...2141)(
+          SourceLineNode(2128...2136)(),
           nil,
-          (2074...2076),
-          (2086...2090)
+          (2125...2127),
+          (2137...2141)
         )],
        nil,
-       (2064...2068),
-       (2091...2094)
+       (2115...2119),
+       (2142...2145)
      ),
-     CaseNode(2095...2129)(
-       CallNode(2100...2103)(
+     CaseNode(2146...2180)(
+       CallNode(2151...2154)(
          nil,
          nil,
-         IDENTIFIER(2100...2103)("foo"),
+         IDENTIFIER(2151...2154)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2105...2125)(
-          SourceEncodingNode(2108...2120)(),
+       [InNode(2156...2176)(
+          SourceEncodingNode(2159...2171)(),
           nil,
-          (2105...2107),
-          (2121...2125)
+          (2156...2158),
+          (2172...2176)
         )],
        nil,
-       (2095...2099),
-       (2126...2129)
+       (2146...2150),
+       (2177...2180)
      ),
-     CaseNode(2130...2162)(
-       CallNode(2135...2138)(
+     CaseNode(2181...2213)(
+       CallNode(2186...2189)(
          nil,
          nil,
-         IDENTIFIER(2135...2138)("foo"),
+         IDENTIFIER(2186...2189)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2140...2158)(
-          LambdaNode(2143...2151)(
-            Scope(2143...2145)([]),
-            MINUS_GREATER(2143...2145)("->"),
+       [InNode(2191...2209)(
+          LambdaNode(2194...2202)(
+            Scope(2194...2196)([]),
+            MINUS_GREATER(2194...2196)("->"),
             nil,
             nil,
             nil,
-            StatementsNode(2148...2151)(
-              [LocalVariableReadNode(2148...2151)(
-                 IDENTIFIER(2148...2151)("bar")
+            StatementsNode(2199...2202)(
+              [LocalVariableReadNode(2199...2202)(
+                 IDENTIFIER(2199...2202)("bar")
                )]
             )
           ),
           nil,
-          (2140...2142),
-          (2154...2158)
+          (2191...2193),
+          (2205...2209)
         )],
        nil,
-       (2130...2134),
-       (2159...2162)
+       (2181...2185),
+       (2210...2213)
      ),
-     CaseNode(2164...2196)(
-       CallNode(2169...2172)(
+     CaseNode(2215...2247)(
+       CallNode(2220...2223)(
          nil,
          nil,
-         IDENTIFIER(2169...2172)("foo"),
+         IDENTIFIER(2220...2223)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2174...2192)(
-          IfNode(2177...2187)(
-            KEYWORD_IF_MODIFIER(2181...2183)("if"),
-            CallNode(2184...2187)(
+       [InNode(2225...2243)(
+          IfNode(2228...2238)(
+            KEYWORD_IF_MODIFIER(2232...2234)("if"),
+            CallNode(2235...2238)(
               nil,
               nil,
-              IDENTIFIER(2184...2187)("baz"),
+              IDENTIFIER(2235...2238)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2177...2180)(
-              [LocalVariableWriteNode(2177...2180)(
-                 IDENTIFIER(2177...2180)("bar"),
+            StatementsNode(2228...2231)(
+              [LocalVariableWriteNode(2228...2231)(
+                 IDENTIFIER(2228...2231)("bar"),
                  nil,
                  nil
                )]
@@ -2388,185 +2466,185 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2174...2176),
-          (2188...2192)
+          (2225...2227),
+          (2239...2243)
         )],
        nil,
-       (2164...2168),
-       (2193...2196)
+       (2215...2219),
+       (2244...2247)
      ),
-     CaseNode(2197...2227)(
-       CallNode(2202...2205)(
+     CaseNode(2248...2278)(
+       CallNode(2253...2256)(
          nil,
          nil,
-         IDENTIFIER(2202...2205)("foo"),
+         IDENTIFIER(2253...2256)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2207...2223)(
-          IfNode(2210...2218)(
-            KEYWORD_IF_MODIFIER(2212...2214)("if"),
-            CallNode(2215...2218)(
+       [InNode(2258...2274)(
+          IfNode(2261...2269)(
+            KEYWORD_IF_MODIFIER(2263...2265)("if"),
+            CallNode(2266...2269)(
               nil,
               nil,
-              IDENTIFIER(2215...2218)("baz"),
+              IDENTIFIER(2266...2269)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2210...2211)([IntegerNode(2210...2211)()]),
+            StatementsNode(2261...2262)([IntegerNode(2261...2262)()]),
             nil,
             nil
           ),
           nil,
-          (2207...2209),
-          (2219...2223)
+          (2258...2260),
+          (2270...2274)
         )],
        nil,
-       (2197...2201),
-       (2224...2227)
+       (2248...2252),
+       (2275...2278)
      ),
-     CaseNode(2228...2260)(
-       CallNode(2233...2236)(
+     CaseNode(2279...2311)(
+       CallNode(2284...2287)(
          nil,
          nil,
-         IDENTIFIER(2233...2236)("foo"),
+         IDENTIFIER(2284...2287)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2238...2256)(
-          IfNode(2241...2251)(
-            KEYWORD_IF_MODIFIER(2245...2247)("if"),
-            CallNode(2248...2251)(
+       [InNode(2289...2307)(
+          IfNode(2292...2302)(
+            KEYWORD_IF_MODIFIER(2296...2298)("if"),
+            CallNode(2299...2302)(
               nil,
               nil,
-              IDENTIFIER(2248...2251)("baz"),
+              IDENTIFIER(2299...2302)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2241...2244)([FloatNode(2241...2244)()]),
+            StatementsNode(2292...2295)([FloatNode(2292...2295)()]),
             nil,
             nil
           ),
           nil,
-          (2238...2240),
-          (2252...2256)
+          (2289...2291),
+          (2303...2307)
         )],
        nil,
-       (2228...2232),
-       (2257...2260)
+       (2279...2283),
+       (2308...2311)
      ),
-     CaseNode(2261...2292)(
-       CallNode(2266...2269)(
+     CaseNode(2312...2343)(
+       CallNode(2317...2320)(
          nil,
          nil,
-         IDENTIFIER(2266...2269)("foo"),
+         IDENTIFIER(2317...2320)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2271...2288)(
-          IfNode(2274...2283)(
-            KEYWORD_IF_MODIFIER(2277...2279)("if"),
-            CallNode(2280...2283)(
+       [InNode(2322...2339)(
+          IfNode(2325...2334)(
+            KEYWORD_IF_MODIFIER(2328...2330)("if"),
+            CallNode(2331...2334)(
               nil,
               nil,
-              IDENTIFIER(2280...2283)("baz"),
+              IDENTIFIER(2331...2334)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2274...2276)([ImaginaryNode(2274...2276)()]),
+            StatementsNode(2325...2327)([ImaginaryNode(2325...2327)()]),
             nil,
             nil
           ),
           nil,
-          (2271...2273),
-          (2284...2288)
+          (2322...2324),
+          (2335...2339)
         )],
        nil,
-       (2261...2265),
-       (2289...2292)
+       (2312...2316),
+       (2340...2343)
      ),
-     CaseNode(2293...2324)(
-       CallNode(2298...2301)(
+     CaseNode(2344...2375)(
+       CallNode(2349...2352)(
          nil,
          nil,
-         IDENTIFIER(2298...2301)("foo"),
+         IDENTIFIER(2349...2352)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2303...2320)(
-          IfNode(2306...2315)(
-            KEYWORD_IF_MODIFIER(2309...2311)("if"),
-            CallNode(2312...2315)(
+       [InNode(2354...2371)(
+          IfNode(2357...2366)(
+            KEYWORD_IF_MODIFIER(2360...2362)("if"),
+            CallNode(2363...2366)(
               nil,
               nil,
-              IDENTIFIER(2312...2315)("baz"),
+              IDENTIFIER(2363...2366)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2306...2308)([RationalNode(2306...2308)()]),
+            StatementsNode(2357...2359)([RationalNode(2357...2359)()]),
             nil,
             nil
           ),
           nil,
-          (2303...2305),
-          (2316...2320)
+          (2354...2356),
+          (2367...2371)
         )],
        nil,
-       (2293...2297),
-       (2321...2324)
+       (2344...2348),
+       (2372...2375)
      ),
-     CaseNode(2325...2358)(
-       CallNode(2330...2333)(
+     CaseNode(2376...2409)(
+       CallNode(2381...2384)(
          nil,
          nil,
-         IDENTIFIER(2330...2333)("foo"),
+         IDENTIFIER(2381...2384)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2335...2354)(
-          IfNode(2338...2349)(
-            KEYWORD_IF_MODIFIER(2343...2345)("if"),
-            CallNode(2346...2349)(
+       [InNode(2386...2405)(
+          IfNode(2389...2400)(
+            KEYWORD_IF_MODIFIER(2394...2396)("if"),
+            CallNode(2397...2400)(
               nil,
               nil,
-              IDENTIFIER(2346...2349)("baz"),
+              IDENTIFIER(2397...2400)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2338...2342)(
-              [SymbolNode(2338...2342)(
-                 SYMBOL_BEGIN(2338...2339)(":"),
-                 IDENTIFIER(2339...2342)("foo"),
+            StatementsNode(2389...2393)(
+              [SymbolNode(2389...2393)(
+                 SYMBOL_BEGIN(2389...2390)(":"),
+                 IDENTIFIER(2390...2393)("foo"),
                  nil,
                  "foo"
                )]
@@ -2575,42 +2653,42 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2335...2337),
-          (2350...2354)
+          (2386...2388),
+          (2401...2405)
         )],
        nil,
-       (2325...2329),
-       (2355...2358)
+       (2376...2380),
+       (2406...2409)
      ),
-     CaseNode(2359...2395)(
-       CallNode(2364...2367)(
+     CaseNode(2410...2446)(
+       CallNode(2415...2418)(
          nil,
          nil,
-         IDENTIFIER(2364...2367)("foo"),
+         IDENTIFIER(2415...2418)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2369...2391)(
-          IfNode(2372...2386)(
-            KEYWORD_IF_MODIFIER(2380...2382)("if"),
-            CallNode(2383...2386)(
+       [InNode(2420...2442)(
+          IfNode(2423...2437)(
+            KEYWORD_IF_MODIFIER(2431...2433)("if"),
+            CallNode(2434...2437)(
               nil,
               nil,
-              IDENTIFIER(2383...2386)("baz"),
+              IDENTIFIER(2434...2437)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2372...2379)(
-              [SymbolNode(2372...2379)(
-                 SYMBOL_BEGIN(2372...2375)("%s["),
-                 STRING_CONTENT(2375...2378)("foo"),
-                 STRING_END(2378...2379)("]"),
+            StatementsNode(2423...2430)(
+              [SymbolNode(2423...2430)(
+                 SYMBOL_BEGIN(2423...2426)("%s["),
+                 STRING_CONTENT(2426...2429)("foo"),
+                 STRING_END(2429...2430)("]"),
                  "foo"
                )]
             ),
@@ -2618,89 +2696,89 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2369...2371),
-          (2387...2391)
+          (2420...2422),
+          (2438...2442)
         )],
        nil,
-       (2359...2363),
-       (2392...2395)
+       (2410...2414),
+       (2443...2446)
      ),
-     CaseNode(2396...2431)(
-       CallNode(2401...2404)(
+     CaseNode(2447...2482)(
+       CallNode(2452...2455)(
          nil,
          nil,
-         IDENTIFIER(2401...2404)("foo"),
+         IDENTIFIER(2452...2455)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2406...2427)(
-          IfNode(2411...2422)(
-            KEYWORD_IF_MODIFIER(2416...2418)("if"),
-            CallNode(2419...2422)(
+       [InNode(2457...2478)(
+          IfNode(2462...2473)(
+            KEYWORD_IF_MODIFIER(2467...2469)("if"),
+            CallNode(2470...2473)(
               nil,
               nil,
-              IDENTIFIER(2419...2422)("baz"),
+              IDENTIFIER(2470...2473)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2411...2414)(
-              [InterpolatedSymbolNode(2411...2414)(
-                 SYMBOL_BEGIN(2409...2411)(":\""),
-                 [StringNode(2411...2414)(
+            StatementsNode(2462...2465)(
+              [InterpolatedSymbolNode(2462...2465)(
+                 SYMBOL_BEGIN(2460...2462)(":\""),
+                 [StringNode(2462...2465)(
                     nil,
-                    STRING_CONTENT(2411...2414)("foo"),
+                    STRING_CONTENT(2462...2465)("foo"),
                     nil,
                     "foo"
                   )],
-                 STRING_END(2414...2415)("\"")
+                 STRING_END(2465...2466)("\"")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2406...2408),
-          (2423...2427)
+          (2457...2459),
+          (2474...2478)
         )],
        nil,
-       (2396...2400),
-       (2428...2431)
+       (2447...2451),
+       (2479...2482)
      ),
-     CaseNode(2432...2466)(
-       CallNode(2437...2440)(
+     CaseNode(2483...2517)(
+       CallNode(2488...2491)(
          nil,
          nil,
-         IDENTIFIER(2437...2440)("foo"),
+         IDENTIFIER(2488...2491)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2442...2462)(
-          IfNode(2445...2457)(
-            KEYWORD_IF_MODIFIER(2451...2453)("if"),
-            CallNode(2454...2457)(
+       [InNode(2493...2513)(
+          IfNode(2496...2508)(
+            KEYWORD_IF_MODIFIER(2502...2504)("if"),
+            CallNode(2505...2508)(
               nil,
               nil,
-              IDENTIFIER(2454...2457)("baz"),
+              IDENTIFIER(2505...2508)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2445...2450)(
-              [RegularExpressionNode(2445...2450)(
-                 REGEXP_BEGIN(2445...2446)("/"),
-                 STRING_CONTENT(2446...2449)("foo"),
-                 REGEXP_END(2449...2450)("/"),
+            StatementsNode(2496...2501)(
+              [RegularExpressionNode(2496...2501)(
+                 REGEXP_BEGIN(2496...2497)("/"),
+                 STRING_CONTENT(2497...2500)("foo"),
+                 REGEXP_END(2500...2501)("/"),
                  "foo"
                )]
             ),
@@ -2708,42 +2786,42 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2442...2444),
-          (2458...2462)
+          (2493...2495),
+          (2509...2513)
         )],
        nil,
-       (2432...2436),
-       (2463...2466)
+       (2483...2487),
+       (2514...2517)
      ),
-     CaseNode(2467...2501)(
-       CallNode(2472...2475)(
+     CaseNode(2518...2552)(
+       CallNode(2523...2526)(
          nil,
          nil,
-         IDENTIFIER(2472...2475)("foo"),
+         IDENTIFIER(2523...2526)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2477...2497)(
-          IfNode(2480...2492)(
-            KEYWORD_IF_MODIFIER(2486...2488)("if"),
-            CallNode(2489...2492)(
+       [InNode(2528...2548)(
+          IfNode(2531...2543)(
+            KEYWORD_IF_MODIFIER(2537...2539)("if"),
+            CallNode(2540...2543)(
               nil,
               nil,
-              IDENTIFIER(2489...2492)("baz"),
+              IDENTIFIER(2540...2543)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2480...2485)(
-              [XStringNode(2480...2485)(
-                 BACKTICK(2480...2481)("`"),
-                 STRING_CONTENT(2481...2484)("foo"),
-                 STRING_END(2484...2485)("`"),
+            StatementsNode(2531...2536)(
+              [XStringNode(2531...2536)(
+                 BACKTICK(2531...2532)("`"),
+                 STRING_CONTENT(2532...2535)("foo"),
+                 STRING_END(2535...2536)("`"),
                  "foo"
                )]
             ),
@@ -2751,42 +2829,42 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2477...2479),
-          (2493...2497)
+          (2528...2530),
+          (2544...2548)
         )],
        nil,
-       (2467...2471),
-       (2498...2501)
+       (2518...2522),
+       (2549...2552)
      ),
-     CaseNode(2502...2538)(
-       CallNode(2507...2510)(
+     CaseNode(2553...2589)(
+       CallNode(2558...2561)(
          nil,
          nil,
-         IDENTIFIER(2507...2510)("foo"),
+         IDENTIFIER(2558...2561)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2512...2534)(
-          IfNode(2515...2529)(
-            KEYWORD_IF_MODIFIER(2523...2525)("if"),
-            CallNode(2526...2529)(
+       [InNode(2563...2585)(
+          IfNode(2566...2580)(
+            KEYWORD_IF_MODIFIER(2574...2576)("if"),
+            CallNode(2577...2580)(
               nil,
               nil,
-              IDENTIFIER(2526...2529)("baz"),
+              IDENTIFIER(2577...2580)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2515...2522)(
-              [XStringNode(2515...2522)(
-                 PERCENT_LOWER_X(2515...2518)("%x["),
-                 STRING_CONTENT(2518...2521)("foo"),
-                 STRING_END(2521...2522)("]"),
+            StatementsNode(2566...2573)(
+              [XStringNode(2566...2573)(
+                 PERCENT_LOWER_X(2566...2569)("%x["),
+                 STRING_CONTENT(2569...2572)("foo"),
+                 STRING_END(2572...2573)("]"),
                  "foo"
                )]
             ),
@@ -2794,230 +2872,230 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2512...2514),
-          (2530...2534)
+          (2563...2565),
+          (2581...2585)
         )],
        nil,
-       (2502...2506),
-       (2535...2538)
+       (2553...2557),
+       (2586...2589)
      ),
-     CaseNode(2539...2575)(
-       CallNode(2544...2547)(
+     CaseNode(2590...2626)(
+       CallNode(2595...2598)(
          nil,
          nil,
-         IDENTIFIER(2544...2547)("foo"),
+         IDENTIFIER(2595...2598)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2549...2571)(
-          IfNode(2552...2566)(
-            KEYWORD_IF_MODIFIER(2560...2562)("if"),
-            CallNode(2563...2566)(
+       [InNode(2600...2622)(
+          IfNode(2603...2617)(
+            KEYWORD_IF_MODIFIER(2611...2613)("if"),
+            CallNode(2614...2617)(
               nil,
               nil,
-              IDENTIFIER(2563...2566)("baz"),
+              IDENTIFIER(2614...2617)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2552...2559)(
-              [ArrayNode(2552...2559)(
-                 [SymbolNode(2555...2558)(
+            StatementsNode(2603...2610)(
+              [ArrayNode(2603...2610)(
+                 [SymbolNode(2606...2609)(
                     nil,
-                    STRING_CONTENT(2555...2558)("foo"),
+                    STRING_CONTENT(2606...2609)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_LOWER_I(2552...2555)("%i["),
-                 STRING_END(2558...2559)("]")
+                 PERCENT_LOWER_I(2603...2606)("%i["),
+                 STRING_END(2609...2610)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2549...2551),
-          (2567...2571)
+          (2600...2602),
+          (2618...2622)
         )],
        nil,
-       (2539...2543),
-       (2572...2575)
+       (2590...2594),
+       (2623...2626)
      ),
-     CaseNode(2576...2612)(
-       CallNode(2581...2584)(
+     CaseNode(2627...2663)(
+       CallNode(2632...2635)(
          nil,
          nil,
-         IDENTIFIER(2581...2584)("foo"),
+         IDENTIFIER(2632...2635)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2586...2608)(
-          IfNode(2589...2603)(
-            KEYWORD_IF_MODIFIER(2597...2599)("if"),
-            CallNode(2600...2603)(
+       [InNode(2637...2659)(
+          IfNode(2640...2654)(
+            KEYWORD_IF_MODIFIER(2648...2650)("if"),
+            CallNode(2651...2654)(
               nil,
               nil,
-              IDENTIFIER(2600...2603)("baz"),
+              IDENTIFIER(2651...2654)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2589...2596)(
-              [ArrayNode(2589...2596)(
-                 [SymbolNode(2592...2595)(
+            StatementsNode(2640...2647)(
+              [ArrayNode(2640...2647)(
+                 [SymbolNode(2643...2646)(
                     nil,
-                    STRING_CONTENT(2592...2595)("foo"),
+                    STRING_CONTENT(2643...2646)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_UPPER_I(2589...2592)("%I["),
-                 STRING_END(2595...2596)("]")
+                 PERCENT_UPPER_I(2640...2643)("%I["),
+                 STRING_END(2646...2647)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2586...2588),
-          (2604...2608)
+          (2637...2639),
+          (2655...2659)
         )],
        nil,
-       (2576...2580),
-       (2609...2612)
+       (2627...2631),
+       (2660...2663)
      ),
-     CaseNode(2613...2649)(
-       CallNode(2618...2621)(
+     CaseNode(2664...2700)(
+       CallNode(2669...2672)(
          nil,
          nil,
-         IDENTIFIER(2618...2621)("foo"),
+         IDENTIFIER(2669...2672)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2623...2645)(
-          IfNode(2626...2640)(
-            KEYWORD_IF_MODIFIER(2634...2636)("if"),
-            CallNode(2637...2640)(
+       [InNode(2674...2696)(
+          IfNode(2677...2691)(
+            KEYWORD_IF_MODIFIER(2685...2687)("if"),
+            CallNode(2688...2691)(
               nil,
               nil,
-              IDENTIFIER(2637...2640)("baz"),
+              IDENTIFIER(2688...2691)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2626...2633)(
-              [ArrayNode(2626...2633)(
-                 [StringNode(2629...2632)(
+            StatementsNode(2677...2684)(
+              [ArrayNode(2677...2684)(
+                 [StringNode(2680...2683)(
                     nil,
-                    STRING_CONTENT(2629...2632)("foo"),
+                    STRING_CONTENT(2680...2683)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_LOWER_W(2626...2629)("%w["),
-                 STRING_END(2632...2633)("]")
+                 PERCENT_LOWER_W(2677...2680)("%w["),
+                 STRING_END(2683...2684)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2623...2625),
-          (2641...2645)
+          (2674...2676),
+          (2692...2696)
         )],
        nil,
-       (2613...2617),
-       (2646...2649)
+       (2664...2668),
+       (2697...2700)
      ),
-     CaseNode(2650...2686)(
-       CallNode(2655...2658)(
+     CaseNode(2701...2737)(
+       CallNode(2706...2709)(
          nil,
          nil,
-         IDENTIFIER(2655...2658)("foo"),
+         IDENTIFIER(2706...2709)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2660...2682)(
-          IfNode(2663...2677)(
-            KEYWORD_IF_MODIFIER(2671...2673)("if"),
-            CallNode(2674...2677)(
+       [InNode(2711...2733)(
+          IfNode(2714...2728)(
+            KEYWORD_IF_MODIFIER(2722...2724)("if"),
+            CallNode(2725...2728)(
               nil,
               nil,
-              IDENTIFIER(2674...2677)("baz"),
+              IDENTIFIER(2725...2728)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2663...2670)(
-              [ArrayNode(2663...2670)(
-                 [StringNode(2666...2669)(
+            StatementsNode(2714...2721)(
+              [ArrayNode(2714...2721)(
+                 [StringNode(2717...2720)(
                     nil,
-                    STRING_CONTENT(2666...2669)("foo"),
+                    STRING_CONTENT(2717...2720)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_UPPER_W(2663...2666)("%W["),
-                 STRING_END(2669...2670)("]")
+                 PERCENT_UPPER_W(2714...2717)("%W["),
+                 STRING_END(2720...2721)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2660...2662),
-          (2678...2682)
+          (2711...2713),
+          (2729...2733)
         )],
        nil,
-       (2650...2654),
-       (2683...2686)
+       (2701...2705),
+       (2734...2737)
      ),
-     CaseNode(2687...2723)(
-       CallNode(2692...2695)(
+     CaseNode(2738...2774)(
+       CallNode(2743...2746)(
          nil,
          nil,
-         IDENTIFIER(2692...2695)("foo"),
+         IDENTIFIER(2743...2746)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2697...2719)(
-          IfNode(2700...2714)(
-            KEYWORD_IF_MODIFIER(2708...2710)("if"),
-            CallNode(2711...2714)(
+       [InNode(2748...2770)(
+          IfNode(2751...2765)(
+            KEYWORD_IF_MODIFIER(2759...2761)("if"),
+            CallNode(2762...2765)(
               nil,
               nil,
-              IDENTIFIER(2711...2714)("baz"),
+              IDENTIFIER(2762...2765)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2700...2707)(
-              [StringNode(2700...2707)(
-                 STRING_BEGIN(2700...2703)("%q["),
-                 STRING_CONTENT(2703...2706)("foo"),
-                 STRING_END(2706...2707)("]"),
+            StatementsNode(2751...2758)(
+              [StringNode(2751...2758)(
+                 STRING_BEGIN(2751...2754)("%q["),
+                 STRING_CONTENT(2754...2757)("foo"),
+                 STRING_END(2757...2758)("]"),
                  "foo"
                )]
             ),
@@ -3025,42 +3103,42 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2697...2699),
-          (2715...2719)
+          (2748...2750),
+          (2766...2770)
         )],
        nil,
-       (2687...2691),
-       (2720...2723)
+       (2738...2742),
+       (2771...2774)
      ),
-     CaseNode(2724...2760)(
-       CallNode(2729...2732)(
+     CaseNode(2775...2811)(
+       CallNode(2780...2783)(
          nil,
          nil,
-         IDENTIFIER(2729...2732)("foo"),
+         IDENTIFIER(2780...2783)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2734...2756)(
-          IfNode(2737...2751)(
-            KEYWORD_IF_MODIFIER(2745...2747)("if"),
-            CallNode(2748...2751)(
+       [InNode(2785...2807)(
+          IfNode(2788...2802)(
+            KEYWORD_IF_MODIFIER(2796...2798)("if"),
+            CallNode(2799...2802)(
               nil,
               nil,
-              IDENTIFIER(2748...2751)("baz"),
+              IDENTIFIER(2799...2802)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2737...2744)(
-              [StringNode(2737...2744)(
-                 STRING_BEGIN(2737...2740)("%Q["),
-                 STRING_CONTENT(2740...2743)("foo"),
-                 STRING_END(2743...2744)("]"),
+            StatementsNode(2788...2795)(
+              [StringNode(2788...2795)(
+                 STRING_BEGIN(2788...2791)("%Q["),
+                 STRING_CONTENT(2791...2794)("foo"),
+                 STRING_END(2794...2795)("]"),
                  "foo"
                )]
             ),
@@ -3068,42 +3146,42 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2734...2736),
-          (2752...2756)
+          (2785...2787),
+          (2803...2807)
         )],
        nil,
-       (2724...2728),
-       (2757...2760)
+       (2775...2779),
+       (2808...2811)
      ),
-     CaseNode(2761...2795)(
-       CallNode(2766...2769)(
+     CaseNode(2812...2846)(
+       CallNode(2817...2820)(
          nil,
          nil,
-         IDENTIFIER(2766...2769)("foo"),
+         IDENTIFIER(2817...2820)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2771...2791)(
-          IfNode(2774...2786)(
-            KEYWORD_IF_MODIFIER(2780...2782)("if"),
-            CallNode(2783...2786)(
+       [InNode(2822...2842)(
+          IfNode(2825...2837)(
+            KEYWORD_IF_MODIFIER(2831...2833)("if"),
+            CallNode(2834...2837)(
               nil,
               nil,
-              IDENTIFIER(2783...2786)("baz"),
+              IDENTIFIER(2834...2837)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2774...2779)(
-              [StringNode(2774...2779)(
-                 STRING_BEGIN(2774...2775)("\""),
-                 STRING_CONTENT(2775...2778)("foo"),
-                 STRING_END(2778...2779)("\""),
+            StatementsNode(2825...2830)(
+              [StringNode(2825...2830)(
+                 STRING_BEGIN(2825...2826)("\""),
+                 STRING_CONTENT(2826...2829)("foo"),
+                 STRING_END(2829...2830)("\""),
                  "foo"
                )]
             ),
@@ -3111,299 +3189,299 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (2771...2773),
-          (2787...2791)
+          (2822...2824),
+          (2838...2842)
         )],
        nil,
-       (2761...2765),
-       (2792...2795)
+       (2812...2816),
+       (2843...2846)
      ),
-     CaseNode(2796...2828)(
-       CallNode(2801...2804)(
+     CaseNode(2847...2879)(
+       CallNode(2852...2855)(
          nil,
          nil,
-         IDENTIFIER(2801...2804)("foo"),
+         IDENTIFIER(2852...2855)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2806...2824)(
-          IfNode(2809...2819)(
-            KEYWORD_IF_MODIFIER(2813...2815)("if"),
-            CallNode(2816...2819)(
+       [InNode(2857...2875)(
+          IfNode(2860...2870)(
+            KEYWORD_IF_MODIFIER(2864...2866)("if"),
+            CallNode(2867...2870)(
               nil,
               nil,
-              IDENTIFIER(2816...2819)("baz"),
+              IDENTIFIER(2867...2870)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2809...2812)([NilNode(2809...2812)()]),
+            StatementsNode(2860...2863)([NilNode(2860...2863)()]),
             nil,
             nil
           ),
           nil,
-          (2806...2808),
-          (2820...2824)
+          (2857...2859),
+          (2871...2875)
         )],
        nil,
-       (2796...2800),
-       (2825...2828)
+       (2847...2851),
+       (2876...2879)
      ),
-     CaseNode(2829...2862)(
-       CallNode(2834...2837)(
+     CaseNode(2880...2913)(
+       CallNode(2885...2888)(
          nil,
          nil,
-         IDENTIFIER(2834...2837)("foo"),
+         IDENTIFIER(2885...2888)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2839...2858)(
-          IfNode(2842...2853)(
-            KEYWORD_IF_MODIFIER(2847...2849)("if"),
-            CallNode(2850...2853)(
+       [InNode(2890...2909)(
+          IfNode(2893...2904)(
+            KEYWORD_IF_MODIFIER(2898...2900)("if"),
+            CallNode(2901...2904)(
               nil,
               nil,
-              IDENTIFIER(2850...2853)("baz"),
+              IDENTIFIER(2901...2904)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2842...2846)([SelfNode(2842...2846)()]),
+            StatementsNode(2893...2897)([SelfNode(2893...2897)()]),
             nil,
             nil
           ),
           nil,
-          (2839...2841),
-          (2854...2858)
+          (2890...2892),
+          (2905...2909)
         )],
        nil,
-       (2829...2833),
-       (2859...2862)
+       (2880...2884),
+       (2910...2913)
      ),
-     CaseNode(2863...2896)(
-       CallNode(2868...2871)(
+     CaseNode(2914...2947)(
+       CallNode(2919...2922)(
          nil,
          nil,
-         IDENTIFIER(2868...2871)("foo"),
+         IDENTIFIER(2919...2922)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2873...2892)(
-          IfNode(2876...2887)(
-            KEYWORD_IF_MODIFIER(2881...2883)("if"),
-            CallNode(2884...2887)(
+       [InNode(2924...2943)(
+          IfNode(2927...2938)(
+            KEYWORD_IF_MODIFIER(2932...2934)("if"),
+            CallNode(2935...2938)(
               nil,
               nil,
-              IDENTIFIER(2884...2887)("baz"),
+              IDENTIFIER(2935...2938)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2876...2880)([TrueNode(2876...2880)()]),
+            StatementsNode(2927...2931)([TrueNode(2927...2931)()]),
             nil,
             nil
           ),
           nil,
-          (2873...2875),
-          (2888...2892)
+          (2924...2926),
+          (2939...2943)
         )],
        nil,
-       (2863...2867),
-       (2893...2896)
+       (2914...2918),
+       (2944...2947)
      ),
-     CaseNode(2897...2931)(
-       CallNode(2902...2905)(
+     CaseNode(2948...2982)(
+       CallNode(2953...2956)(
          nil,
          nil,
-         IDENTIFIER(2902...2905)("foo"),
+         IDENTIFIER(2953...2956)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2907...2927)(
-          IfNode(2910...2922)(
-            KEYWORD_IF_MODIFIER(2916...2918)("if"),
-            CallNode(2919...2922)(
+       [InNode(2958...2978)(
+          IfNode(2961...2973)(
+            KEYWORD_IF_MODIFIER(2967...2969)("if"),
+            CallNode(2970...2973)(
               nil,
               nil,
-              IDENTIFIER(2919...2922)("baz"),
+              IDENTIFIER(2970...2973)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2910...2915)([FalseNode(2910...2915)()]),
+            StatementsNode(2961...2966)([FalseNode(2961...2966)()]),
             nil,
             nil
           ),
           nil,
-          (2907...2909),
-          (2923...2927)
+          (2958...2960),
+          (2974...2978)
         )],
        nil,
-       (2897...2901),
-       (2928...2931)
+       (2948...2952),
+       (2979...2982)
      ),
-     CaseNode(2932...2969)(
-       CallNode(2937...2940)(
+     CaseNode(2983...3020)(
+       CallNode(2988...2991)(
          nil,
          nil,
-         IDENTIFIER(2937...2940)("foo"),
+         IDENTIFIER(2988...2991)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2942...2965)(
-          IfNode(2945...2960)(
-            KEYWORD_IF_MODIFIER(2954...2956)("if"),
-            CallNode(2957...2960)(
+       [InNode(2993...3016)(
+          IfNode(2996...3011)(
+            KEYWORD_IF_MODIFIER(3005...3007)("if"),
+            CallNode(3008...3011)(
               nil,
               nil,
-              IDENTIFIER(2957...2960)("baz"),
+              IDENTIFIER(3008...3011)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2945...2953)([SourceFileNode(2945...2953)()]),
+            StatementsNode(2996...3004)([SourceFileNode(2996...3004)()]),
             nil,
             nil
           ),
           nil,
-          (2942...2944),
-          (2961...2965)
+          (2993...2995),
+          (3012...3016)
         )],
        nil,
-       (2932...2936),
-       (2966...2969)
+       (2983...2987),
+       (3017...3020)
      ),
-     CaseNode(2970...3007)(
-       CallNode(2975...2978)(
+     CaseNode(3021...3058)(
+       CallNode(3026...3029)(
          nil,
          nil,
-         IDENTIFIER(2975...2978)("foo"),
+         IDENTIFIER(3026...3029)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2980...3003)(
-          IfNode(2983...2998)(
-            KEYWORD_IF_MODIFIER(2992...2994)("if"),
-            CallNode(2995...2998)(
+       [InNode(3031...3054)(
+          IfNode(3034...3049)(
+            KEYWORD_IF_MODIFIER(3043...3045)("if"),
+            CallNode(3046...3049)(
               nil,
               nil,
-              IDENTIFIER(2995...2998)("baz"),
+              IDENTIFIER(3046...3049)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2983...2991)([SourceLineNode(2983...2991)()]),
+            StatementsNode(3034...3042)([SourceLineNode(3034...3042)()]),
             nil,
             nil
           ),
           nil,
-          (2980...2982),
-          (2999...3003)
+          (3031...3033),
+          (3050...3054)
         )],
        nil,
-       (2970...2974),
-       (3004...3007)
+       (3021...3025),
+       (3055...3058)
      ),
-     CaseNode(3008...3049)(
-       CallNode(3013...3016)(
+     CaseNode(3059...3100)(
+       CallNode(3064...3067)(
          nil,
          nil,
-         IDENTIFIER(3013...3016)("foo"),
+         IDENTIFIER(3064...3067)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(3018...3045)(
-          IfNode(3021...3040)(
-            KEYWORD_IF_MODIFIER(3034...3036)("if"),
-            CallNode(3037...3040)(
+       [InNode(3069...3096)(
+          IfNode(3072...3091)(
+            KEYWORD_IF_MODIFIER(3085...3087)("if"),
+            CallNode(3088...3091)(
               nil,
               nil,
-              IDENTIFIER(3037...3040)("baz"),
+              IDENTIFIER(3088...3091)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(3021...3033)([SourceEncodingNode(3021...3033)()]),
+            StatementsNode(3072...3084)([SourceEncodingNode(3072...3084)()]),
             nil,
             nil
           ),
           nil,
-          (3018...3020),
-          (3041...3045)
+          (3069...3071),
+          (3092...3096)
         )],
        nil,
-       (3008...3012),
-       (3046...3049)
+       (3059...3063),
+       (3097...3100)
      ),
-     CaseNode(3050...3089)(
-       CallNode(3055...3058)(
+     CaseNode(3101...3140)(
+       CallNode(3106...3109)(
          nil,
          nil,
-         IDENTIFIER(3055...3058)("foo"),
+         IDENTIFIER(3106...3109)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(3060...3085)(
-          IfNode(3063...3080)(
-            KEYWORD_IF_MODIFIER(3074...3076)("if"),
-            CallNode(3077...3080)(
+       [InNode(3111...3136)(
+          IfNode(3114...3131)(
+            KEYWORD_IF_MODIFIER(3125...3127)("if"),
+            CallNode(3128...3131)(
               nil,
               nil,
-              IDENTIFIER(3077...3080)("baz"),
+              IDENTIFIER(3128...3131)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(3063...3071)(
-              [LambdaNode(3063...3071)(
-                 Scope(3063...3065)([]),
-                 MINUS_GREATER(3063...3065)("->"),
+            StatementsNode(3114...3122)(
+              [LambdaNode(3114...3122)(
+                 Scope(3114...3116)([]),
+                 MINUS_GREATER(3114...3116)("->"),
                  nil,
                  nil,
                  nil,
-                 StatementsNode(3068...3071)(
-                   [LocalVariableReadNode(3068...3071)(
-                      IDENTIFIER(3068...3071)("bar")
+                 StatementsNode(3119...3122)(
+                   [LocalVariableReadNode(3119...3122)(
+                      IDENTIFIER(3119...3122)("bar")
                     )]
                  )
                )]
@@ -3412,12 +3490,12 @@ ProgramNode(0...3089)(
             nil
           ),
           nil,
-          (3060...3062),
-          (3081...3085)
+          (3111...3113),
+          (3132...3136)
         )],
        nil,
-       (3050...3054),
-       (3086...3089)
+       (3101...3105),
+       (3137...3140)
      )]
   )
 )

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -1,6 +1,10 @@
-ProgramNode(0...3140)(
-  Scope(0...0)([IDENTIFIER(7...10)("bar")]),
-  StatementsNode(0...3140)(
+ProgramNode(0...3655)(
+  Scope(0...0)(
+    [IDENTIFIER(7...10)("bar"),
+     IDENTIFIER(1195...1198)("baz"),
+     IDENTIFIER(1245...1248)("qux")]
+  ),
+  StatementsNode(0...3655)(
     [MatchRequiredNode(0...10)(
        CallNode(0...3)(
          nil,
@@ -1323,7 +1327,7 @@ ProgramNode(0...3140)(
        ),
        (1095...1097)
      ),
-     MatchPredicateNode(1115...1125)(
+     MatchRequiredNode(1115...1127)(
        CallNode(1115...1118)(
          nil,
          nil,
@@ -1334,89 +1338,86 @@ ProgramNode(0...3140)(
          nil,
          "foo"
        ),
-       LocalVariableWriteNode(1122...1125)(
-         IDENTIFIER(1122...1125)("bar"),
+       ArrayPatternNode(1122...1127)(
+         ConstantReadNode(1122...1125)(),
+         [],
          nil,
-         nil
+         [],
+         (1125...1126),
+         (1126...1127)
        ),
        (1119...1121)
      ),
-     MatchPredicateNode(1126...1134)(
-       CallNode(1126...1129)(
+     MatchRequiredNode(1128...1141)(
+       CallNode(1128...1131)(
          nil,
          nil,
-         IDENTIFIER(1126...1129)("foo"),
+         IDENTIFIER(1128...1131)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       IntegerNode(1133...1134)(),
-       (1130...1132)
+       ArrayPatternNode(1135...1141)(
+         ConstantReadNode(1135...1138)(),
+         [IntegerNode(1139...1140)()],
+         nil,
+         [],
+         (1138...1139),
+         (1140...1141)
+       ),
+       (1132...1134)
      ),
-     MatchPredicateNode(1135...1145)(
-       CallNode(1135...1138)(
+     MatchRequiredNode(1142...1161)(
+       CallNode(1142...1145)(
          nil,
          nil,
-         IDENTIFIER(1135...1138)("foo"),
+         IDENTIFIER(1142...1145)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       FloatNode(1142...1145)(),
-       (1139...1141)
+       ArrayPatternNode(1149...1161)(
+         ConstantReadNode(1149...1152)(),
+         [IntegerNode(1153...1154)(),
+          IntegerNode(1156...1157)(),
+          IntegerNode(1159...1160)()],
+         nil,
+         [],
+         (1152...1153),
+         (1160...1161)
+       ),
+       (1146...1148)
      ),
-     MatchPredicateNode(1146...1155)(
-       CallNode(1146...1149)(
+     MatchRequiredNode(1162...1177)(
+       CallNode(1162...1165)(
          nil,
          nil,
-         IDENTIFIER(1146...1149)("foo"),
+         IDENTIFIER(1162...1165)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ImaginaryNode(1153...1155)(),
-       (1150...1152)
+       ArrayPatternNode(1169...1177)(
+         ConstantReadNode(1169...1172)(),
+         [LocalVariableWriteNode(1173...1176)(
+            IDENTIFIER(1173...1176)("bar"),
+            nil,
+            nil
+          )],
+         nil,
+         [],
+         (1172...1173),
+         (1176...1177)
+       ),
+       (1166...1168)
      ),
-     MatchPredicateNode(1156...1165)(
-       CallNode(1156...1159)(
-         nil,
-         nil,
-         IDENTIFIER(1156...1159)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       RationalNode(1163...1165)(),
-       (1160...1162)
-     ),
-     MatchPredicateNode(1166...1177)(
-       CallNode(1166...1169)(
-         nil,
-         nil,
-         IDENTIFIER(1166...1169)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       SymbolNode(1173...1177)(
-         SYMBOL_BEGIN(1173...1174)(":"),
-         IDENTIFIER(1174...1177)("foo"),
-         nil,
-         "foo"
-       ),
-       (1170...1172)
-     ),
-     MatchPredicateNode(1178...1192)(
+     MatchRequiredNode(1178...1199)(
        CallNode(1178...1181)(
          nil,
          nil,
@@ -1427,141 +1428,141 @@ ProgramNode(0...3140)(
          nil,
          "foo"
        ),
-       SymbolNode(1185...1192)(
-         SYMBOL_BEGIN(1185...1188)("%s["),
-         STRING_CONTENT(1188...1191)("foo"),
-         STRING_END(1191...1192)("]"),
-         "foo"
+       ArrayPatternNode(1185...1199)(
+         ConstantReadNode(1185...1188)(),
+         [],
+         SplatNode(1189...1193)(
+           USTAR(1189...1190)("*"),
+           LocalVariableWriteNode(1190...1193)(
+             IDENTIFIER(1190...1193)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1195...1198)(
+            IDENTIFIER(1195...1198)("baz"),
+            nil,
+            nil
+          )],
+         (1188...1189),
+         (1198...1199)
        ),
        (1182...1184)
      ),
-     MatchPredicateNode(1193...1205)(
-       CallNode(1193...1196)(
+     MatchRequiredNode(1200...1221)(
+       CallNode(1200...1203)(
          nil,
          nil,
-         IDENTIFIER(1193...1196)("foo"),
+         IDENTIFIER(1200...1203)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       InterpolatedSymbolNode(1202...1205)(
-         SYMBOL_BEGIN(1200...1202)(":\""),
-         [StringNode(1202...1205)(
+       ArrayPatternNode(1207...1221)(
+         ConstantReadNode(1207...1210)(),
+         [LocalVariableWriteNode(1211...1214)(
+            IDENTIFIER(1211...1214)("bar"),
             nil,
-            STRING_CONTENT(1202...1205)("foo"),
-            nil,
-            "foo"
+            nil
           )],
-         STRING_END(1205...1206)("\"")
+         SplatNode(1216...1220)(
+           USTAR(1216...1217)("*"),
+           LocalVariableWriteNode(1217...1220)(
+             IDENTIFIER(1217...1220)("baz"),
+             nil,
+             nil
+           )
+         ),
+         [],
+         (1210...1211),
+         (1220...1221)
        ),
-       (1197...1199)
+       (1204...1206)
      ),
-     MatchPredicateNode(1207...1219)(
-       CallNode(1207...1210)(
+     MatchRequiredNode(1222...1249)(
+       CallNode(1222...1225)(
          nil,
          nil,
-         IDENTIFIER(1207...1210)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       RegularExpressionNode(1214...1219)(
-         REGEXP_BEGIN(1214...1215)("/"),
-         STRING_CONTENT(1215...1218)("foo"),
-         REGEXP_END(1218...1219)("/"),
-         "foo"
-       ),
-       (1211...1213)
-     ),
-     MatchPredicateNode(1220...1232)(
-       CallNode(1220...1223)(
-         nil,
-         nil,
-         IDENTIFIER(1220...1223)("foo"),
+         IDENTIFIER(1222...1225)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       XStringNode(1227...1232)(
-         BACKTICK(1227...1228)("`"),
-         STRING_CONTENT(1228...1231)("foo"),
-         STRING_END(1231...1232)("`"),
-         "foo"
-       ),
-       (1224...1226)
-     ),
-     MatchPredicateNode(1233...1247)(
-       CallNode(1233...1236)(
-         nil,
-         nil,
-         IDENTIFIER(1233...1236)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       XStringNode(1240...1247)(
-         PERCENT_LOWER_X(1240...1243)("%x["),
-         STRING_CONTENT(1243...1246)("foo"),
-         STRING_END(1246...1247)("]"),
-         "foo"
-       ),
-       (1237...1239)
-     ),
-     MatchPredicateNode(1248...1262)(
-       CallNode(1248...1251)(
-         nil,
-         nil,
-         IDENTIFIER(1248...1251)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       ArrayNode(1255...1262)(
-         [SymbolNode(1258...1261)(
+       FindPatternNode(1229...1249)(
+         ConstantReadNode(1229...1232)(),
+         SplatNode(1233...1237)(
+           USTAR(1233...1234)("*"),
+           LocalVariableWriteNode(1234...1237)(
+             IDENTIFIER(1234...1237)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1239...1242)(
+            IDENTIFIER(1239...1242)("baz"),
             nil,
-            STRING_CONTENT(1258...1261)("foo"),
-            nil,
-            "foo"
+            nil
           )],
-         PERCENT_LOWER_I(1255...1258)("%i["),
-         STRING_END(1261...1262)("]")
+         SplatNode(1244...1248)(
+           USTAR(1244...1245)("*"),
+           LocalVariableWriteNode(1245...1248)(
+             IDENTIFIER(1245...1248)("qux"),
+             nil,
+             nil
+           )
+         ),
+         (1232...1233),
+         (1248...1249)
        ),
-       (1252...1254)
+       (1226...1228)
      ),
-     MatchPredicateNode(1263...1277)(
-       CallNode(1263...1266)(
+     MatchRequiredNode(1251...1263)(
+       CallNode(1251...1254)(
          nil,
          nil,
-         IDENTIFIER(1263...1266)("foo"),
+         IDENTIFIER(1251...1254)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ArrayNode(1270...1277)(
-         [SymbolNode(1273...1276)(
-            nil,
-            STRING_CONTENT(1273...1276)("foo"),
-            nil,
-            "foo"
-          )],
-         PERCENT_UPPER_I(1270...1273)("%I["),
-         STRING_END(1276...1277)("]")
+       ArrayPatternNode(1258...1263)(
+         ConstantReadNode(1258...1261)(),
+         [],
+         nil,
+         [],
+         (1261...1262),
+         (1262...1263)
        ),
-       (1267...1269)
+       (1255...1257)
      ),
-     MatchPredicateNode(1278...1292)(
+     MatchRequiredNode(1264...1277)(
+       CallNode(1264...1267)(
+         nil,
+         nil,
+         IDENTIFIER(1264...1267)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayPatternNode(1271...1277)(
+         ConstantReadNode(1271...1274)(),
+         [IntegerNode(1275...1276)()],
+         nil,
+         [],
+         (1274...1275),
+         (1276...1277)
+       ),
+       (1268...1270)
+     ),
+     MatchRequiredNode(1278...1297)(
        CallNode(1278...1281)(
          nil,
          nil,
@@ -1572,155 +1573,175 @@ ProgramNode(0...3140)(
          nil,
          "foo"
        ),
-       ArrayNode(1285...1292)(
-         [StringNode(1288...1291)(
-            nil,
-            STRING_CONTENT(1288...1291)("foo"),
-            nil,
-            "foo"
-          )],
-         PERCENT_LOWER_W(1285...1288)("%w["),
-         STRING_END(1291...1292)("]")
+       ArrayPatternNode(1285...1297)(
+         ConstantReadNode(1285...1288)(),
+         [IntegerNode(1289...1290)(),
+          IntegerNode(1292...1293)(),
+          IntegerNode(1295...1296)()],
+         nil,
+         [],
+         (1288...1289),
+         (1296...1297)
        ),
        (1282...1284)
      ),
-     MatchPredicateNode(1293...1307)(
-       CallNode(1293...1296)(
+     MatchRequiredNode(1298...1313)(
+       CallNode(1298...1301)(
          nil,
          nil,
-         IDENTIFIER(1293...1296)("foo"),
+         IDENTIFIER(1298...1301)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ArrayNode(1300...1307)(
-         [StringNode(1303...1306)(
+       ArrayPatternNode(1305...1313)(
+         ConstantReadNode(1305...1308)(),
+         [LocalVariableWriteNode(1309...1312)(
+            IDENTIFIER(1309...1312)("bar"),
             nil,
-            STRING_CONTENT(1303...1306)("foo"),
-            nil,
-            "foo"
+            nil
           )],
-         PERCENT_UPPER_W(1300...1303)("%W["),
-         STRING_END(1306...1307)("]")
+         nil,
+         [],
+         (1308...1309),
+         (1312...1313)
        ),
-       (1297...1299)
+       (1302...1304)
      ),
-     MatchPredicateNode(1308...1322)(
-       CallNode(1308...1311)(
+     MatchRequiredNode(1314...1335)(
+       CallNode(1314...1317)(
          nil,
          nil,
-         IDENTIFIER(1308...1311)("foo"),
+         IDENTIFIER(1314...1317)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1315...1322)(
-         STRING_BEGIN(1315...1318)("%q["),
-         STRING_CONTENT(1318...1321)("foo"),
-         STRING_END(1321...1322)("]"),
-         "foo"
+       ArrayPatternNode(1321...1335)(
+         ConstantReadNode(1321...1324)(),
+         [],
+         SplatNode(1325...1329)(
+           USTAR(1325...1326)("*"),
+           LocalVariableWriteNode(1326...1329)(
+             IDENTIFIER(1326...1329)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1331...1334)(
+            IDENTIFIER(1331...1334)("baz"),
+            nil,
+            nil
+          )],
+         (1324...1325),
+         (1334...1335)
        ),
-       (1312...1314)
+       (1318...1320)
      ),
-     MatchPredicateNode(1323...1337)(
-       CallNode(1323...1326)(
+     MatchRequiredNode(1336...1357)(
+       CallNode(1336...1339)(
          nil,
          nil,
-         IDENTIFIER(1323...1326)("foo"),
+         IDENTIFIER(1336...1339)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1330...1337)(
-         STRING_BEGIN(1330...1333)("%Q["),
-         STRING_CONTENT(1333...1336)("foo"),
-         STRING_END(1336...1337)("]"),
-         "foo"
+       ArrayPatternNode(1343...1357)(
+         ConstantReadNode(1343...1346)(),
+         [LocalVariableWriteNode(1347...1350)(
+            IDENTIFIER(1347...1350)("bar"),
+            nil,
+            nil
+          )],
+         SplatNode(1352...1356)(
+           USTAR(1352...1353)("*"),
+           LocalVariableWriteNode(1353...1356)(
+             IDENTIFIER(1353...1356)("baz"),
+             nil,
+             nil
+           )
+         ),
+         [],
+         (1346...1347),
+         (1356...1357)
        ),
-       (1327...1329)
+       (1340...1342)
      ),
-     MatchPredicateNode(1338...1350)(
-       CallNode(1338...1341)(
+     MatchRequiredNode(1358...1385)(
+       CallNode(1358...1361)(
          nil,
          nil,
-         IDENTIFIER(1338...1341)("foo"),
+         IDENTIFIER(1358...1361)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1345...1350)(
-         STRING_BEGIN(1345...1346)("\""),
-         STRING_CONTENT(1346...1349)("foo"),
-         STRING_END(1349...1350)("\""),
-         "foo"
+       FindPatternNode(1365...1385)(
+         ConstantReadNode(1365...1368)(),
+         SplatNode(1369...1373)(
+           USTAR(1369...1370)("*"),
+           LocalVariableWriteNode(1370...1373)(
+             IDENTIFIER(1370...1373)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1375...1378)(
+            IDENTIFIER(1375...1378)("baz"),
+            nil,
+            nil
+          )],
+         SplatNode(1380...1384)(
+           USTAR(1380...1381)("*"),
+           LocalVariableWriteNode(1381...1384)(
+             IDENTIFIER(1381...1384)("qux"),
+             nil,
+             nil
+           )
+         ),
+         (1368...1369),
+         (1384...1385)
        ),
-       (1342...1344)
+       (1362...1364)
      ),
-     MatchPredicateNode(1351...1361)(
-       CallNode(1351...1354)(
+     MatchRequiredNode(1387...1398)(
+       CallNode(1387...1390)(
          nil,
          nil,
-         IDENTIFIER(1351...1354)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       NilNode(1358...1361)(),
-       (1355...1357)
-     ),
-     MatchPredicateNode(1362...1373)(
-       CallNode(1362...1365)(
-         nil,
-         nil,
-         IDENTIFIER(1362...1365)("foo"),
+         IDENTIFIER(1387...1390)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SelfNode(1369...1373)(),
-       (1366...1368)
-     ),
-     MatchPredicateNode(1374...1385)(
-       CallNode(1374...1377)(
+       ArrayPatternNode(1394...1398)(
          nil,
+         [],
+         SplatNode(1394...1398)(
+           USTAR(1394...1395)("*"),
+           LocalVariableWriteNode(1395...1398)(
+             IDENTIFIER(1395...1398)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [],
          nil,
-         IDENTIFIER(1374...1377)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
+         nil
        ),
-       TrueNode(1381...1385)(),
-       (1378...1380)
+       (1391...1393)
      ),
-     MatchPredicateNode(1386...1398)(
-       CallNode(1386...1389)(
-         nil,
-         nil,
-         IDENTIFIER(1386...1389)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       FalseNode(1393...1398)(),
-       (1390...1392)
-     ),
-     MatchPredicateNode(1399...1414)(
+     MatchRequiredNode(1399...1420)(
        CallNode(1399...1402)(
          nil,
          nil,
@@ -1731,733 +1752,1517 @@ ProgramNode(0...3140)(
          nil,
          "foo"
        ),
-       SourceFileNode(1406...1414)(),
+       ArrayPatternNode(1406...1420)(
+         nil,
+         [],
+         SplatNode(1406...1410)(
+           USTAR(1406...1407)("*"),
+           LocalVariableWriteNode(1407...1410)(
+             IDENTIFIER(1407...1410)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1412...1415)(
+            IDENTIFIER(1412...1415)("baz"),
+            nil,
+            nil
+          ),
+          LocalVariableWriteNode(1417...1420)(
+            IDENTIFIER(1417...1420)("qux"),
+            nil,
+            nil
+          )],
+         nil,
+         nil
+       ),
        (1403...1405)
      ),
-     MatchPredicateNode(1415...1430)(
-       CallNode(1415...1418)(
+     MatchRequiredNode(1421...1442)(
+       CallNode(1421...1424)(
          nil,
          nil,
-         IDENTIFIER(1415...1418)("foo"),
+         IDENTIFIER(1421...1424)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceLineNode(1422...1430)(),
-       (1419...1421)
+       ArrayPatternNode(1428...1442)(
+         nil,
+         [LocalVariableWriteNode(1428...1431)(
+            IDENTIFIER(1428...1431)("bar"),
+            nil,
+            nil
+          )],
+         SplatNode(1433...1437)(
+           USTAR(1433...1434)("*"),
+           LocalVariableWriteNode(1434...1437)(
+             IDENTIFIER(1434...1437)("baz"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1439...1442)(
+            IDENTIFIER(1439...1442)("qux"),
+            nil,
+            nil
+          )],
+         nil,
+         nil
+       ),
+       (1425...1427)
      ),
-     MatchPredicateNode(1431...1450)(
-       CallNode(1431...1434)(
+     MatchRequiredNode(1443...1464)(
+       CallNode(1443...1446)(
          nil,
          nil,
-         IDENTIFIER(1431...1434)("foo"),
+         IDENTIFIER(1443...1446)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceEncodingNode(1438...1450)(),
-       (1435...1437)
+       ArrayPatternNode(1450...1464)(
+         nil,
+         [LocalVariableWriteNode(1450...1453)(
+            IDENTIFIER(1450...1453)("bar"),
+            nil,
+            nil
+          ),
+          LocalVariableWriteNode(1455...1458)(
+            IDENTIFIER(1455...1458)("baz"),
+            nil,
+            nil
+          )],
+         SplatNode(1460...1464)(
+           USTAR(1460...1461)("*"),
+           LocalVariableWriteNode(1461...1464)(
+             IDENTIFIER(1461...1464)("qux"),
+             nil,
+             nil
+           )
+         ),
+         [],
+         nil,
+         nil
+       ),
+       (1447...1449)
      ),
-     MatchPredicateNode(1451...1466)(
-       CallNode(1451...1454)(
+     MatchRequiredNode(1465...1487)(
+       CallNode(1465...1468)(
          nil,
          nil,
-         IDENTIFIER(1451...1454)("foo"),
+         IDENTIFIER(1465...1468)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       LambdaNode(1458...1466)(
-         Scope(1458...1460)([]),
-         MINUS_GREATER(1458...1460)("->"),
+       FindPatternNode(1472...1487)(
+         nil,
+         SplatNode(1472...1476)(
+           USTAR(1472...1473)("*"),
+           LocalVariableWriteNode(1473...1476)(
+             IDENTIFIER(1473...1476)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1478...1481)(
+            IDENTIFIER(1478...1481)("baz"),
+            nil,
+            nil
+          )],
+         SplatNode(1483...1487)(
+           USTAR(1483...1484)("*"),
+           LocalVariableWriteNode(1484...1487)(
+             IDENTIFIER(1484...1487)("qux"),
+             nil,
+             nil
+           )
+         ),
+         nil,
+         nil
+       ),
+       (1469...1471)
+     ),
+     MatchRequiredNode(1489...1498)(
+       CallNode(1489...1492)(
+         nil,
+         nil,
+         IDENTIFIER(1489...1492)("foo"),
          nil,
          nil,
          nil,
-         StatementsNode(1463...1466)(
-           [LocalVariableReadNode(1463...1466)(IDENTIFIER(1463...1466)("bar"))]
+         nil,
+         "foo"
+       ),
+       ArrayPatternNode(1496...1498)(
+         nil,
+         [],
+         nil,
+         [],
+         (1496...1497),
+         (1497...1498)
+       ),
+       (1493...1495)
+     ),
+     MatchRequiredNode(1499...1516)(
+       CallNode(1499...1502)(
+         nil,
+         nil,
+         IDENTIFIER(1499...1502)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayPatternNode(1506...1516)(
+         nil,
+         [ArrayPatternNode(1507...1515)(
+            nil,
+            [ArrayPatternNode(1508...1514)(
+               nil,
+               [ArrayPatternNode(1509...1513)(
+                  nil,
+                  [ArrayPatternNode(1510...1512)(
+                     nil,
+                     [],
+                     nil,
+                     [],
+                     (1510...1511),
+                     (1511...1512)
+                   )],
+                  nil,
+                  [],
+                  (1509...1510),
+                  (1512...1513)
+                )],
+               nil,
+               [],
+               (1508...1509),
+               (1513...1514)
+             )],
+            nil,
+            [],
+            (1507...1508),
+            (1514...1515)
+          )],
+         nil,
+         [],
+         (1506...1507),
+         (1515...1516)
+       ),
+       (1503...1505)
+     ),
+     MatchRequiredNode(1518...1531)(
+       CallNode(1518...1521)(
+         nil,
+         nil,
+         IDENTIFIER(1518...1521)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayPatternNode(1525...1531)(
+         nil,
+         [],
+         SplatNode(1526...1530)(
+           USTAR(1526...1527)("*"),
+           LocalVariableWriteNode(1527...1530)(
+             IDENTIFIER(1527...1530)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [],
+         (1525...1526),
+         (1530...1531)
+       ),
+       (1522...1524)
+     ),
+     MatchRequiredNode(1532...1555)(
+       CallNode(1532...1535)(
+         nil,
+         nil,
+         IDENTIFIER(1532...1535)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayPatternNode(1539...1555)(
+         nil,
+         [],
+         SplatNode(1540...1544)(
+           USTAR(1540...1541)("*"),
+           LocalVariableWriteNode(1541...1544)(
+             IDENTIFIER(1541...1544)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1546...1549)(
+            IDENTIFIER(1546...1549)("baz"),
+            nil,
+            nil
+          ),
+          LocalVariableWriteNode(1551...1554)(
+            IDENTIFIER(1551...1554)("qux"),
+            nil,
+            nil
+          )],
+         (1539...1540),
+         (1554...1555)
+       ),
+       (1536...1538)
+     ),
+     MatchRequiredNode(1556...1579)(
+       CallNode(1556...1559)(
+         nil,
+         nil,
+         IDENTIFIER(1556...1559)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayPatternNode(1563...1579)(
+         nil,
+         [LocalVariableWriteNode(1564...1567)(
+            IDENTIFIER(1564...1567)("bar"),
+            nil,
+            nil
+          )],
+         SplatNode(1569...1573)(
+           USTAR(1569...1570)("*"),
+           LocalVariableWriteNode(1570...1573)(
+             IDENTIFIER(1570...1573)("baz"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1575...1578)(
+            IDENTIFIER(1575...1578)("qux"),
+            nil,
+            nil
+          )],
+         (1563...1564),
+         (1578...1579)
+       ),
+       (1560...1562)
+     ),
+     MatchRequiredNode(1580...1603)(
+       CallNode(1580...1583)(
+         nil,
+         nil,
+         IDENTIFIER(1580...1583)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayPatternNode(1587...1603)(
+         nil,
+         [LocalVariableWriteNode(1588...1591)(
+            IDENTIFIER(1588...1591)("bar"),
+            nil,
+            nil
+          ),
+          LocalVariableWriteNode(1593...1596)(
+            IDENTIFIER(1593...1596)("baz"),
+            nil,
+            nil
+          )],
+         SplatNode(1598...1602)(
+           USTAR(1598...1599)("*"),
+           LocalVariableWriteNode(1599...1602)(
+             IDENTIFIER(1599...1602)("qux"),
+             nil,
+             nil
+           )
+         ),
+         [],
+         (1587...1588),
+         (1602...1603)
+       ),
+       (1584...1586)
+     ),
+     MatchRequiredNode(1604...1628)(
+       CallNode(1604...1607)(
+         nil,
+         nil,
+         IDENTIFIER(1604...1607)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       FindPatternNode(1611...1628)(
+         nil,
+         SplatNode(1612...1616)(
+           USTAR(1612...1613)("*"),
+           LocalVariableWriteNode(1613...1616)(
+             IDENTIFIER(1613...1616)("bar"),
+             nil,
+             nil
+           )
+         ),
+         [LocalVariableWriteNode(1618...1621)(
+            IDENTIFIER(1618...1621)("baz"),
+            nil,
+            nil
+          )],
+         SplatNode(1623...1627)(
+           USTAR(1623...1624)("*"),
+           LocalVariableWriteNode(1624...1627)(
+             IDENTIFIER(1624...1627)("qux"),
+             nil,
+             nil
+           )
+         ),
+         (1611...1612),
+         (1627...1628)
+       ),
+       (1608...1610)
+     ),
+     MatchPredicateNode(1630...1640)(
+       CallNode(1630...1633)(
+         nil,
+         nil,
+         IDENTIFIER(1630...1633)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       LocalVariableWriteNode(1637...1640)(
+         IDENTIFIER(1637...1640)("bar"),
+         nil,
+         nil
+       ),
+       (1634...1636)
+     ),
+     MatchPredicateNode(1641...1649)(
+       CallNode(1641...1644)(
+         nil,
+         nil,
+         IDENTIFIER(1641...1644)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       IntegerNode(1648...1649)(),
+       (1645...1647)
+     ),
+     MatchPredicateNode(1650...1660)(
+       CallNode(1650...1653)(
+         nil,
+         nil,
+         IDENTIFIER(1650...1653)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       FloatNode(1657...1660)(),
+       (1654...1656)
+     ),
+     MatchPredicateNode(1661...1670)(
+       CallNode(1661...1664)(
+         nil,
+         nil,
+         IDENTIFIER(1661...1664)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ImaginaryNode(1668...1670)(),
+       (1665...1667)
+     ),
+     MatchPredicateNode(1671...1680)(
+       CallNode(1671...1674)(
+         nil,
+         nil,
+         IDENTIFIER(1671...1674)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       RationalNode(1678...1680)(),
+       (1675...1677)
+     ),
+     MatchPredicateNode(1681...1692)(
+       CallNode(1681...1684)(
+         nil,
+         nil,
+         IDENTIFIER(1681...1684)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SymbolNode(1688...1692)(
+         SYMBOL_BEGIN(1688...1689)(":"),
+         IDENTIFIER(1689...1692)("foo"),
+         nil,
+         "foo"
+       ),
+       (1685...1687)
+     ),
+     MatchPredicateNode(1693...1707)(
+       CallNode(1693...1696)(
+         nil,
+         nil,
+         IDENTIFIER(1693...1696)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SymbolNode(1700...1707)(
+         SYMBOL_BEGIN(1700...1703)("%s["),
+         STRING_CONTENT(1703...1706)("foo"),
+         STRING_END(1706...1707)("]"),
+         "foo"
+       ),
+       (1697...1699)
+     ),
+     MatchPredicateNode(1708...1720)(
+       CallNode(1708...1711)(
+         nil,
+         nil,
+         IDENTIFIER(1708...1711)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       InterpolatedSymbolNode(1717...1720)(
+         SYMBOL_BEGIN(1715...1717)(":\""),
+         [StringNode(1717...1720)(
+            nil,
+            STRING_CONTENT(1717...1720)("foo"),
+            nil,
+            "foo"
+          )],
+         STRING_END(1720...1721)("\"")
+       ),
+       (1712...1714)
+     ),
+     MatchPredicateNode(1722...1734)(
+       CallNode(1722...1725)(
+         nil,
+         nil,
+         IDENTIFIER(1722...1725)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       RegularExpressionNode(1729...1734)(
+         REGEXP_BEGIN(1729...1730)("/"),
+         STRING_CONTENT(1730...1733)("foo"),
+         REGEXP_END(1733...1734)("/"),
+         "foo"
+       ),
+       (1726...1728)
+     ),
+     MatchPredicateNode(1735...1747)(
+       CallNode(1735...1738)(
+         nil,
+         nil,
+         IDENTIFIER(1735...1738)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       XStringNode(1742...1747)(
+         BACKTICK(1742...1743)("`"),
+         STRING_CONTENT(1743...1746)("foo"),
+         STRING_END(1746...1747)("`"),
+         "foo"
+       ),
+       (1739...1741)
+     ),
+     MatchPredicateNode(1748...1762)(
+       CallNode(1748...1751)(
+         nil,
+         nil,
+         IDENTIFIER(1748...1751)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       XStringNode(1755...1762)(
+         PERCENT_LOWER_X(1755...1758)("%x["),
+         STRING_CONTENT(1758...1761)("foo"),
+         STRING_END(1761...1762)("]"),
+         "foo"
+       ),
+       (1752...1754)
+     ),
+     MatchPredicateNode(1763...1777)(
+       CallNode(1763...1766)(
+         nil,
+         nil,
+         IDENTIFIER(1763...1766)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayNode(1770...1777)(
+         [SymbolNode(1773...1776)(
+            nil,
+            STRING_CONTENT(1773...1776)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_LOWER_I(1770...1773)("%i["),
+         STRING_END(1776...1777)("]")
+       ),
+       (1767...1769)
+     ),
+     MatchPredicateNode(1778...1792)(
+       CallNode(1778...1781)(
+         nil,
+         nil,
+         IDENTIFIER(1778...1781)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayNode(1785...1792)(
+         [SymbolNode(1788...1791)(
+            nil,
+            STRING_CONTENT(1788...1791)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_UPPER_I(1785...1788)("%I["),
+         STRING_END(1791...1792)("]")
+       ),
+       (1782...1784)
+     ),
+     MatchPredicateNode(1793...1807)(
+       CallNode(1793...1796)(
+         nil,
+         nil,
+         IDENTIFIER(1793...1796)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayNode(1800...1807)(
+         [StringNode(1803...1806)(
+            nil,
+            STRING_CONTENT(1803...1806)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_LOWER_W(1800...1803)("%w["),
+         STRING_END(1806...1807)("]")
+       ),
+       (1797...1799)
+     ),
+     MatchPredicateNode(1808...1822)(
+       CallNode(1808...1811)(
+         nil,
+         nil,
+         IDENTIFIER(1808...1811)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayNode(1815...1822)(
+         [StringNode(1818...1821)(
+            nil,
+            STRING_CONTENT(1818...1821)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_UPPER_W(1815...1818)("%W["),
+         STRING_END(1821...1822)("]")
+       ),
+       (1812...1814)
+     ),
+     MatchPredicateNode(1823...1837)(
+       CallNode(1823...1826)(
+         nil,
+         nil,
+         IDENTIFIER(1823...1826)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       StringNode(1830...1837)(
+         STRING_BEGIN(1830...1833)("%q["),
+         STRING_CONTENT(1833...1836)("foo"),
+         STRING_END(1836...1837)("]"),
+         "foo"
+       ),
+       (1827...1829)
+     ),
+     MatchPredicateNode(1838...1852)(
+       CallNode(1838...1841)(
+         nil,
+         nil,
+         IDENTIFIER(1838...1841)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       StringNode(1845...1852)(
+         STRING_BEGIN(1845...1848)("%Q["),
+         STRING_CONTENT(1848...1851)("foo"),
+         STRING_END(1851...1852)("]"),
+         "foo"
+       ),
+       (1842...1844)
+     ),
+     MatchPredicateNode(1853...1865)(
+       CallNode(1853...1856)(
+         nil,
+         nil,
+         IDENTIFIER(1853...1856)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       StringNode(1860...1865)(
+         STRING_BEGIN(1860...1861)("\""),
+         STRING_CONTENT(1861...1864)("foo"),
+         STRING_END(1864...1865)("\""),
+         "foo"
+       ),
+       (1857...1859)
+     ),
+     MatchPredicateNode(1866...1876)(
+       CallNode(1866...1869)(
+         nil,
+         nil,
+         IDENTIFIER(1866...1869)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       NilNode(1873...1876)(),
+       (1870...1872)
+     ),
+     MatchPredicateNode(1877...1888)(
+       CallNode(1877...1880)(
+         nil,
+         nil,
+         IDENTIFIER(1877...1880)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SelfNode(1884...1888)(),
+       (1881...1883)
+     ),
+     MatchPredicateNode(1889...1900)(
+       CallNode(1889...1892)(
+         nil,
+         nil,
+         IDENTIFIER(1889...1892)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       TrueNode(1896...1900)(),
+       (1893...1895)
+     ),
+     MatchPredicateNode(1901...1913)(
+       CallNode(1901...1904)(
+         nil,
+         nil,
+         IDENTIFIER(1901...1904)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       FalseNode(1908...1913)(),
+       (1905...1907)
+     ),
+     MatchPredicateNode(1914...1929)(
+       CallNode(1914...1917)(
+         nil,
+         nil,
+         IDENTIFIER(1914...1917)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SourceFileNode(1921...1929)(),
+       (1918...1920)
+     ),
+     MatchPredicateNode(1930...1945)(
+       CallNode(1930...1933)(
+         nil,
+         nil,
+         IDENTIFIER(1930...1933)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SourceLineNode(1937...1945)(),
+       (1934...1936)
+     ),
+     MatchPredicateNode(1946...1965)(
+       CallNode(1946...1949)(
+         nil,
+         nil,
+         IDENTIFIER(1946...1949)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SourceEncodingNode(1953...1965)(),
+       (1950...1952)
+     ),
+     MatchPredicateNode(1966...1981)(
+       CallNode(1966...1969)(
+         nil,
+         nil,
+         IDENTIFIER(1966...1969)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       LambdaNode(1973...1981)(
+         Scope(1973...1975)([]),
+         MINUS_GREATER(1973...1975)("->"),
+         nil,
+         nil,
+         nil,
+         StatementsNode(1978...1981)(
+           [LocalVariableReadNode(1978...1981)(IDENTIFIER(1978...1981)("bar"))]
          )
        ),
-       (1455...1457)
+       (1970...1972)
      ),
-     CaseNode(1470...1495)(
-       CallNode(1475...1478)(
+     CaseNode(1985...2010)(
+       CallNode(1990...1993)(
          nil,
          nil,
-         IDENTIFIER(1475...1478)("foo"),
+         IDENTIFIER(1990...1993)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1480...1491)(
-          LocalVariableWriteNode(1483...1486)(
-            IDENTIFIER(1483...1486)("bar"),
+       [InNode(1995...2006)(
+          LocalVariableWriteNode(1998...2001)(
+            IDENTIFIER(1998...2001)("bar"),
             nil,
             nil
           ),
           nil,
-          (1480...1482),
-          (1487...1491)
+          (1995...1997),
+          (2002...2006)
         )],
        nil,
-       (1470...1474),
-       (1492...1495)
+       (1985...1989),
+       (2007...2010)
      ),
-     CaseNode(1496...1519)(
-       CallNode(1501...1504)(
+     CaseNode(2011...2034)(
+       CallNode(2016...2019)(
          nil,
          nil,
-         IDENTIFIER(1501...1504)("foo"),
+         IDENTIFIER(2016...2019)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1506...1515)(
-          IntegerNode(1509...1510)(),
+       [InNode(2021...2030)(
+          IntegerNode(2024...2025)(),
           nil,
-          (1506...1508),
-          (1511...1515)
+          (2021...2023),
+          (2026...2030)
         )],
        nil,
-       (1496...1500),
-       (1516...1519)
+       (2011...2015),
+       (2031...2034)
      ),
-     CaseNode(1520...1545)(
-       CallNode(1525...1528)(
+     CaseNode(2035...2060)(
+       CallNode(2040...2043)(
          nil,
          nil,
-         IDENTIFIER(1525...1528)("foo"),
+         IDENTIFIER(2040...2043)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1530...1541)(
-          FloatNode(1533...1536)(),
+       [InNode(2045...2056)(
+          FloatNode(2048...2051)(),
           nil,
-          (1530...1532),
-          (1537...1541)
+          (2045...2047),
+          (2052...2056)
         )],
        nil,
-       (1520...1524),
-       (1542...1545)
+       (2035...2039),
+       (2057...2060)
      ),
-     CaseNode(1546...1570)(
-       CallNode(1551...1554)(
+     CaseNode(2061...2085)(
+       CallNode(2066...2069)(
          nil,
          nil,
-         IDENTIFIER(1551...1554)("foo"),
+         IDENTIFIER(2066...2069)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1556...1566)(
-          ImaginaryNode(1559...1561)(),
+       [InNode(2071...2081)(
+          ImaginaryNode(2074...2076)(),
           nil,
-          (1556...1558),
-          (1562...1566)
+          (2071...2073),
+          (2077...2081)
         )],
        nil,
-       (1546...1550),
-       (1567...1570)
+       (2061...2065),
+       (2082...2085)
      ),
-     CaseNode(1571...1595)(
-       CallNode(1576...1579)(
+     CaseNode(2086...2110)(
+       CallNode(2091...2094)(
          nil,
          nil,
-         IDENTIFIER(1576...1579)("foo"),
+         IDENTIFIER(2091...2094)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1581...1591)(
-          RationalNode(1584...1586)(),
+       [InNode(2096...2106)(
+          RationalNode(2099...2101)(),
           nil,
-          (1581...1583),
-          (1587...1591)
+          (2096...2098),
+          (2102...2106)
         )],
        nil,
-       (1571...1575),
-       (1592...1595)
+       (2086...2090),
+       (2107...2110)
      ),
-     CaseNode(1596...1622)(
-       CallNode(1601...1604)(
+     CaseNode(2111...2137)(
+       CallNode(2116...2119)(
          nil,
          nil,
-         IDENTIFIER(1601...1604)("foo"),
+         IDENTIFIER(2116...2119)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1606...1618)(
-          SymbolNode(1609...1613)(
-            SYMBOL_BEGIN(1609...1610)(":"),
-            IDENTIFIER(1610...1613)("foo"),
+       [InNode(2121...2133)(
+          SymbolNode(2124...2128)(
+            SYMBOL_BEGIN(2124...2125)(":"),
+            IDENTIFIER(2125...2128)("foo"),
             nil,
             "foo"
           ),
           nil,
-          (1606...1608),
-          (1614...1618)
+          (2121...2123),
+          (2129...2133)
         )],
        nil,
-       (1596...1600),
-       (1619...1622)
+       (2111...2115),
+       (2134...2137)
      ),
-     CaseNode(1623...1652)(
-       CallNode(1628...1631)(
+     CaseNode(2138...2167)(
+       CallNode(2143...2146)(
          nil,
          nil,
-         IDENTIFIER(1628...1631)("foo"),
+         IDENTIFIER(2143...2146)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1633...1648)(
-          SymbolNode(1636...1643)(
-            SYMBOL_BEGIN(1636...1639)("%s["),
-            STRING_CONTENT(1639...1642)("foo"),
-            STRING_END(1642...1643)("]"),
+       [InNode(2148...2163)(
+          SymbolNode(2151...2158)(
+            SYMBOL_BEGIN(2151...2154)("%s["),
+            STRING_CONTENT(2154...2157)("foo"),
+            STRING_END(2157...2158)("]"),
             "foo"
           ),
           nil,
-          (1633...1635),
-          (1644...1648)
+          (2148...2150),
+          (2159...2163)
         )],
        nil,
-       (1623...1627),
-       (1649...1652)
+       (2138...2142),
+       (2164...2167)
      ),
-     CaseNode(1653...1681)(
-       CallNode(1658...1661)(
+     CaseNode(2168...2196)(
+       CallNode(2173...2176)(
          nil,
          nil,
-         IDENTIFIER(1658...1661)("foo"),
+         IDENTIFIER(2173...2176)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1663...1677)(
-          InterpolatedSymbolNode(1668...1671)(
-            SYMBOL_BEGIN(1666...1668)(":\""),
-            [StringNode(1668...1671)(
+       [InNode(2178...2192)(
+          InterpolatedSymbolNode(2183...2186)(
+            SYMBOL_BEGIN(2181...2183)(":\""),
+            [StringNode(2183...2186)(
                nil,
-               STRING_CONTENT(1668...1671)("foo"),
+               STRING_CONTENT(2183...2186)("foo"),
                nil,
                "foo"
              )],
-            STRING_END(1671...1672)("\"")
+            STRING_END(2186...2187)("\"")
           ),
           nil,
-          (1663...1665),
-          (1673...1677)
+          (2178...2180),
+          (2188...2192)
         )],
        nil,
-       (1653...1657),
-       (1678...1681)
+       (2168...2172),
+       (2193...2196)
      ),
-     CaseNode(1682...1709)(
-       CallNode(1687...1690)(
+     CaseNode(2197...2224)(
+       CallNode(2202...2205)(
          nil,
          nil,
-         IDENTIFIER(1687...1690)("foo"),
+         IDENTIFIER(2202...2205)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1692...1705)(
-          RegularExpressionNode(1695...1700)(
-            REGEXP_BEGIN(1695...1696)("/"),
-            STRING_CONTENT(1696...1699)("foo"),
-            REGEXP_END(1699...1700)("/"),
+       [InNode(2207...2220)(
+          RegularExpressionNode(2210...2215)(
+            REGEXP_BEGIN(2210...2211)("/"),
+            STRING_CONTENT(2211...2214)("foo"),
+            REGEXP_END(2214...2215)("/"),
             "foo"
           ),
           nil,
-          (1692...1694),
-          (1701...1705)
+          (2207...2209),
+          (2216...2220)
         )],
        nil,
-       (1682...1686),
-       (1706...1709)
+       (2197...2201),
+       (2221...2224)
      ),
-     CaseNode(1710...1737)(
-       CallNode(1715...1718)(
+     CaseNode(2225...2252)(
+       CallNode(2230...2233)(
          nil,
          nil,
-         IDENTIFIER(1715...1718)("foo"),
+         IDENTIFIER(2230...2233)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1720...1733)(
-          XStringNode(1723...1728)(
-            BACKTICK(1723...1724)("`"),
-            STRING_CONTENT(1724...1727)("foo"),
-            STRING_END(1727...1728)("`"),
+       [InNode(2235...2248)(
+          XStringNode(2238...2243)(
+            BACKTICK(2238...2239)("`"),
+            STRING_CONTENT(2239...2242)("foo"),
+            STRING_END(2242...2243)("`"),
             "foo"
           ),
           nil,
-          (1720...1722),
-          (1729...1733)
+          (2235...2237),
+          (2244...2248)
         )],
        nil,
-       (1710...1714),
-       (1734...1737)
+       (2225...2229),
+       (2249...2252)
      ),
-     CaseNode(1738...1767)(
-       CallNode(1743...1746)(
+     CaseNode(2253...2282)(
+       CallNode(2258...2261)(
          nil,
          nil,
-         IDENTIFIER(1743...1746)("foo"),
+         IDENTIFIER(2258...2261)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1748...1763)(
-          XStringNode(1751...1758)(
-            PERCENT_LOWER_X(1751...1754)("%x["),
-            STRING_CONTENT(1754...1757)("foo"),
-            STRING_END(1757...1758)("]"),
+       [InNode(2263...2278)(
+          XStringNode(2266...2273)(
+            PERCENT_LOWER_X(2266...2269)("%x["),
+            STRING_CONTENT(2269...2272)("foo"),
+            STRING_END(2272...2273)("]"),
             "foo"
           ),
           nil,
-          (1748...1750),
-          (1759...1763)
+          (2263...2265),
+          (2274...2278)
         )],
        nil,
-       (1738...1742),
-       (1764...1767)
+       (2253...2257),
+       (2279...2282)
      ),
-     CaseNode(1768...1797)(
-       CallNode(1773...1776)(
+     CaseNode(2283...2312)(
+       CallNode(2288...2291)(
          nil,
          nil,
-         IDENTIFIER(1773...1776)("foo"),
+         IDENTIFIER(2288...2291)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1778...1793)(
-          ArrayNode(1781...1788)(
-            [SymbolNode(1784...1787)(
+       [InNode(2293...2308)(
+          ArrayNode(2296...2303)(
+            [SymbolNode(2299...2302)(
                nil,
-               STRING_CONTENT(1784...1787)("foo"),
+               STRING_CONTENT(2299...2302)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_LOWER_I(1781...1784)("%i["),
-            STRING_END(1787...1788)("]")
+            PERCENT_LOWER_I(2296...2299)("%i["),
+            STRING_END(2302...2303)("]")
           ),
           nil,
-          (1778...1780),
-          (1789...1793)
+          (2293...2295),
+          (2304...2308)
         )],
        nil,
-       (1768...1772),
-       (1794...1797)
+       (2283...2287),
+       (2309...2312)
      ),
-     CaseNode(1798...1827)(
-       CallNode(1803...1806)(
+     CaseNode(2313...2342)(
+       CallNode(2318...2321)(
          nil,
          nil,
-         IDENTIFIER(1803...1806)("foo"),
+         IDENTIFIER(2318...2321)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1808...1823)(
-          ArrayNode(1811...1818)(
-            [SymbolNode(1814...1817)(
+       [InNode(2323...2338)(
+          ArrayNode(2326...2333)(
+            [SymbolNode(2329...2332)(
                nil,
-               STRING_CONTENT(1814...1817)("foo"),
-               nil,
-               "foo"
-             )],
-            PERCENT_UPPER_I(1811...1814)("%I["),
-            STRING_END(1817...1818)("]")
-          ),
-          nil,
-          (1808...1810),
-          (1819...1823)
-        )],
-       nil,
-       (1798...1802),
-       (1824...1827)
-     ),
-     CaseNode(1828...1857)(
-       CallNode(1833...1836)(
-         nil,
-         nil,
-         IDENTIFIER(1833...1836)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       [InNode(1838...1853)(
-          ArrayNode(1841...1848)(
-            [StringNode(1844...1847)(
-               nil,
-               STRING_CONTENT(1844...1847)("foo"),
+               STRING_CONTENT(2329...2332)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_LOWER_W(1841...1844)("%w["),
-            STRING_END(1847...1848)("]")
+            PERCENT_UPPER_I(2326...2329)("%I["),
+            STRING_END(2332...2333)("]")
           ),
           nil,
-          (1838...1840),
-          (1849...1853)
+          (2323...2325),
+          (2334...2338)
         )],
        nil,
-       (1828...1832),
-       (1854...1857)
+       (2313...2317),
+       (2339...2342)
      ),
-     CaseNode(1858...1887)(
-       CallNode(1863...1866)(
+     CaseNode(2343...2372)(
+       CallNode(2348...2351)(
          nil,
          nil,
-         IDENTIFIER(1863...1866)("foo"),
+         IDENTIFIER(2348...2351)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1868...1883)(
-          ArrayNode(1871...1878)(
-            [StringNode(1874...1877)(
+       [InNode(2353...2368)(
+          ArrayNode(2356...2363)(
+            [StringNode(2359...2362)(
                nil,
-               STRING_CONTENT(1874...1877)("foo"),
+               STRING_CONTENT(2359...2362)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_UPPER_W(1871...1874)("%W["),
-            STRING_END(1877...1878)("]")
+            PERCENT_LOWER_W(2356...2359)("%w["),
+            STRING_END(2362...2363)("]")
           ),
           nil,
-          (1868...1870),
-          (1879...1883)
+          (2353...2355),
+          (2364...2368)
         )],
        nil,
-       (1858...1862),
-       (1884...1887)
+       (2343...2347),
+       (2369...2372)
      ),
-     CaseNode(1888...1917)(
-       CallNode(1893...1896)(
+     CaseNode(2373...2402)(
+       CallNode(2378...2381)(
          nil,
          nil,
-         IDENTIFIER(1893...1896)("foo"),
+         IDENTIFIER(2378...2381)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1898...1913)(
-          StringNode(1901...1908)(
-            STRING_BEGIN(1901...1904)("%q["),
-            STRING_CONTENT(1904...1907)("foo"),
-            STRING_END(1907...1908)("]"),
+       [InNode(2383...2398)(
+          ArrayNode(2386...2393)(
+            [StringNode(2389...2392)(
+               nil,
+               STRING_CONTENT(2389...2392)("foo"),
+               nil,
+               "foo"
+             )],
+            PERCENT_UPPER_W(2386...2389)("%W["),
+            STRING_END(2392...2393)("]")
+          ),
+          nil,
+          (2383...2385),
+          (2394...2398)
+        )],
+       nil,
+       (2373...2377),
+       (2399...2402)
+     ),
+     CaseNode(2403...2432)(
+       CallNode(2408...2411)(
+         nil,
+         nil,
+         IDENTIFIER(2408...2411)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       [InNode(2413...2428)(
+          StringNode(2416...2423)(
+            STRING_BEGIN(2416...2419)("%q["),
+            STRING_CONTENT(2419...2422)("foo"),
+            STRING_END(2422...2423)("]"),
             "foo"
           ),
           nil,
-          (1898...1900),
-          (1909...1913)
+          (2413...2415),
+          (2424...2428)
         )],
        nil,
-       (1888...1892),
-       (1914...1917)
+       (2403...2407),
+       (2429...2432)
      ),
-     CaseNode(1918...1947)(
-       CallNode(1923...1926)(
+     CaseNode(2433...2462)(
+       CallNode(2438...2441)(
          nil,
          nil,
-         IDENTIFIER(1923...1926)("foo"),
+         IDENTIFIER(2438...2441)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1928...1943)(
-          StringNode(1931...1938)(
-            STRING_BEGIN(1931...1934)("%Q["),
-            STRING_CONTENT(1934...1937)("foo"),
-            STRING_END(1937...1938)("]"),
+       [InNode(2443...2458)(
+          StringNode(2446...2453)(
+            STRING_BEGIN(2446...2449)("%Q["),
+            STRING_CONTENT(2449...2452)("foo"),
+            STRING_END(2452...2453)("]"),
             "foo"
           ),
           nil,
-          (1928...1930),
-          (1939...1943)
+          (2443...2445),
+          (2454...2458)
         )],
        nil,
-       (1918...1922),
-       (1944...1947)
+       (2433...2437),
+       (2459...2462)
      ),
-     CaseNode(1948...1975)(
-       CallNode(1953...1956)(
+     CaseNode(2463...2490)(
+       CallNode(2468...2471)(
          nil,
          nil,
-         IDENTIFIER(1953...1956)("foo"),
+         IDENTIFIER(2468...2471)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1958...1971)(
-          StringNode(1961...1966)(
-            STRING_BEGIN(1961...1962)("\""),
-            STRING_CONTENT(1962...1965)("foo"),
-            STRING_END(1965...1966)("\""),
+       [InNode(2473...2486)(
+          StringNode(2476...2481)(
+            STRING_BEGIN(2476...2477)("\""),
+            STRING_CONTENT(2477...2480)("foo"),
+            STRING_END(2480...2481)("\""),
             "foo"
           ),
           nil,
-          (1958...1960),
-          (1967...1971)
+          (2473...2475),
+          (2482...2486)
         )],
        nil,
-       (1948...1952),
-       (1972...1975)
+       (2463...2467),
+       (2487...2490)
      ),
-     CaseNode(1976...2001)(
-       CallNode(1981...1984)(
+     CaseNode(2491...2516)(
+       CallNode(2496...2499)(
          nil,
          nil,
-         IDENTIFIER(1981...1984)("foo"),
+         IDENTIFIER(2496...2499)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1986...1997)(
-          NilNode(1989...1992)(),
+       [InNode(2501...2512)(
+          NilNode(2504...2507)(),
           nil,
-          (1986...1988),
-          (1993...1997)
+          (2501...2503),
+          (2508...2512)
         )],
        nil,
-       (1976...1980),
-       (1998...2001)
+       (2491...2495),
+       (2513...2516)
      ),
-     CaseNode(2002...2028)(
-       CallNode(2007...2010)(
+     CaseNode(2517...2543)(
+       CallNode(2522...2525)(
          nil,
          nil,
-         IDENTIFIER(2007...2010)("foo"),
+         IDENTIFIER(2522...2525)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2012...2024)(
-          SelfNode(2015...2019)(),
+       [InNode(2527...2539)(
+          SelfNode(2530...2534)(),
           nil,
-          (2012...2014),
-          (2020...2024)
+          (2527...2529),
+          (2535...2539)
         )],
        nil,
-       (2002...2006),
-       (2025...2028)
+       (2517...2521),
+       (2540...2543)
      ),
-     CaseNode(2029...2055)(
-       CallNode(2034...2037)(
+     CaseNode(2544...2570)(
+       CallNode(2549...2552)(
          nil,
          nil,
-         IDENTIFIER(2034...2037)("foo"),
+         IDENTIFIER(2549...2552)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2039...2051)(
-          TrueNode(2042...2046)(),
+       [InNode(2554...2566)(
+          TrueNode(2557...2561)(),
           nil,
-          (2039...2041),
-          (2047...2051)
+          (2554...2556),
+          (2562...2566)
         )],
        nil,
-       (2029...2033),
-       (2052...2055)
+       (2544...2548),
+       (2567...2570)
      ),
-     CaseNode(2056...2083)(
-       CallNode(2061...2064)(
+     CaseNode(2571...2598)(
+       CallNode(2576...2579)(
          nil,
          nil,
-         IDENTIFIER(2061...2064)("foo"),
+         IDENTIFIER(2576...2579)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2066...2079)(
-          FalseNode(2069...2074)(),
+       [InNode(2581...2594)(
+          FalseNode(2584...2589)(),
           nil,
-          (2066...2068),
-          (2075...2079)
+          (2581...2583),
+          (2590...2594)
         )],
        nil,
-       (2056...2060),
-       (2080...2083)
+       (2571...2575),
+       (2595...2598)
      ),
-     CaseNode(2084...2114)(
-       CallNode(2089...2092)(
+     CaseNode(2599...2629)(
+       CallNode(2604...2607)(
          nil,
          nil,
-         IDENTIFIER(2089...2092)("foo"),
+         IDENTIFIER(2604...2607)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2094...2110)(
-          SourceFileNode(2097...2105)(),
+       [InNode(2609...2625)(
+          SourceFileNode(2612...2620)(),
           nil,
-          (2094...2096),
-          (2106...2110)
+          (2609...2611),
+          (2621...2625)
         )],
        nil,
-       (2084...2088),
-       (2111...2114)
+       (2599...2603),
+       (2626...2629)
      ),
-     CaseNode(2115...2145)(
-       CallNode(2120...2123)(
+     CaseNode(2630...2660)(
+       CallNode(2635...2638)(
          nil,
          nil,
-         IDENTIFIER(2120...2123)("foo"),
+         IDENTIFIER(2635...2638)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2125...2141)(
-          SourceLineNode(2128...2136)(),
+       [InNode(2640...2656)(
+          SourceLineNode(2643...2651)(),
           nil,
-          (2125...2127),
-          (2137...2141)
+          (2640...2642),
+          (2652...2656)
         )],
        nil,
-       (2115...2119),
-       (2142...2145)
+       (2630...2634),
+       (2657...2660)
      ),
-     CaseNode(2146...2180)(
-       CallNode(2151...2154)(
+     CaseNode(2661...2695)(
+       CallNode(2666...2669)(
          nil,
          nil,
-         IDENTIFIER(2151...2154)("foo"),
+         IDENTIFIER(2666...2669)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2156...2176)(
-          SourceEncodingNode(2159...2171)(),
+       [InNode(2671...2691)(
+          SourceEncodingNode(2674...2686)(),
           nil,
-          (2156...2158),
-          (2172...2176)
+          (2671...2673),
+          (2687...2691)
         )],
        nil,
-       (2146...2150),
-       (2177...2180)
+       (2661...2665),
+       (2692...2695)
      ),
-     CaseNode(2181...2213)(
-       CallNode(2186...2189)(
+     CaseNode(2696...2728)(
+       CallNode(2701...2704)(
          nil,
          nil,
-         IDENTIFIER(2186...2189)("foo"),
+         IDENTIFIER(2701...2704)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2191...2209)(
-          LambdaNode(2194...2202)(
-            Scope(2194...2196)([]),
-            MINUS_GREATER(2194...2196)("->"),
+       [InNode(2706...2724)(
+          LambdaNode(2709...2717)(
+            Scope(2709...2711)([]),
+            MINUS_GREATER(2709...2711)("->"),
             nil,
             nil,
             nil,
-            StatementsNode(2199...2202)(
-              [LocalVariableReadNode(2199...2202)(
-                 IDENTIFIER(2199...2202)("bar")
+            StatementsNode(2714...2717)(
+              [LocalVariableReadNode(2714...2717)(
+                 IDENTIFIER(2714...2717)("bar")
                )]
             )
           ),
           nil,
-          (2191...2193),
-          (2205...2209)
+          (2706...2708),
+          (2720...2724)
         )],
        nil,
-       (2181...2185),
-       (2210...2213)
+       (2696...2700),
+       (2725...2728)
      ),
-     CaseNode(2215...2247)(
-       CallNode(2220...2223)(
+     CaseNode(2730...2762)(
+       CallNode(2735...2738)(
          nil,
          nil,
-         IDENTIFIER(2220...2223)("foo"),
+         IDENTIFIER(2735...2738)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2225...2243)(
-          IfNode(2228...2238)(
-            KEYWORD_IF_MODIFIER(2232...2234)("if"),
-            CallNode(2235...2238)(
-              nil,
-              nil,
-              IDENTIFIER(2235...2238)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2228...2231)(
-              [LocalVariableWriteNode(2228...2231)(
-                 IDENTIFIER(2228...2231)("bar"),
+       [InNode(2740...2758)(
+          IfNode(2743...2753)(
+            KEYWORD_IF_MODIFIER(2747...2749)("if"),
+            LocalVariableReadNode(2750...2753)(IDENTIFIER(2750...2753)("baz")),
+            StatementsNode(2743...2746)(
+              [LocalVariableWriteNode(2743...2746)(
+                 IDENTIFIER(2743...2746)("bar"),
                  nil,
                  nil
                )]
@@ -2466,185 +3271,140 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2225...2227),
-          (2239...2243)
+          (2740...2742),
+          (2754...2758)
         )],
        nil,
-       (2215...2219),
-       (2244...2247)
+       (2730...2734),
+       (2759...2762)
      ),
-     CaseNode(2248...2278)(
-       CallNode(2253...2256)(
+     CaseNode(2763...2793)(
+       CallNode(2768...2771)(
          nil,
          nil,
-         IDENTIFIER(2253...2256)("foo"),
+         IDENTIFIER(2768...2771)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2258...2274)(
-          IfNode(2261...2269)(
-            KEYWORD_IF_MODIFIER(2263...2265)("if"),
-            CallNode(2266...2269)(
-              nil,
-              nil,
-              IDENTIFIER(2266...2269)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2261...2262)([IntegerNode(2261...2262)()]),
+       [InNode(2773...2789)(
+          IfNode(2776...2784)(
+            KEYWORD_IF_MODIFIER(2778...2780)("if"),
+            LocalVariableReadNode(2781...2784)(IDENTIFIER(2781...2784)("baz")),
+            StatementsNode(2776...2777)([IntegerNode(2776...2777)()]),
             nil,
             nil
           ),
           nil,
-          (2258...2260),
-          (2270...2274)
+          (2773...2775),
+          (2785...2789)
         )],
        nil,
-       (2248...2252),
-       (2275...2278)
+       (2763...2767),
+       (2790...2793)
      ),
-     CaseNode(2279...2311)(
-       CallNode(2284...2287)(
+     CaseNode(2794...2826)(
+       CallNode(2799...2802)(
          nil,
          nil,
-         IDENTIFIER(2284...2287)("foo"),
+         IDENTIFIER(2799...2802)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2289...2307)(
-          IfNode(2292...2302)(
-            KEYWORD_IF_MODIFIER(2296...2298)("if"),
-            CallNode(2299...2302)(
-              nil,
-              nil,
-              IDENTIFIER(2299...2302)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2292...2295)([FloatNode(2292...2295)()]),
+       [InNode(2804...2822)(
+          IfNode(2807...2817)(
+            KEYWORD_IF_MODIFIER(2811...2813)("if"),
+            LocalVariableReadNode(2814...2817)(IDENTIFIER(2814...2817)("baz")),
+            StatementsNode(2807...2810)([FloatNode(2807...2810)()]),
             nil,
             nil
           ),
           nil,
-          (2289...2291),
-          (2303...2307)
+          (2804...2806),
+          (2818...2822)
         )],
        nil,
-       (2279...2283),
-       (2308...2311)
+       (2794...2798),
+       (2823...2826)
      ),
-     CaseNode(2312...2343)(
-       CallNode(2317...2320)(
+     CaseNode(2827...2858)(
+       CallNode(2832...2835)(
          nil,
          nil,
-         IDENTIFIER(2317...2320)("foo"),
+         IDENTIFIER(2832...2835)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2322...2339)(
-          IfNode(2325...2334)(
-            KEYWORD_IF_MODIFIER(2328...2330)("if"),
-            CallNode(2331...2334)(
-              nil,
-              nil,
-              IDENTIFIER(2331...2334)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2325...2327)([ImaginaryNode(2325...2327)()]),
+       [InNode(2837...2854)(
+          IfNode(2840...2849)(
+            KEYWORD_IF_MODIFIER(2843...2845)("if"),
+            LocalVariableReadNode(2846...2849)(IDENTIFIER(2846...2849)("baz")),
+            StatementsNode(2840...2842)([ImaginaryNode(2840...2842)()]),
             nil,
             nil
           ),
           nil,
-          (2322...2324),
-          (2335...2339)
+          (2837...2839),
+          (2850...2854)
         )],
        nil,
-       (2312...2316),
-       (2340...2343)
+       (2827...2831),
+       (2855...2858)
      ),
-     CaseNode(2344...2375)(
-       CallNode(2349...2352)(
+     CaseNode(2859...2890)(
+       CallNode(2864...2867)(
          nil,
          nil,
-         IDENTIFIER(2349...2352)("foo"),
+         IDENTIFIER(2864...2867)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2354...2371)(
-          IfNode(2357...2366)(
-            KEYWORD_IF_MODIFIER(2360...2362)("if"),
-            CallNode(2363...2366)(
-              nil,
-              nil,
-              IDENTIFIER(2363...2366)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2357...2359)([RationalNode(2357...2359)()]),
+       [InNode(2869...2886)(
+          IfNode(2872...2881)(
+            KEYWORD_IF_MODIFIER(2875...2877)("if"),
+            LocalVariableReadNode(2878...2881)(IDENTIFIER(2878...2881)("baz")),
+            StatementsNode(2872...2874)([RationalNode(2872...2874)()]),
             nil,
             nil
           ),
           nil,
-          (2354...2356),
-          (2367...2371)
+          (2869...2871),
+          (2882...2886)
         )],
        nil,
-       (2344...2348),
-       (2372...2375)
+       (2859...2863),
+       (2887...2890)
      ),
-     CaseNode(2376...2409)(
-       CallNode(2381...2384)(
+     CaseNode(2891...2924)(
+       CallNode(2896...2899)(
          nil,
          nil,
-         IDENTIFIER(2381...2384)("foo"),
+         IDENTIFIER(2896...2899)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2386...2405)(
-          IfNode(2389...2400)(
-            KEYWORD_IF_MODIFIER(2394...2396)("if"),
-            CallNode(2397...2400)(
-              nil,
-              nil,
-              IDENTIFIER(2397...2400)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2389...2393)(
-              [SymbolNode(2389...2393)(
-                 SYMBOL_BEGIN(2389...2390)(":"),
-                 IDENTIFIER(2390...2393)("foo"),
+       [InNode(2901...2920)(
+          IfNode(2904...2915)(
+            KEYWORD_IF_MODIFIER(2909...2911)("if"),
+            LocalVariableReadNode(2912...2915)(IDENTIFIER(2912...2915)("baz")),
+            StatementsNode(2904...2908)(
+              [SymbolNode(2904...2908)(
+                 SYMBOL_BEGIN(2904...2905)(":"),
+                 IDENTIFIER(2905...2908)("foo"),
                  nil,
                  "foo"
                )]
@@ -2653,42 +3413,33 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2386...2388),
-          (2401...2405)
+          (2901...2903),
+          (2916...2920)
         )],
        nil,
-       (2376...2380),
-       (2406...2409)
+       (2891...2895),
+       (2921...2924)
      ),
-     CaseNode(2410...2446)(
-       CallNode(2415...2418)(
+     CaseNode(2925...2961)(
+       CallNode(2930...2933)(
          nil,
          nil,
-         IDENTIFIER(2415...2418)("foo"),
+         IDENTIFIER(2930...2933)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2420...2442)(
-          IfNode(2423...2437)(
-            KEYWORD_IF_MODIFIER(2431...2433)("if"),
-            CallNode(2434...2437)(
-              nil,
-              nil,
-              IDENTIFIER(2434...2437)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2423...2430)(
-              [SymbolNode(2423...2430)(
-                 SYMBOL_BEGIN(2423...2426)("%s["),
-                 STRING_CONTENT(2426...2429)("foo"),
-                 STRING_END(2429...2430)("]"),
+       [InNode(2935...2957)(
+          IfNode(2938...2952)(
+            KEYWORD_IF_MODIFIER(2946...2948)("if"),
+            LocalVariableReadNode(2949...2952)(IDENTIFIER(2949...2952)("baz")),
+            StatementsNode(2938...2945)(
+              [SymbolNode(2938...2945)(
+                 SYMBOL_BEGIN(2938...2941)("%s["),
+                 STRING_CONTENT(2941...2944)("foo"),
+                 STRING_END(2944...2945)("]"),
                  "foo"
                )]
             ),
@@ -2696,89 +3447,71 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2420...2422),
-          (2438...2442)
+          (2935...2937),
+          (2953...2957)
         )],
        nil,
-       (2410...2414),
-       (2443...2446)
+       (2925...2929),
+       (2958...2961)
      ),
-     CaseNode(2447...2482)(
-       CallNode(2452...2455)(
+     CaseNode(2962...2997)(
+       CallNode(2967...2970)(
          nil,
          nil,
-         IDENTIFIER(2452...2455)("foo"),
+         IDENTIFIER(2967...2970)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2457...2478)(
-          IfNode(2462...2473)(
-            KEYWORD_IF_MODIFIER(2467...2469)("if"),
-            CallNode(2470...2473)(
-              nil,
-              nil,
-              IDENTIFIER(2470...2473)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2462...2465)(
-              [InterpolatedSymbolNode(2462...2465)(
-                 SYMBOL_BEGIN(2460...2462)(":\""),
-                 [StringNode(2462...2465)(
+       [InNode(2972...2993)(
+          IfNode(2977...2988)(
+            KEYWORD_IF_MODIFIER(2982...2984)("if"),
+            LocalVariableReadNode(2985...2988)(IDENTIFIER(2985...2988)("baz")),
+            StatementsNode(2977...2980)(
+              [InterpolatedSymbolNode(2977...2980)(
+                 SYMBOL_BEGIN(2975...2977)(":\""),
+                 [StringNode(2977...2980)(
                     nil,
-                    STRING_CONTENT(2462...2465)("foo"),
+                    STRING_CONTENT(2977...2980)("foo"),
                     nil,
                     "foo"
                   )],
-                 STRING_END(2465...2466)("\"")
+                 STRING_END(2980...2981)("\"")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2457...2459),
-          (2474...2478)
+          (2972...2974),
+          (2989...2993)
         )],
        nil,
-       (2447...2451),
-       (2479...2482)
+       (2962...2966),
+       (2994...2997)
      ),
-     CaseNode(2483...2517)(
-       CallNode(2488...2491)(
+     CaseNode(2998...3032)(
+       CallNode(3003...3006)(
          nil,
          nil,
-         IDENTIFIER(2488...2491)("foo"),
+         IDENTIFIER(3003...3006)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2493...2513)(
-          IfNode(2496...2508)(
-            KEYWORD_IF_MODIFIER(2502...2504)("if"),
-            CallNode(2505...2508)(
-              nil,
-              nil,
-              IDENTIFIER(2505...2508)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2496...2501)(
-              [RegularExpressionNode(2496...2501)(
-                 REGEXP_BEGIN(2496...2497)("/"),
-                 STRING_CONTENT(2497...2500)("foo"),
-                 REGEXP_END(2500...2501)("/"),
+       [InNode(3008...3028)(
+          IfNode(3011...3023)(
+            KEYWORD_IF_MODIFIER(3017...3019)("if"),
+            LocalVariableReadNode(3020...3023)(IDENTIFIER(3020...3023)("baz")),
+            StatementsNode(3011...3016)(
+              [RegularExpressionNode(3011...3016)(
+                 REGEXP_BEGIN(3011...3012)("/"),
+                 STRING_CONTENT(3012...3015)("foo"),
+                 REGEXP_END(3015...3016)("/"),
                  "foo"
                )]
             ),
@@ -2786,42 +3519,33 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2493...2495),
-          (2509...2513)
+          (3008...3010),
+          (3024...3028)
         )],
        nil,
-       (2483...2487),
-       (2514...2517)
+       (2998...3002),
+       (3029...3032)
      ),
-     CaseNode(2518...2552)(
-       CallNode(2523...2526)(
+     CaseNode(3033...3067)(
+       CallNode(3038...3041)(
          nil,
          nil,
-         IDENTIFIER(2523...2526)("foo"),
+         IDENTIFIER(3038...3041)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2528...2548)(
-          IfNode(2531...2543)(
-            KEYWORD_IF_MODIFIER(2537...2539)("if"),
-            CallNode(2540...2543)(
-              nil,
-              nil,
-              IDENTIFIER(2540...2543)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2531...2536)(
-              [XStringNode(2531...2536)(
-                 BACKTICK(2531...2532)("`"),
-                 STRING_CONTENT(2532...2535)("foo"),
-                 STRING_END(2535...2536)("`"),
+       [InNode(3043...3063)(
+          IfNode(3046...3058)(
+            KEYWORD_IF_MODIFIER(3052...3054)("if"),
+            LocalVariableReadNode(3055...3058)(IDENTIFIER(3055...3058)("baz")),
+            StatementsNode(3046...3051)(
+              [XStringNode(3046...3051)(
+                 BACKTICK(3046...3047)("`"),
+                 STRING_CONTENT(3047...3050)("foo"),
+                 STRING_END(3050...3051)("`"),
                  "foo"
                )]
             ),
@@ -2829,42 +3553,33 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2528...2530),
-          (2544...2548)
+          (3043...3045),
+          (3059...3063)
         )],
        nil,
-       (2518...2522),
-       (2549...2552)
+       (3033...3037),
+       (3064...3067)
      ),
-     CaseNode(2553...2589)(
-       CallNode(2558...2561)(
+     CaseNode(3068...3104)(
+       CallNode(3073...3076)(
          nil,
          nil,
-         IDENTIFIER(2558...2561)("foo"),
+         IDENTIFIER(3073...3076)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2563...2585)(
-          IfNode(2566...2580)(
-            KEYWORD_IF_MODIFIER(2574...2576)("if"),
-            CallNode(2577...2580)(
-              nil,
-              nil,
-              IDENTIFIER(2577...2580)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2566...2573)(
-              [XStringNode(2566...2573)(
-                 PERCENT_LOWER_X(2566...2569)("%x["),
-                 STRING_CONTENT(2569...2572)("foo"),
-                 STRING_END(2572...2573)("]"),
+       [InNode(3078...3100)(
+          IfNode(3081...3095)(
+            KEYWORD_IF_MODIFIER(3089...3091)("if"),
+            LocalVariableReadNode(3092...3095)(IDENTIFIER(3092...3095)("baz")),
+            StatementsNode(3081...3088)(
+              [XStringNode(3081...3088)(
+                 PERCENT_LOWER_X(3081...3084)("%x["),
+                 STRING_CONTENT(3084...3087)("foo"),
+                 STRING_END(3087...3088)("]"),
                  "foo"
                )]
             ),
@@ -2872,230 +3587,185 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2563...2565),
-          (2581...2585)
+          (3078...3080),
+          (3096...3100)
         )],
        nil,
-       (2553...2557),
-       (2586...2589)
+       (3068...3072),
+       (3101...3104)
      ),
-     CaseNode(2590...2626)(
-       CallNode(2595...2598)(
+     CaseNode(3105...3141)(
+       CallNode(3110...3113)(
          nil,
          nil,
-         IDENTIFIER(2595...2598)("foo"),
+         IDENTIFIER(3110...3113)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2600...2622)(
-          IfNode(2603...2617)(
-            KEYWORD_IF_MODIFIER(2611...2613)("if"),
-            CallNode(2614...2617)(
-              nil,
-              nil,
-              IDENTIFIER(2614...2617)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2603...2610)(
-              [ArrayNode(2603...2610)(
-                 [SymbolNode(2606...2609)(
+       [InNode(3115...3137)(
+          IfNode(3118...3132)(
+            KEYWORD_IF_MODIFIER(3126...3128)("if"),
+            LocalVariableReadNode(3129...3132)(IDENTIFIER(3129...3132)("baz")),
+            StatementsNode(3118...3125)(
+              [ArrayNode(3118...3125)(
+                 [SymbolNode(3121...3124)(
                     nil,
-                    STRING_CONTENT(2606...2609)("foo"),
+                    STRING_CONTENT(3121...3124)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_LOWER_I(2603...2606)("%i["),
-                 STRING_END(2609...2610)("]")
+                 PERCENT_LOWER_I(3118...3121)("%i["),
+                 STRING_END(3124...3125)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2600...2602),
-          (2618...2622)
+          (3115...3117),
+          (3133...3137)
         )],
        nil,
-       (2590...2594),
-       (2623...2626)
+       (3105...3109),
+       (3138...3141)
      ),
-     CaseNode(2627...2663)(
-       CallNode(2632...2635)(
+     CaseNode(3142...3178)(
+       CallNode(3147...3150)(
          nil,
          nil,
-         IDENTIFIER(2632...2635)("foo"),
+         IDENTIFIER(3147...3150)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2637...2659)(
-          IfNode(2640...2654)(
-            KEYWORD_IF_MODIFIER(2648...2650)("if"),
-            CallNode(2651...2654)(
-              nil,
-              nil,
-              IDENTIFIER(2651...2654)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2640...2647)(
-              [ArrayNode(2640...2647)(
-                 [SymbolNode(2643...2646)(
+       [InNode(3152...3174)(
+          IfNode(3155...3169)(
+            KEYWORD_IF_MODIFIER(3163...3165)("if"),
+            LocalVariableReadNode(3166...3169)(IDENTIFIER(3166...3169)("baz")),
+            StatementsNode(3155...3162)(
+              [ArrayNode(3155...3162)(
+                 [SymbolNode(3158...3161)(
                     nil,
-                    STRING_CONTENT(2643...2646)("foo"),
+                    STRING_CONTENT(3158...3161)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_UPPER_I(2640...2643)("%I["),
-                 STRING_END(2646...2647)("]")
+                 PERCENT_UPPER_I(3155...3158)("%I["),
+                 STRING_END(3161...3162)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2637...2639),
-          (2655...2659)
+          (3152...3154),
+          (3170...3174)
         )],
        nil,
-       (2627...2631),
-       (2660...2663)
+       (3142...3146),
+       (3175...3178)
      ),
-     CaseNode(2664...2700)(
-       CallNode(2669...2672)(
+     CaseNode(3179...3215)(
+       CallNode(3184...3187)(
          nil,
          nil,
-         IDENTIFIER(2669...2672)("foo"),
+         IDENTIFIER(3184...3187)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2674...2696)(
-          IfNode(2677...2691)(
-            KEYWORD_IF_MODIFIER(2685...2687)("if"),
-            CallNode(2688...2691)(
-              nil,
-              nil,
-              IDENTIFIER(2688...2691)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2677...2684)(
-              [ArrayNode(2677...2684)(
-                 [StringNode(2680...2683)(
+       [InNode(3189...3211)(
+          IfNode(3192...3206)(
+            KEYWORD_IF_MODIFIER(3200...3202)("if"),
+            LocalVariableReadNode(3203...3206)(IDENTIFIER(3203...3206)("baz")),
+            StatementsNode(3192...3199)(
+              [ArrayNode(3192...3199)(
+                 [StringNode(3195...3198)(
                     nil,
-                    STRING_CONTENT(2680...2683)("foo"),
+                    STRING_CONTENT(3195...3198)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_LOWER_W(2677...2680)("%w["),
-                 STRING_END(2683...2684)("]")
+                 PERCENT_LOWER_W(3192...3195)("%w["),
+                 STRING_END(3198...3199)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2674...2676),
-          (2692...2696)
+          (3189...3191),
+          (3207...3211)
         )],
        nil,
-       (2664...2668),
-       (2697...2700)
+       (3179...3183),
+       (3212...3215)
      ),
-     CaseNode(2701...2737)(
-       CallNode(2706...2709)(
+     CaseNode(3216...3252)(
+       CallNode(3221...3224)(
          nil,
          nil,
-         IDENTIFIER(2706...2709)("foo"),
+         IDENTIFIER(3221...3224)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2711...2733)(
-          IfNode(2714...2728)(
-            KEYWORD_IF_MODIFIER(2722...2724)("if"),
-            CallNode(2725...2728)(
-              nil,
-              nil,
-              IDENTIFIER(2725...2728)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2714...2721)(
-              [ArrayNode(2714...2721)(
-                 [StringNode(2717...2720)(
+       [InNode(3226...3248)(
+          IfNode(3229...3243)(
+            KEYWORD_IF_MODIFIER(3237...3239)("if"),
+            LocalVariableReadNode(3240...3243)(IDENTIFIER(3240...3243)("baz")),
+            StatementsNode(3229...3236)(
+              [ArrayNode(3229...3236)(
+                 [StringNode(3232...3235)(
                     nil,
-                    STRING_CONTENT(2717...2720)("foo"),
+                    STRING_CONTENT(3232...3235)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_UPPER_W(2714...2717)("%W["),
-                 STRING_END(2720...2721)("]")
+                 PERCENT_UPPER_W(3229...3232)("%W["),
+                 STRING_END(3235...3236)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2711...2713),
-          (2729...2733)
+          (3226...3228),
+          (3244...3248)
         )],
        nil,
-       (2701...2705),
-       (2734...2737)
+       (3216...3220),
+       (3249...3252)
      ),
-     CaseNode(2738...2774)(
-       CallNode(2743...2746)(
+     CaseNode(3253...3289)(
+       CallNode(3258...3261)(
          nil,
          nil,
-         IDENTIFIER(2743...2746)("foo"),
+         IDENTIFIER(3258...3261)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2748...2770)(
-          IfNode(2751...2765)(
-            KEYWORD_IF_MODIFIER(2759...2761)("if"),
-            CallNode(2762...2765)(
-              nil,
-              nil,
-              IDENTIFIER(2762...2765)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2751...2758)(
-              [StringNode(2751...2758)(
-                 STRING_BEGIN(2751...2754)("%q["),
-                 STRING_CONTENT(2754...2757)("foo"),
-                 STRING_END(2757...2758)("]"),
+       [InNode(3263...3285)(
+          IfNode(3266...3280)(
+            KEYWORD_IF_MODIFIER(3274...3276)("if"),
+            LocalVariableReadNode(3277...3280)(IDENTIFIER(3277...3280)("baz")),
+            StatementsNode(3266...3273)(
+              [StringNode(3266...3273)(
+                 STRING_BEGIN(3266...3269)("%q["),
+                 STRING_CONTENT(3269...3272)("foo"),
+                 STRING_END(3272...3273)("]"),
                  "foo"
                )]
             ),
@@ -3103,42 +3773,33 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2748...2750),
-          (2766...2770)
+          (3263...3265),
+          (3281...3285)
         )],
        nil,
-       (2738...2742),
-       (2771...2774)
+       (3253...3257),
+       (3286...3289)
      ),
-     CaseNode(2775...2811)(
-       CallNode(2780...2783)(
+     CaseNode(3290...3326)(
+       CallNode(3295...3298)(
          nil,
          nil,
-         IDENTIFIER(2780...2783)("foo"),
+         IDENTIFIER(3295...3298)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2785...2807)(
-          IfNode(2788...2802)(
-            KEYWORD_IF_MODIFIER(2796...2798)("if"),
-            CallNode(2799...2802)(
-              nil,
-              nil,
-              IDENTIFIER(2799...2802)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2788...2795)(
-              [StringNode(2788...2795)(
-                 STRING_BEGIN(2788...2791)("%Q["),
-                 STRING_CONTENT(2791...2794)("foo"),
-                 STRING_END(2794...2795)("]"),
+       [InNode(3300...3322)(
+          IfNode(3303...3317)(
+            KEYWORD_IF_MODIFIER(3311...3313)("if"),
+            LocalVariableReadNode(3314...3317)(IDENTIFIER(3314...3317)("baz")),
+            StatementsNode(3303...3310)(
+              [StringNode(3303...3310)(
+                 STRING_BEGIN(3303...3306)("%Q["),
+                 STRING_CONTENT(3306...3309)("foo"),
+                 STRING_END(3309...3310)("]"),
                  "foo"
                )]
             ),
@@ -3146,42 +3807,33 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2785...2787),
-          (2803...2807)
+          (3300...3302),
+          (3318...3322)
         )],
        nil,
-       (2775...2779),
-       (2808...2811)
+       (3290...3294),
+       (3323...3326)
      ),
-     CaseNode(2812...2846)(
-       CallNode(2817...2820)(
+     CaseNode(3327...3361)(
+       CallNode(3332...3335)(
          nil,
          nil,
-         IDENTIFIER(2817...2820)("foo"),
+         IDENTIFIER(3332...3335)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2822...2842)(
-          IfNode(2825...2837)(
-            KEYWORD_IF_MODIFIER(2831...2833)("if"),
-            CallNode(2834...2837)(
-              nil,
-              nil,
-              IDENTIFIER(2834...2837)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2825...2830)(
-              [StringNode(2825...2830)(
-                 STRING_BEGIN(2825...2826)("\""),
-                 STRING_CONTENT(2826...2829)("foo"),
-                 STRING_END(2829...2830)("\""),
+       [InNode(3337...3357)(
+          IfNode(3340...3352)(
+            KEYWORD_IF_MODIFIER(3346...3348)("if"),
+            LocalVariableReadNode(3349...3352)(IDENTIFIER(3349...3352)("baz")),
+            StatementsNode(3340...3345)(
+              [StringNode(3340...3345)(
+                 STRING_BEGIN(3340...3341)("\""),
+                 STRING_CONTENT(3341...3344)("foo"),
+                 STRING_END(3344...3345)("\""),
                  "foo"
                )]
             ),
@@ -3189,299 +3841,227 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (2822...2824),
-          (2838...2842)
+          (3337...3339),
+          (3353...3357)
         )],
        nil,
-       (2812...2816),
-       (2843...2846)
+       (3327...3331),
+       (3358...3361)
      ),
-     CaseNode(2847...2879)(
-       CallNode(2852...2855)(
+     CaseNode(3362...3394)(
+       CallNode(3367...3370)(
          nil,
          nil,
-         IDENTIFIER(2852...2855)("foo"),
+         IDENTIFIER(3367...3370)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2857...2875)(
-          IfNode(2860...2870)(
-            KEYWORD_IF_MODIFIER(2864...2866)("if"),
-            CallNode(2867...2870)(
-              nil,
-              nil,
-              IDENTIFIER(2867...2870)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2860...2863)([NilNode(2860...2863)()]),
+       [InNode(3372...3390)(
+          IfNode(3375...3385)(
+            KEYWORD_IF_MODIFIER(3379...3381)("if"),
+            LocalVariableReadNode(3382...3385)(IDENTIFIER(3382...3385)("baz")),
+            StatementsNode(3375...3378)([NilNode(3375...3378)()]),
             nil,
             nil
           ),
           nil,
-          (2857...2859),
-          (2871...2875)
+          (3372...3374),
+          (3386...3390)
         )],
        nil,
-       (2847...2851),
-       (2876...2879)
+       (3362...3366),
+       (3391...3394)
      ),
-     CaseNode(2880...2913)(
-       CallNode(2885...2888)(
+     CaseNode(3395...3428)(
+       CallNode(3400...3403)(
          nil,
          nil,
-         IDENTIFIER(2885...2888)("foo"),
+         IDENTIFIER(3400...3403)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2890...2909)(
-          IfNode(2893...2904)(
-            KEYWORD_IF_MODIFIER(2898...2900)("if"),
-            CallNode(2901...2904)(
-              nil,
-              nil,
-              IDENTIFIER(2901...2904)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2893...2897)([SelfNode(2893...2897)()]),
+       [InNode(3405...3424)(
+          IfNode(3408...3419)(
+            KEYWORD_IF_MODIFIER(3413...3415)("if"),
+            LocalVariableReadNode(3416...3419)(IDENTIFIER(3416...3419)("baz")),
+            StatementsNode(3408...3412)([SelfNode(3408...3412)()]),
             nil,
             nil
           ),
           nil,
-          (2890...2892),
-          (2905...2909)
+          (3405...3407),
+          (3420...3424)
         )],
        nil,
-       (2880...2884),
-       (2910...2913)
+       (3395...3399),
+       (3425...3428)
      ),
-     CaseNode(2914...2947)(
-       CallNode(2919...2922)(
+     CaseNode(3429...3462)(
+       CallNode(3434...3437)(
          nil,
          nil,
-         IDENTIFIER(2919...2922)("foo"),
+         IDENTIFIER(3434...3437)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2924...2943)(
-          IfNode(2927...2938)(
-            KEYWORD_IF_MODIFIER(2932...2934)("if"),
-            CallNode(2935...2938)(
-              nil,
-              nil,
-              IDENTIFIER(2935...2938)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2927...2931)([TrueNode(2927...2931)()]),
+       [InNode(3439...3458)(
+          IfNode(3442...3453)(
+            KEYWORD_IF_MODIFIER(3447...3449)("if"),
+            LocalVariableReadNode(3450...3453)(IDENTIFIER(3450...3453)("baz")),
+            StatementsNode(3442...3446)([TrueNode(3442...3446)()]),
             nil,
             nil
           ),
           nil,
-          (2924...2926),
-          (2939...2943)
+          (3439...3441),
+          (3454...3458)
         )],
        nil,
-       (2914...2918),
-       (2944...2947)
+       (3429...3433),
+       (3459...3462)
      ),
-     CaseNode(2948...2982)(
-       CallNode(2953...2956)(
+     CaseNode(3463...3497)(
+       CallNode(3468...3471)(
          nil,
          nil,
-         IDENTIFIER(2953...2956)("foo"),
+         IDENTIFIER(3468...3471)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2958...2978)(
-          IfNode(2961...2973)(
-            KEYWORD_IF_MODIFIER(2967...2969)("if"),
-            CallNode(2970...2973)(
-              nil,
-              nil,
-              IDENTIFIER(2970...2973)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2961...2966)([FalseNode(2961...2966)()]),
+       [InNode(3473...3493)(
+          IfNode(3476...3488)(
+            KEYWORD_IF_MODIFIER(3482...3484)("if"),
+            LocalVariableReadNode(3485...3488)(IDENTIFIER(3485...3488)("baz")),
+            StatementsNode(3476...3481)([FalseNode(3476...3481)()]),
             nil,
             nil
           ),
           nil,
-          (2958...2960),
-          (2974...2978)
+          (3473...3475),
+          (3489...3493)
         )],
        nil,
-       (2948...2952),
-       (2979...2982)
+       (3463...3467),
+       (3494...3497)
      ),
-     CaseNode(2983...3020)(
-       CallNode(2988...2991)(
+     CaseNode(3498...3535)(
+       CallNode(3503...3506)(
          nil,
          nil,
-         IDENTIFIER(2988...2991)("foo"),
+         IDENTIFIER(3503...3506)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2993...3016)(
-          IfNode(2996...3011)(
-            KEYWORD_IF_MODIFIER(3005...3007)("if"),
-            CallNode(3008...3011)(
-              nil,
-              nil,
-              IDENTIFIER(3008...3011)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2996...3004)([SourceFileNode(2996...3004)()]),
+       [InNode(3508...3531)(
+          IfNode(3511...3526)(
+            KEYWORD_IF_MODIFIER(3520...3522)("if"),
+            LocalVariableReadNode(3523...3526)(IDENTIFIER(3523...3526)("baz")),
+            StatementsNode(3511...3519)([SourceFileNode(3511...3519)()]),
             nil,
             nil
           ),
           nil,
-          (2993...2995),
-          (3012...3016)
+          (3508...3510),
+          (3527...3531)
         )],
        nil,
-       (2983...2987),
-       (3017...3020)
+       (3498...3502),
+       (3532...3535)
      ),
-     CaseNode(3021...3058)(
-       CallNode(3026...3029)(
+     CaseNode(3536...3573)(
+       CallNode(3541...3544)(
          nil,
          nil,
-         IDENTIFIER(3026...3029)("foo"),
+         IDENTIFIER(3541...3544)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(3031...3054)(
-          IfNode(3034...3049)(
-            KEYWORD_IF_MODIFIER(3043...3045)("if"),
-            CallNode(3046...3049)(
-              nil,
-              nil,
-              IDENTIFIER(3046...3049)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(3034...3042)([SourceLineNode(3034...3042)()]),
+       [InNode(3546...3569)(
+          IfNode(3549...3564)(
+            KEYWORD_IF_MODIFIER(3558...3560)("if"),
+            LocalVariableReadNode(3561...3564)(IDENTIFIER(3561...3564)("baz")),
+            StatementsNode(3549...3557)([SourceLineNode(3549...3557)()]),
             nil,
             nil
           ),
           nil,
-          (3031...3033),
-          (3050...3054)
+          (3546...3548),
+          (3565...3569)
         )],
        nil,
-       (3021...3025),
-       (3055...3058)
+       (3536...3540),
+       (3570...3573)
      ),
-     CaseNode(3059...3100)(
-       CallNode(3064...3067)(
+     CaseNode(3574...3615)(
+       CallNode(3579...3582)(
          nil,
          nil,
-         IDENTIFIER(3064...3067)("foo"),
+         IDENTIFIER(3579...3582)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(3069...3096)(
-          IfNode(3072...3091)(
-            KEYWORD_IF_MODIFIER(3085...3087)("if"),
-            CallNode(3088...3091)(
-              nil,
-              nil,
-              IDENTIFIER(3088...3091)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(3072...3084)([SourceEncodingNode(3072...3084)()]),
+       [InNode(3584...3611)(
+          IfNode(3587...3606)(
+            KEYWORD_IF_MODIFIER(3600...3602)("if"),
+            LocalVariableReadNode(3603...3606)(IDENTIFIER(3603...3606)("baz")),
+            StatementsNode(3587...3599)([SourceEncodingNode(3587...3599)()]),
             nil,
             nil
           ),
           nil,
-          (3069...3071),
-          (3092...3096)
+          (3584...3586),
+          (3607...3611)
         )],
        nil,
-       (3059...3063),
-       (3097...3100)
+       (3574...3578),
+       (3612...3615)
      ),
-     CaseNode(3101...3140)(
-       CallNode(3106...3109)(
+     CaseNode(3616...3655)(
+       CallNode(3621...3624)(
          nil,
          nil,
-         IDENTIFIER(3106...3109)("foo"),
+         IDENTIFIER(3621...3624)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(3111...3136)(
-          IfNode(3114...3131)(
-            KEYWORD_IF_MODIFIER(3125...3127)("if"),
-            CallNode(3128...3131)(
-              nil,
-              nil,
-              IDENTIFIER(3128...3131)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(3114...3122)(
-              [LambdaNode(3114...3122)(
-                 Scope(3114...3116)([]),
-                 MINUS_GREATER(3114...3116)("->"),
+       [InNode(3626...3651)(
+          IfNode(3629...3646)(
+            KEYWORD_IF_MODIFIER(3640...3642)("if"),
+            LocalVariableReadNode(3643...3646)(IDENTIFIER(3643...3646)("baz")),
+            StatementsNode(3629...3637)(
+              [LambdaNode(3629...3637)(
+                 Scope(3629...3631)([]),
+                 MINUS_GREATER(3629...3631)("->"),
                  nil,
                  nil,
                  nil,
-                 StatementsNode(3119...3122)(
-                   [LocalVariableReadNode(3119...3122)(
-                      IDENTIFIER(3119...3122)("bar")
+                 StatementsNode(3634...3637)(
+                   [LocalVariableReadNode(3634...3637)(
+                      IDENTIFIER(3634...3637)("bar")
                     )]
                  )
                )]
@@ -3490,12 +4070,12 @@ ProgramNode(0...3140)(
             nil
           ),
           nil,
-          (3111...3113),
-          (3132...3136)
+          (3626...3628),
+          (3647...3651)
         )],
        nil,
-       (3101...3105),
-       (3137...3140)
+       (3616...3620),
+       (3652...3655)
      )]
   )
 )

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...3053)(
+ProgramNode(0...3089)(
   Scope(0...0)([IDENTIFIER(7...10)("bar")]),
-  StatementsNode(0...3053)(
+  StatementsNode(0...3089)(
     [MatchRequiredNode(0...10)(
        CallNode(0...3)(
          nil,
@@ -1201,376 +1201,373 @@ ProgramNode(0...3053)(
        ),
        (1010...1012)
      ),
-     MatchPredicateNode(1028...1038)(
-       CallNode(1028...1031)(
+     MatchRequiredNode(1027...1039)(
+       CallNode(1027...1030)(
          nil,
          nil,
-         IDENTIFIER(1028...1031)("foo"),
+         IDENTIFIER(1027...1030)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       LocalVariableWriteNode(1035...1038)(
-         IDENTIFIER(1035...1038)("bar"),
+       ConstantPathNode(1034...1039)(
+         nil,
+         ConstantReadNode(1036...1039)(),
+         (1034...1036)
+       ),
+       (1031...1033)
+     ),
+     MatchRequiredNode(1040...1062)(
+       CallNode(1040...1043)(
+         nil,
+         nil,
+         IDENTIFIER(1040...1043)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ConstantPathNode(1047...1062)(
+         ConstantPathNode(1047...1057)(
+           ConstantPathNode(1047...1052)(
+             nil,
+             ConstantReadNode(1049...1052)(),
+             (1047...1049)
+           ),
+           ConstantReadNode(1054...1057)(),
+           (1052...1054)
+         ),
+         ConstantReadNode(1059...1062)(),
+         (1057...1059)
+       ),
+       (1044...1046)
+     ),
+     MatchPredicateNode(1064...1074)(
+       CallNode(1064...1067)(
+         nil,
+         nil,
+         IDENTIFIER(1064...1067)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       LocalVariableWriteNode(1071...1074)(
+         IDENTIFIER(1071...1074)("bar"),
          nil,
          nil
        ),
-       (1032...1034)
+       (1068...1070)
      ),
-     MatchPredicateNode(1039...1047)(
-       CallNode(1039...1042)(
+     MatchPredicateNode(1075...1083)(
+       CallNode(1075...1078)(
          nil,
          nil,
-         IDENTIFIER(1039...1042)("foo"),
+         IDENTIFIER(1075...1078)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       IntegerNode(1046...1047)(),
-       (1043...1045)
+       IntegerNode(1082...1083)(),
+       (1079...1081)
      ),
-     MatchPredicateNode(1048...1058)(
-       CallNode(1048...1051)(
+     MatchPredicateNode(1084...1094)(
+       CallNode(1084...1087)(
          nil,
          nil,
-         IDENTIFIER(1048...1051)("foo"),
+         IDENTIFIER(1084...1087)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       FloatNode(1055...1058)(),
-       (1052...1054)
+       FloatNode(1091...1094)(),
+       (1088...1090)
      ),
-     MatchPredicateNode(1059...1068)(
-       CallNode(1059...1062)(
+     MatchPredicateNode(1095...1104)(
+       CallNode(1095...1098)(
          nil,
          nil,
-         IDENTIFIER(1059...1062)("foo"),
+         IDENTIFIER(1095...1098)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ImaginaryNode(1066...1068)(),
-       (1063...1065)
+       ImaginaryNode(1102...1104)(),
+       (1099...1101)
      ),
-     MatchPredicateNode(1069...1078)(
-       CallNode(1069...1072)(
+     MatchPredicateNode(1105...1114)(
+       CallNode(1105...1108)(
          nil,
          nil,
-         IDENTIFIER(1069...1072)("foo"),
+         IDENTIFIER(1105...1108)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       RationalNode(1076...1078)(),
-       (1073...1075)
+       RationalNode(1112...1114)(),
+       (1109...1111)
      ),
-     MatchPredicateNode(1079...1090)(
-       CallNode(1079...1082)(
+     MatchPredicateNode(1115...1126)(
+       CallNode(1115...1118)(
          nil,
          nil,
-         IDENTIFIER(1079...1082)("foo"),
+         IDENTIFIER(1115...1118)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SymbolNode(1086...1090)(
-         SYMBOL_BEGIN(1086...1087)(":"),
-         IDENTIFIER(1087...1090)("foo"),
+       SymbolNode(1122...1126)(
+         SYMBOL_BEGIN(1122...1123)(":"),
+         IDENTIFIER(1123...1126)("foo"),
          nil,
          "foo"
        ),
-       (1083...1085)
+       (1119...1121)
      ),
-     MatchPredicateNode(1091...1105)(
-       CallNode(1091...1094)(
+     MatchPredicateNode(1127...1141)(
+       CallNode(1127...1130)(
          nil,
          nil,
-         IDENTIFIER(1091...1094)("foo"),
+         IDENTIFIER(1127...1130)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SymbolNode(1098...1105)(
-         SYMBOL_BEGIN(1098...1101)("%s["),
-         STRING_CONTENT(1101...1104)("foo"),
-         STRING_END(1104...1105)("]"),
+       SymbolNode(1134...1141)(
+         SYMBOL_BEGIN(1134...1137)("%s["),
+         STRING_CONTENT(1137...1140)("foo"),
+         STRING_END(1140...1141)("]"),
          "foo"
        ),
-       (1095...1097)
+       (1131...1133)
      ),
-     MatchPredicateNode(1106...1118)(
-       CallNode(1106...1109)(
+     MatchPredicateNode(1142...1154)(
+       CallNode(1142...1145)(
          nil,
          nil,
-         IDENTIFIER(1106...1109)("foo"),
+         IDENTIFIER(1142...1145)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       InterpolatedSymbolNode(1115...1118)(
-         SYMBOL_BEGIN(1113...1115)(":\""),
-         [StringNode(1115...1118)(
+       InterpolatedSymbolNode(1151...1154)(
+         SYMBOL_BEGIN(1149...1151)(":\""),
+         [StringNode(1151...1154)(
             nil,
-            STRING_CONTENT(1115...1118)("foo"),
-            nil,
-            "foo"
-          )],
-         STRING_END(1118...1119)("\"")
-       ),
-       (1110...1112)
-     ),
-     MatchPredicateNode(1120...1132)(
-       CallNode(1120...1123)(
-         nil,
-         nil,
-         IDENTIFIER(1120...1123)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       RegularExpressionNode(1127...1132)(
-         REGEXP_BEGIN(1127...1128)("/"),
-         STRING_CONTENT(1128...1131)("foo"),
-         REGEXP_END(1131...1132)("/"),
-         "foo"
-       ),
-       (1124...1126)
-     ),
-     MatchPredicateNode(1133...1145)(
-       CallNode(1133...1136)(
-         nil,
-         nil,
-         IDENTIFIER(1133...1136)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       XStringNode(1140...1145)(
-         BACKTICK(1140...1141)("`"),
-         STRING_CONTENT(1141...1144)("foo"),
-         STRING_END(1144...1145)("`"),
-         "foo"
-       ),
-       (1137...1139)
-     ),
-     MatchPredicateNode(1146...1160)(
-       CallNode(1146...1149)(
-         nil,
-         nil,
-         IDENTIFIER(1146...1149)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       XStringNode(1153...1160)(
-         PERCENT_LOWER_X(1153...1156)("%x["),
-         STRING_CONTENT(1156...1159)("foo"),
-         STRING_END(1159...1160)("]"),
-         "foo"
-       ),
-       (1150...1152)
-     ),
-     MatchPredicateNode(1161...1175)(
-       CallNode(1161...1164)(
-         nil,
-         nil,
-         IDENTIFIER(1161...1164)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       ArrayNode(1168...1175)(
-         [SymbolNode(1171...1174)(
-            nil,
-            STRING_CONTENT(1171...1174)("foo"),
+            STRING_CONTENT(1151...1154)("foo"),
             nil,
             "foo"
           )],
-         PERCENT_LOWER_I(1168...1171)("%i["),
-         STRING_END(1174...1175)("]")
+         STRING_END(1154...1155)("\"")
        ),
-       (1165...1167)
+       (1146...1148)
      ),
-     MatchPredicateNode(1176...1190)(
-       CallNode(1176...1179)(
+     MatchPredicateNode(1156...1168)(
+       CallNode(1156...1159)(
          nil,
          nil,
-         IDENTIFIER(1176...1179)("foo"),
+         IDENTIFIER(1156...1159)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ArrayNode(1183...1190)(
-         [SymbolNode(1186...1189)(
+       RegularExpressionNode(1163...1168)(
+         REGEXP_BEGIN(1163...1164)("/"),
+         STRING_CONTENT(1164...1167)("foo"),
+         REGEXP_END(1167...1168)("/"),
+         "foo"
+       ),
+       (1160...1162)
+     ),
+     MatchPredicateNode(1169...1181)(
+       CallNode(1169...1172)(
+         nil,
+         nil,
+         IDENTIFIER(1169...1172)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       XStringNode(1176...1181)(
+         BACKTICK(1176...1177)("`"),
+         STRING_CONTENT(1177...1180)("foo"),
+         STRING_END(1180...1181)("`"),
+         "foo"
+       ),
+       (1173...1175)
+     ),
+     MatchPredicateNode(1182...1196)(
+       CallNode(1182...1185)(
+         nil,
+         nil,
+         IDENTIFIER(1182...1185)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       XStringNode(1189...1196)(
+         PERCENT_LOWER_X(1189...1192)("%x["),
+         STRING_CONTENT(1192...1195)("foo"),
+         STRING_END(1195...1196)("]"),
+         "foo"
+       ),
+       (1186...1188)
+     ),
+     MatchPredicateNode(1197...1211)(
+       CallNode(1197...1200)(
+         nil,
+         nil,
+         IDENTIFIER(1197...1200)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       ArrayNode(1204...1211)(
+         [SymbolNode(1207...1210)(
             nil,
-            STRING_CONTENT(1186...1189)("foo"),
+            STRING_CONTENT(1207...1210)("foo"),
             nil,
             "foo"
           )],
-         PERCENT_UPPER_I(1183...1186)("%I["),
-         STRING_END(1189...1190)("]")
+         PERCENT_LOWER_I(1204...1207)("%i["),
+         STRING_END(1210...1211)("]")
        ),
-       (1180...1182)
+       (1201...1203)
      ),
-     MatchPredicateNode(1191...1205)(
-       CallNode(1191...1194)(
+     MatchPredicateNode(1212...1226)(
+       CallNode(1212...1215)(
          nil,
          nil,
-         IDENTIFIER(1191...1194)("foo"),
+         IDENTIFIER(1212...1215)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       ArrayNode(1198...1205)(
-         [StringNode(1201...1204)(
+       ArrayNode(1219...1226)(
+         [SymbolNode(1222...1225)(
             nil,
-            STRING_CONTENT(1201...1204)("foo"),
-            nil,
-            "foo"
-          )],
-         PERCENT_LOWER_W(1198...1201)("%w["),
-         STRING_END(1204...1205)("]")
-       ),
-       (1195...1197)
-     ),
-     MatchPredicateNode(1206...1220)(
-       CallNode(1206...1209)(
-         nil,
-         nil,
-         IDENTIFIER(1206...1209)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       ArrayNode(1213...1220)(
-         [StringNode(1216...1219)(
-            nil,
-            STRING_CONTENT(1216...1219)("foo"),
+            STRING_CONTENT(1222...1225)("foo"),
             nil,
             "foo"
           )],
-         PERCENT_UPPER_W(1213...1216)("%W["),
-         STRING_END(1219...1220)("]")
+         PERCENT_UPPER_I(1219...1222)("%I["),
+         STRING_END(1225...1226)("]")
        ),
-       (1210...1212)
+       (1216...1218)
      ),
-     MatchPredicateNode(1221...1235)(
-       CallNode(1221...1224)(
+     MatchPredicateNode(1227...1241)(
+       CallNode(1227...1230)(
          nil,
          nil,
-         IDENTIFIER(1221...1224)("foo"),
+         IDENTIFIER(1227...1230)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1228...1235)(
-         STRING_BEGIN(1228...1231)("%q["),
-         STRING_CONTENT(1231...1234)("foo"),
-         STRING_END(1234...1235)("]"),
-         "foo"
+       ArrayNode(1234...1241)(
+         [StringNode(1237...1240)(
+            nil,
+            STRING_CONTENT(1237...1240)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_LOWER_W(1234...1237)("%w["),
+         STRING_END(1240...1241)("]")
        ),
-       (1225...1227)
+       (1231...1233)
      ),
-     MatchPredicateNode(1236...1250)(
-       CallNode(1236...1239)(
+     MatchPredicateNode(1242...1256)(
+       CallNode(1242...1245)(
          nil,
          nil,
-         IDENTIFIER(1236...1239)("foo"),
+         IDENTIFIER(1242...1245)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1243...1250)(
-         STRING_BEGIN(1243...1246)("%Q["),
-         STRING_CONTENT(1246...1249)("foo"),
-         STRING_END(1249...1250)("]"),
-         "foo"
+       ArrayNode(1249...1256)(
+         [StringNode(1252...1255)(
+            nil,
+            STRING_CONTENT(1252...1255)("foo"),
+            nil,
+            "foo"
+          )],
+         PERCENT_UPPER_W(1249...1252)("%W["),
+         STRING_END(1255...1256)("]")
        ),
-       (1240...1242)
+       (1246...1248)
      ),
-     MatchPredicateNode(1251...1263)(
-       CallNode(1251...1254)(
+     MatchPredicateNode(1257...1271)(
+       CallNode(1257...1260)(
          nil,
          nil,
-         IDENTIFIER(1251...1254)("foo"),
+         IDENTIFIER(1257...1260)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       StringNode(1258...1263)(
-         STRING_BEGIN(1258...1259)("\""),
-         STRING_CONTENT(1259...1262)("foo"),
-         STRING_END(1262...1263)("\""),
+       StringNode(1264...1271)(
+         STRING_BEGIN(1264...1267)("%q["),
+         STRING_CONTENT(1267...1270)("foo"),
+         STRING_END(1270...1271)("]"),
          "foo"
        ),
-       (1255...1257)
+       (1261...1263)
      ),
-     MatchPredicateNode(1264...1274)(
-       CallNode(1264...1267)(
+     MatchPredicateNode(1272...1286)(
+       CallNode(1272...1275)(
          nil,
          nil,
-         IDENTIFIER(1264...1267)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       NilNode(1271...1274)(),
-       (1268...1270)
-     ),
-     MatchPredicateNode(1275...1286)(
-       CallNode(1275...1278)(
-         nil,
-         nil,
-         IDENTIFIER(1275...1278)("foo"),
+         IDENTIFIER(1272...1275)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SelfNode(1282...1286)(),
-       (1279...1281)
+       StringNode(1279...1286)(
+         STRING_BEGIN(1279...1282)("%Q["),
+         STRING_CONTENT(1282...1285)("foo"),
+         STRING_END(1285...1286)("]"),
+         "foo"
+       ),
+       (1276...1278)
      ),
-     MatchPredicateNode(1287...1298)(
+     MatchPredicateNode(1287...1299)(
        CallNode(1287...1290)(
          nil,
          nil,
@@ -1581,64 +1578,83 @@ ProgramNode(0...3053)(
          nil,
          "foo"
        ),
-       TrueNode(1294...1298)(),
+       StringNode(1294...1299)(
+         STRING_BEGIN(1294...1295)("\""),
+         STRING_CONTENT(1295...1298)("foo"),
+         STRING_END(1298...1299)("\""),
+         "foo"
+       ),
        (1291...1293)
      ),
-     MatchPredicateNode(1299...1311)(
-       CallNode(1299...1302)(
+     MatchPredicateNode(1300...1310)(
+       CallNode(1300...1303)(
          nil,
          nil,
-         IDENTIFIER(1299...1302)("foo"),
+         IDENTIFIER(1300...1303)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       FalseNode(1306...1311)(),
-       (1303...1305)
+       NilNode(1307...1310)(),
+       (1304...1306)
      ),
-     MatchPredicateNode(1312...1327)(
-       CallNode(1312...1315)(
+     MatchPredicateNode(1311...1322)(
+       CallNode(1311...1314)(
          nil,
          nil,
-         IDENTIFIER(1312...1315)("foo"),
+         IDENTIFIER(1311...1314)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceFileNode(1319...1327)(),
-       (1316...1318)
+       SelfNode(1318...1322)(),
+       (1315...1317)
      ),
-     MatchPredicateNode(1328...1343)(
-       CallNode(1328...1331)(
+     MatchPredicateNode(1323...1334)(
+       CallNode(1323...1326)(
          nil,
          nil,
-         IDENTIFIER(1328...1331)("foo"),
+         IDENTIFIER(1323...1326)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceLineNode(1335...1343)(),
-       (1332...1334)
+       TrueNode(1330...1334)(),
+       (1327...1329)
      ),
-     MatchPredicateNode(1344...1363)(
-       CallNode(1344...1347)(
+     MatchPredicateNode(1335...1347)(
+       CallNode(1335...1338)(
          nil,
          nil,
-         IDENTIFIER(1344...1347)("foo"),
+         IDENTIFIER(1335...1338)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       SourceEncodingNode(1351...1363)(),
-       (1348...1350)
+       FalseNode(1342...1347)(),
+       (1339...1341)
+     ),
+     MatchPredicateNode(1348...1363)(
+       CallNode(1348...1351)(
+         nil,
+         nil,
+         IDENTIFIER(1348...1351)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       SourceFileNode(1355...1363)(),
+       (1352...1354)
      ),
      MatchPredicateNode(1364...1379)(
        CallNode(1364...1367)(
@@ -1651,691 +1667,719 @@ ProgramNode(0...3053)(
          nil,
          "foo"
        ),
-       LambdaNode(1371...1379)(
-         Scope(1371...1373)([]),
-         MINUS_GREATER(1371...1373)("->"),
-         nil,
-         nil,
-         nil,
-         StatementsNode(1376...1379)(
-           [LocalVariableReadNode(1376...1379)(IDENTIFIER(1376...1379)("bar"))]
-         )
-       ),
+       SourceLineNode(1371...1379)(),
        (1368...1370)
      ),
-     CaseNode(1383...1408)(
-       CallNode(1388...1391)(
+     MatchPredicateNode(1380...1399)(
+       CallNode(1380...1383)(
          nil,
          nil,
-         IDENTIFIER(1388...1391)("foo"),
+         IDENTIFIER(1380...1383)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1393...1404)(
-          LocalVariableWriteNode(1396...1399)(
-            IDENTIFIER(1396...1399)("bar"),
+       SourceEncodingNode(1387...1399)(),
+       (1384...1386)
+     ),
+     MatchPredicateNode(1400...1415)(
+       CallNode(1400...1403)(
+         nil,
+         nil,
+         IDENTIFIER(1400...1403)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       LambdaNode(1407...1415)(
+         Scope(1407...1409)([]),
+         MINUS_GREATER(1407...1409)("->"),
+         nil,
+         nil,
+         nil,
+         StatementsNode(1412...1415)(
+           [LocalVariableReadNode(1412...1415)(IDENTIFIER(1412...1415)("bar"))]
+         )
+       ),
+       (1404...1406)
+     ),
+     CaseNode(1419...1444)(
+       CallNode(1424...1427)(
+         nil,
+         nil,
+         IDENTIFIER(1424...1427)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       [InNode(1429...1440)(
+          LocalVariableWriteNode(1432...1435)(
+            IDENTIFIER(1432...1435)("bar"),
             nil,
             nil
           ),
           nil,
-          (1393...1395),
-          (1400...1404)
+          (1429...1431),
+          (1436...1440)
         )],
        nil,
-       (1383...1387),
-       (1405...1408)
+       (1419...1423),
+       (1441...1444)
      ),
-     CaseNode(1409...1432)(
-       CallNode(1414...1417)(
+     CaseNode(1445...1468)(
+       CallNode(1450...1453)(
          nil,
          nil,
-         IDENTIFIER(1414...1417)("foo"),
+         IDENTIFIER(1450...1453)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1419...1428)(
-          IntegerNode(1422...1423)(),
+       [InNode(1455...1464)(
+          IntegerNode(1458...1459)(),
           nil,
-          (1419...1421),
-          (1424...1428)
+          (1455...1457),
+          (1460...1464)
         )],
        nil,
-       (1409...1413),
-       (1429...1432)
+       (1445...1449),
+       (1465...1468)
      ),
-     CaseNode(1433...1458)(
-       CallNode(1438...1441)(
+     CaseNode(1469...1494)(
+       CallNode(1474...1477)(
          nil,
          nil,
-         IDENTIFIER(1438...1441)("foo"),
+         IDENTIFIER(1474...1477)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1443...1454)(
-          FloatNode(1446...1449)(),
+       [InNode(1479...1490)(
+          FloatNode(1482...1485)(),
           nil,
-          (1443...1445),
-          (1450...1454)
+          (1479...1481),
+          (1486...1490)
         )],
        nil,
-       (1433...1437),
-       (1455...1458)
+       (1469...1473),
+       (1491...1494)
      ),
-     CaseNode(1459...1483)(
-       CallNode(1464...1467)(
+     CaseNode(1495...1519)(
+       CallNode(1500...1503)(
          nil,
          nil,
-         IDENTIFIER(1464...1467)("foo"),
+         IDENTIFIER(1500...1503)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1469...1479)(
-          ImaginaryNode(1472...1474)(),
+       [InNode(1505...1515)(
+          ImaginaryNode(1508...1510)(),
           nil,
-          (1469...1471),
-          (1475...1479)
+          (1505...1507),
+          (1511...1515)
         )],
        nil,
-       (1459...1463),
-       (1480...1483)
+       (1495...1499),
+       (1516...1519)
      ),
-     CaseNode(1484...1508)(
-       CallNode(1489...1492)(
+     CaseNode(1520...1544)(
+       CallNode(1525...1528)(
          nil,
          nil,
-         IDENTIFIER(1489...1492)("foo"),
+         IDENTIFIER(1525...1528)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1494...1504)(
-          RationalNode(1497...1499)(),
+       [InNode(1530...1540)(
+          RationalNode(1533...1535)(),
           nil,
-          (1494...1496),
-          (1500...1504)
+          (1530...1532),
+          (1536...1540)
         )],
        nil,
-       (1484...1488),
-       (1505...1508)
+       (1520...1524),
+       (1541...1544)
      ),
-     CaseNode(1509...1535)(
-       CallNode(1514...1517)(
+     CaseNode(1545...1571)(
+       CallNode(1550...1553)(
          nil,
          nil,
-         IDENTIFIER(1514...1517)("foo"),
+         IDENTIFIER(1550...1553)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1519...1531)(
-          SymbolNode(1522...1526)(
-            SYMBOL_BEGIN(1522...1523)(":"),
-            IDENTIFIER(1523...1526)("foo"),
+       [InNode(1555...1567)(
+          SymbolNode(1558...1562)(
+            SYMBOL_BEGIN(1558...1559)(":"),
+            IDENTIFIER(1559...1562)("foo"),
             nil,
             "foo"
           ),
           nil,
-          (1519...1521),
-          (1527...1531)
+          (1555...1557),
+          (1563...1567)
         )],
        nil,
-       (1509...1513),
-       (1532...1535)
+       (1545...1549),
+       (1568...1571)
      ),
-     CaseNode(1536...1565)(
-       CallNode(1541...1544)(
+     CaseNode(1572...1601)(
+       CallNode(1577...1580)(
          nil,
          nil,
-         IDENTIFIER(1541...1544)("foo"),
+         IDENTIFIER(1577...1580)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1546...1561)(
-          SymbolNode(1549...1556)(
-            SYMBOL_BEGIN(1549...1552)("%s["),
-            STRING_CONTENT(1552...1555)("foo"),
-            STRING_END(1555...1556)("]"),
+       [InNode(1582...1597)(
+          SymbolNode(1585...1592)(
+            SYMBOL_BEGIN(1585...1588)("%s["),
+            STRING_CONTENT(1588...1591)("foo"),
+            STRING_END(1591...1592)("]"),
             "foo"
           ),
           nil,
-          (1546...1548),
-          (1557...1561)
+          (1582...1584),
+          (1593...1597)
         )],
        nil,
-       (1536...1540),
-       (1562...1565)
+       (1572...1576),
+       (1598...1601)
      ),
-     CaseNode(1566...1594)(
-       CallNode(1571...1574)(
+     CaseNode(1602...1630)(
+       CallNode(1607...1610)(
          nil,
          nil,
-         IDENTIFIER(1571...1574)("foo"),
+         IDENTIFIER(1607...1610)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1576...1590)(
-          InterpolatedSymbolNode(1581...1584)(
-            SYMBOL_BEGIN(1579...1581)(":\""),
-            [StringNode(1581...1584)(
+       [InNode(1612...1626)(
+          InterpolatedSymbolNode(1617...1620)(
+            SYMBOL_BEGIN(1615...1617)(":\""),
+            [StringNode(1617...1620)(
                nil,
-               STRING_CONTENT(1581...1584)("foo"),
+               STRING_CONTENT(1617...1620)("foo"),
                nil,
                "foo"
              )],
-            STRING_END(1584...1585)("\"")
+            STRING_END(1620...1621)("\"")
           ),
           nil,
-          (1576...1578),
-          (1586...1590)
+          (1612...1614),
+          (1622...1626)
         )],
        nil,
-       (1566...1570),
-       (1591...1594)
+       (1602...1606),
+       (1627...1630)
      ),
-     CaseNode(1595...1622)(
-       CallNode(1600...1603)(
+     CaseNode(1631...1658)(
+       CallNode(1636...1639)(
          nil,
          nil,
-         IDENTIFIER(1600...1603)("foo"),
+         IDENTIFIER(1636...1639)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1605...1618)(
-          RegularExpressionNode(1608...1613)(
-            REGEXP_BEGIN(1608...1609)("/"),
-            STRING_CONTENT(1609...1612)("foo"),
-            REGEXP_END(1612...1613)("/"),
+       [InNode(1641...1654)(
+          RegularExpressionNode(1644...1649)(
+            REGEXP_BEGIN(1644...1645)("/"),
+            STRING_CONTENT(1645...1648)("foo"),
+            REGEXP_END(1648...1649)("/"),
             "foo"
           ),
           nil,
-          (1605...1607),
-          (1614...1618)
+          (1641...1643),
+          (1650...1654)
         )],
        nil,
-       (1595...1599),
-       (1619...1622)
+       (1631...1635),
+       (1655...1658)
      ),
-     CaseNode(1623...1650)(
-       CallNode(1628...1631)(
+     CaseNode(1659...1686)(
+       CallNode(1664...1667)(
          nil,
          nil,
-         IDENTIFIER(1628...1631)("foo"),
+         IDENTIFIER(1664...1667)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1633...1646)(
-          XStringNode(1636...1641)(
-            BACKTICK(1636...1637)("`"),
-            STRING_CONTENT(1637...1640)("foo"),
-            STRING_END(1640...1641)("`"),
+       [InNode(1669...1682)(
+          XStringNode(1672...1677)(
+            BACKTICK(1672...1673)("`"),
+            STRING_CONTENT(1673...1676)("foo"),
+            STRING_END(1676...1677)("`"),
             "foo"
           ),
           nil,
-          (1633...1635),
-          (1642...1646)
+          (1669...1671),
+          (1678...1682)
         )],
        nil,
-       (1623...1627),
-       (1647...1650)
+       (1659...1663),
+       (1683...1686)
      ),
-     CaseNode(1651...1680)(
-       CallNode(1656...1659)(
+     CaseNode(1687...1716)(
+       CallNode(1692...1695)(
          nil,
          nil,
-         IDENTIFIER(1656...1659)("foo"),
+         IDENTIFIER(1692...1695)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1661...1676)(
-          XStringNode(1664...1671)(
-            PERCENT_LOWER_X(1664...1667)("%x["),
-            STRING_CONTENT(1667...1670)("foo"),
-            STRING_END(1670...1671)("]"),
+       [InNode(1697...1712)(
+          XStringNode(1700...1707)(
+            PERCENT_LOWER_X(1700...1703)("%x["),
+            STRING_CONTENT(1703...1706)("foo"),
+            STRING_END(1706...1707)("]"),
             "foo"
           ),
           nil,
-          (1661...1663),
-          (1672...1676)
+          (1697...1699),
+          (1708...1712)
         )],
        nil,
-       (1651...1655),
-       (1677...1680)
+       (1687...1691),
+       (1713...1716)
      ),
-     CaseNode(1681...1710)(
-       CallNode(1686...1689)(
+     CaseNode(1717...1746)(
+       CallNode(1722...1725)(
          nil,
          nil,
-         IDENTIFIER(1686...1689)("foo"),
+         IDENTIFIER(1722...1725)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1691...1706)(
-          ArrayNode(1694...1701)(
-            [SymbolNode(1697...1700)(
+       [InNode(1727...1742)(
+          ArrayNode(1730...1737)(
+            [SymbolNode(1733...1736)(
                nil,
-               STRING_CONTENT(1697...1700)("foo"),
+               STRING_CONTENT(1733...1736)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_LOWER_I(1694...1697)("%i["),
-            STRING_END(1700...1701)("]")
+            PERCENT_LOWER_I(1730...1733)("%i["),
+            STRING_END(1736...1737)("]")
           ),
           nil,
-          (1691...1693),
-          (1702...1706)
+          (1727...1729),
+          (1738...1742)
         )],
        nil,
-       (1681...1685),
-       (1707...1710)
+       (1717...1721),
+       (1743...1746)
      ),
-     CaseNode(1711...1740)(
-       CallNode(1716...1719)(
+     CaseNode(1747...1776)(
+       CallNode(1752...1755)(
          nil,
          nil,
-         IDENTIFIER(1716...1719)("foo"),
+         IDENTIFIER(1752...1755)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1721...1736)(
-          ArrayNode(1724...1731)(
-            [SymbolNode(1727...1730)(
+       [InNode(1757...1772)(
+          ArrayNode(1760...1767)(
+            [SymbolNode(1763...1766)(
                nil,
-               STRING_CONTENT(1727...1730)("foo"),
-               nil,
-               "foo"
-             )],
-            PERCENT_UPPER_I(1724...1727)("%I["),
-            STRING_END(1730...1731)("]")
-          ),
-          nil,
-          (1721...1723),
-          (1732...1736)
-        )],
-       nil,
-       (1711...1715),
-       (1737...1740)
-     ),
-     CaseNode(1741...1770)(
-       CallNode(1746...1749)(
-         nil,
-         nil,
-         IDENTIFIER(1746...1749)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       [InNode(1751...1766)(
-          ArrayNode(1754...1761)(
-            [StringNode(1757...1760)(
-               nil,
-               STRING_CONTENT(1757...1760)("foo"),
+               STRING_CONTENT(1763...1766)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_LOWER_W(1754...1757)("%w["),
-            STRING_END(1760...1761)("]")
+            PERCENT_UPPER_I(1760...1763)("%I["),
+            STRING_END(1766...1767)("]")
           ),
           nil,
-          (1751...1753),
-          (1762...1766)
+          (1757...1759),
+          (1768...1772)
         )],
        nil,
-       (1741...1745),
-       (1767...1770)
+       (1747...1751),
+       (1773...1776)
      ),
-     CaseNode(1771...1800)(
-       CallNode(1776...1779)(
+     CaseNode(1777...1806)(
+       CallNode(1782...1785)(
          nil,
          nil,
-         IDENTIFIER(1776...1779)("foo"),
+         IDENTIFIER(1782...1785)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1781...1796)(
-          ArrayNode(1784...1791)(
-            [StringNode(1787...1790)(
+       [InNode(1787...1802)(
+          ArrayNode(1790...1797)(
+            [StringNode(1793...1796)(
                nil,
-               STRING_CONTENT(1787...1790)("foo"),
+               STRING_CONTENT(1793...1796)("foo"),
                nil,
                "foo"
              )],
-            PERCENT_UPPER_W(1784...1787)("%W["),
-            STRING_END(1790...1791)("]")
+            PERCENT_LOWER_W(1790...1793)("%w["),
+            STRING_END(1796...1797)("]")
           ),
           nil,
-          (1781...1783),
-          (1792...1796)
+          (1787...1789),
+          (1798...1802)
         )],
        nil,
-       (1771...1775),
-       (1797...1800)
+       (1777...1781),
+       (1803...1806)
      ),
-     CaseNode(1801...1830)(
-       CallNode(1806...1809)(
+     CaseNode(1807...1836)(
+       CallNode(1812...1815)(
          nil,
          nil,
-         IDENTIFIER(1806...1809)("foo"),
+         IDENTIFIER(1812...1815)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1811...1826)(
-          StringNode(1814...1821)(
-            STRING_BEGIN(1814...1817)("%q["),
-            STRING_CONTENT(1817...1820)("foo"),
-            STRING_END(1820...1821)("]"),
+       [InNode(1817...1832)(
+          ArrayNode(1820...1827)(
+            [StringNode(1823...1826)(
+               nil,
+               STRING_CONTENT(1823...1826)("foo"),
+               nil,
+               "foo"
+             )],
+            PERCENT_UPPER_W(1820...1823)("%W["),
+            STRING_END(1826...1827)("]")
+          ),
+          nil,
+          (1817...1819),
+          (1828...1832)
+        )],
+       nil,
+       (1807...1811),
+       (1833...1836)
+     ),
+     CaseNode(1837...1866)(
+       CallNode(1842...1845)(
+         nil,
+         nil,
+         IDENTIFIER(1842...1845)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       [InNode(1847...1862)(
+          StringNode(1850...1857)(
+            STRING_BEGIN(1850...1853)("%q["),
+            STRING_CONTENT(1853...1856)("foo"),
+            STRING_END(1856...1857)("]"),
             "foo"
           ),
           nil,
-          (1811...1813),
-          (1822...1826)
+          (1847...1849),
+          (1858...1862)
         )],
        nil,
-       (1801...1805),
-       (1827...1830)
+       (1837...1841),
+       (1863...1866)
      ),
-     CaseNode(1831...1860)(
-       CallNode(1836...1839)(
+     CaseNode(1867...1896)(
+       CallNode(1872...1875)(
          nil,
          nil,
-         IDENTIFIER(1836...1839)("foo"),
+         IDENTIFIER(1872...1875)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1841...1856)(
-          StringNode(1844...1851)(
-            STRING_BEGIN(1844...1847)("%Q["),
-            STRING_CONTENT(1847...1850)("foo"),
-            STRING_END(1850...1851)("]"),
+       [InNode(1877...1892)(
+          StringNode(1880...1887)(
+            STRING_BEGIN(1880...1883)("%Q["),
+            STRING_CONTENT(1883...1886)("foo"),
+            STRING_END(1886...1887)("]"),
             "foo"
           ),
           nil,
-          (1841...1843),
-          (1852...1856)
+          (1877...1879),
+          (1888...1892)
         )],
        nil,
-       (1831...1835),
-       (1857...1860)
+       (1867...1871),
+       (1893...1896)
      ),
-     CaseNode(1861...1888)(
-       CallNode(1866...1869)(
+     CaseNode(1897...1924)(
+       CallNode(1902...1905)(
          nil,
          nil,
-         IDENTIFIER(1866...1869)("foo"),
+         IDENTIFIER(1902...1905)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1871...1884)(
-          StringNode(1874...1879)(
-            STRING_BEGIN(1874...1875)("\""),
-            STRING_CONTENT(1875...1878)("foo"),
-            STRING_END(1878...1879)("\""),
+       [InNode(1907...1920)(
+          StringNode(1910...1915)(
+            STRING_BEGIN(1910...1911)("\""),
+            STRING_CONTENT(1911...1914)("foo"),
+            STRING_END(1914...1915)("\""),
             "foo"
           ),
           nil,
-          (1871...1873),
-          (1880...1884)
+          (1907...1909),
+          (1916...1920)
         )],
        nil,
-       (1861...1865),
-       (1885...1888)
+       (1897...1901),
+       (1921...1924)
      ),
-     CaseNode(1889...1914)(
-       CallNode(1894...1897)(
+     CaseNode(1925...1950)(
+       CallNode(1930...1933)(
          nil,
          nil,
-         IDENTIFIER(1894...1897)("foo"),
+         IDENTIFIER(1930...1933)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1899...1910)(
-          NilNode(1902...1905)(),
+       [InNode(1935...1946)(
+          NilNode(1938...1941)(),
           nil,
-          (1899...1901),
-          (1906...1910)
+          (1935...1937),
+          (1942...1946)
         )],
        nil,
-       (1889...1893),
-       (1911...1914)
+       (1925...1929),
+       (1947...1950)
      ),
-     CaseNode(1915...1941)(
-       CallNode(1920...1923)(
+     CaseNode(1951...1977)(
+       CallNode(1956...1959)(
          nil,
          nil,
-         IDENTIFIER(1920...1923)("foo"),
+         IDENTIFIER(1956...1959)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1925...1937)(
-          SelfNode(1928...1932)(),
+       [InNode(1961...1973)(
+          SelfNode(1964...1968)(),
           nil,
-          (1925...1927),
-          (1933...1937)
+          (1961...1963),
+          (1969...1973)
         )],
        nil,
-       (1915...1919),
-       (1938...1941)
+       (1951...1955),
+       (1974...1977)
      ),
-     CaseNode(1942...1968)(
-       CallNode(1947...1950)(
+     CaseNode(1978...2004)(
+       CallNode(1983...1986)(
          nil,
          nil,
-         IDENTIFIER(1947...1950)("foo"),
+         IDENTIFIER(1983...1986)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1952...1964)(
-          TrueNode(1955...1959)(),
+       [InNode(1988...2000)(
+          TrueNode(1991...1995)(),
           nil,
-          (1952...1954),
-          (1960...1964)
+          (1988...1990),
+          (1996...2000)
         )],
        nil,
-       (1942...1946),
-       (1965...1968)
+       (1978...1982),
+       (2001...2004)
      ),
-     CaseNode(1969...1996)(
-       CallNode(1974...1977)(
+     CaseNode(2005...2032)(
+       CallNode(2010...2013)(
          nil,
          nil,
-         IDENTIFIER(1974...1977)("foo"),
+         IDENTIFIER(2010...2013)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(1979...1992)(
-          FalseNode(1982...1987)(),
+       [InNode(2015...2028)(
+          FalseNode(2018...2023)(),
           nil,
-          (1979...1981),
-          (1988...1992)
+          (2015...2017),
+          (2024...2028)
         )],
        nil,
-       (1969...1973),
-       (1993...1996)
+       (2005...2009),
+       (2029...2032)
      ),
-     CaseNode(1997...2027)(
-       CallNode(2002...2005)(
+     CaseNode(2033...2063)(
+       CallNode(2038...2041)(
          nil,
          nil,
-         IDENTIFIER(2002...2005)("foo"),
+         IDENTIFIER(2038...2041)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2007...2023)(
-          SourceFileNode(2010...2018)(),
+       [InNode(2043...2059)(
+          SourceFileNode(2046...2054)(),
           nil,
-          (2007...2009),
-          (2019...2023)
+          (2043...2045),
+          (2055...2059)
         )],
        nil,
-       (1997...2001),
-       (2024...2027)
+       (2033...2037),
+       (2060...2063)
      ),
-     CaseNode(2028...2058)(
-       CallNode(2033...2036)(
+     CaseNode(2064...2094)(
+       CallNode(2069...2072)(
          nil,
          nil,
-         IDENTIFIER(2033...2036)("foo"),
+         IDENTIFIER(2069...2072)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2038...2054)(
-          SourceLineNode(2041...2049)(),
+       [InNode(2074...2090)(
+          SourceLineNode(2077...2085)(),
           nil,
-          (2038...2040),
-          (2050...2054)
+          (2074...2076),
+          (2086...2090)
         )],
        nil,
-       (2028...2032),
-       (2055...2058)
+       (2064...2068),
+       (2091...2094)
      ),
-     CaseNode(2059...2093)(
-       CallNode(2064...2067)(
+     CaseNode(2095...2129)(
+       CallNode(2100...2103)(
          nil,
          nil,
-         IDENTIFIER(2064...2067)("foo"),
+         IDENTIFIER(2100...2103)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2069...2089)(
-          SourceEncodingNode(2072...2084)(),
+       [InNode(2105...2125)(
+          SourceEncodingNode(2108...2120)(),
           nil,
-          (2069...2071),
-          (2085...2089)
+          (2105...2107),
+          (2121...2125)
         )],
        nil,
-       (2059...2063),
-       (2090...2093)
+       (2095...2099),
+       (2126...2129)
      ),
-     CaseNode(2094...2126)(
-       CallNode(2099...2102)(
+     CaseNode(2130...2162)(
+       CallNode(2135...2138)(
          nil,
          nil,
-         IDENTIFIER(2099...2102)("foo"),
+         IDENTIFIER(2135...2138)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2104...2122)(
-          LambdaNode(2107...2115)(
-            Scope(2107...2109)([]),
-            MINUS_GREATER(2107...2109)("->"),
+       [InNode(2140...2158)(
+          LambdaNode(2143...2151)(
+            Scope(2143...2145)([]),
+            MINUS_GREATER(2143...2145)("->"),
             nil,
             nil,
             nil,
-            StatementsNode(2112...2115)(
-              [LocalVariableReadNode(2112...2115)(
-                 IDENTIFIER(2112...2115)("bar")
+            StatementsNode(2148...2151)(
+              [LocalVariableReadNode(2148...2151)(
+                 IDENTIFIER(2148...2151)("bar")
                )]
             )
           ),
           nil,
-          (2104...2106),
-          (2118...2122)
+          (2140...2142),
+          (2154...2158)
         )],
        nil,
-       (2094...2098),
-       (2123...2126)
+       (2130...2134),
+       (2159...2162)
      ),
-     CaseNode(2128...2160)(
-       CallNode(2133...2136)(
+     CaseNode(2164...2196)(
+       CallNode(2169...2172)(
          nil,
          nil,
-         IDENTIFIER(2133...2136)("foo"),
+         IDENTIFIER(2169...2172)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2138...2156)(
-          IfNode(2141...2151)(
-            KEYWORD_IF_MODIFIER(2145...2147)("if"),
-            CallNode(2148...2151)(
+       [InNode(2174...2192)(
+          IfNode(2177...2187)(
+            KEYWORD_IF_MODIFIER(2181...2183)("if"),
+            CallNode(2184...2187)(
               nil,
               nil,
-              IDENTIFIER(2148...2151)("baz"),
+              IDENTIFIER(2184...2187)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2141...2144)(
-              [LocalVariableWriteNode(2141...2144)(
-                 IDENTIFIER(2141...2144)("bar"),
+            StatementsNode(2177...2180)(
+              [LocalVariableWriteNode(2177...2180)(
+                 IDENTIFIER(2177...2180)("bar"),
                  nil,
                  nil
                )]
@@ -2344,185 +2388,185 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (2138...2140),
-          (2152...2156)
+          (2174...2176),
+          (2188...2192)
         )],
        nil,
-       (2128...2132),
-       (2157...2160)
+       (2164...2168),
+       (2193...2196)
      ),
-     CaseNode(2161...2191)(
-       CallNode(2166...2169)(
+     CaseNode(2197...2227)(
+       CallNode(2202...2205)(
          nil,
          nil,
-         IDENTIFIER(2166...2169)("foo"),
+         IDENTIFIER(2202...2205)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2171...2187)(
-          IfNode(2174...2182)(
-            KEYWORD_IF_MODIFIER(2176...2178)("if"),
-            CallNode(2179...2182)(
+       [InNode(2207...2223)(
+          IfNode(2210...2218)(
+            KEYWORD_IF_MODIFIER(2212...2214)("if"),
+            CallNode(2215...2218)(
               nil,
               nil,
-              IDENTIFIER(2179...2182)("baz"),
+              IDENTIFIER(2215...2218)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2174...2175)([IntegerNode(2174...2175)()]),
+            StatementsNode(2210...2211)([IntegerNode(2210...2211)()]),
             nil,
             nil
           ),
           nil,
-          (2171...2173),
-          (2183...2187)
+          (2207...2209),
+          (2219...2223)
         )],
        nil,
-       (2161...2165),
-       (2188...2191)
+       (2197...2201),
+       (2224...2227)
      ),
-     CaseNode(2192...2224)(
-       CallNode(2197...2200)(
+     CaseNode(2228...2260)(
+       CallNode(2233...2236)(
          nil,
          nil,
-         IDENTIFIER(2197...2200)("foo"),
+         IDENTIFIER(2233...2236)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2202...2220)(
-          IfNode(2205...2215)(
-            KEYWORD_IF_MODIFIER(2209...2211)("if"),
-            CallNode(2212...2215)(
+       [InNode(2238...2256)(
+          IfNode(2241...2251)(
+            KEYWORD_IF_MODIFIER(2245...2247)("if"),
+            CallNode(2248...2251)(
               nil,
               nil,
-              IDENTIFIER(2212...2215)("baz"),
+              IDENTIFIER(2248...2251)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2205...2208)([FloatNode(2205...2208)()]),
+            StatementsNode(2241...2244)([FloatNode(2241...2244)()]),
             nil,
             nil
           ),
           nil,
-          (2202...2204),
-          (2216...2220)
+          (2238...2240),
+          (2252...2256)
         )],
        nil,
-       (2192...2196),
-       (2221...2224)
+       (2228...2232),
+       (2257...2260)
      ),
-     CaseNode(2225...2256)(
-       CallNode(2230...2233)(
+     CaseNode(2261...2292)(
+       CallNode(2266...2269)(
          nil,
          nil,
-         IDENTIFIER(2230...2233)("foo"),
+         IDENTIFIER(2266...2269)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2235...2252)(
-          IfNode(2238...2247)(
-            KEYWORD_IF_MODIFIER(2241...2243)("if"),
-            CallNode(2244...2247)(
+       [InNode(2271...2288)(
+          IfNode(2274...2283)(
+            KEYWORD_IF_MODIFIER(2277...2279)("if"),
+            CallNode(2280...2283)(
               nil,
               nil,
-              IDENTIFIER(2244...2247)("baz"),
+              IDENTIFIER(2280...2283)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2238...2240)([ImaginaryNode(2238...2240)()]),
+            StatementsNode(2274...2276)([ImaginaryNode(2274...2276)()]),
             nil,
             nil
           ),
           nil,
-          (2235...2237),
-          (2248...2252)
+          (2271...2273),
+          (2284...2288)
         )],
        nil,
-       (2225...2229),
-       (2253...2256)
+       (2261...2265),
+       (2289...2292)
      ),
-     CaseNode(2257...2288)(
-       CallNode(2262...2265)(
+     CaseNode(2293...2324)(
+       CallNode(2298...2301)(
          nil,
          nil,
-         IDENTIFIER(2262...2265)("foo"),
+         IDENTIFIER(2298...2301)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2267...2284)(
-          IfNode(2270...2279)(
-            KEYWORD_IF_MODIFIER(2273...2275)("if"),
-            CallNode(2276...2279)(
+       [InNode(2303...2320)(
+          IfNode(2306...2315)(
+            KEYWORD_IF_MODIFIER(2309...2311)("if"),
+            CallNode(2312...2315)(
               nil,
               nil,
-              IDENTIFIER(2276...2279)("baz"),
+              IDENTIFIER(2312...2315)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2270...2272)([RationalNode(2270...2272)()]),
+            StatementsNode(2306...2308)([RationalNode(2306...2308)()]),
             nil,
             nil
           ),
           nil,
-          (2267...2269),
-          (2280...2284)
+          (2303...2305),
+          (2316...2320)
         )],
        nil,
-       (2257...2261),
-       (2285...2288)
+       (2293...2297),
+       (2321...2324)
      ),
-     CaseNode(2289...2322)(
-       CallNode(2294...2297)(
+     CaseNode(2325...2358)(
+       CallNode(2330...2333)(
          nil,
          nil,
-         IDENTIFIER(2294...2297)("foo"),
+         IDENTIFIER(2330...2333)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2299...2318)(
-          IfNode(2302...2313)(
-            KEYWORD_IF_MODIFIER(2307...2309)("if"),
-            CallNode(2310...2313)(
+       [InNode(2335...2354)(
+          IfNode(2338...2349)(
+            KEYWORD_IF_MODIFIER(2343...2345)("if"),
+            CallNode(2346...2349)(
               nil,
               nil,
-              IDENTIFIER(2310...2313)("baz"),
+              IDENTIFIER(2346...2349)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2302...2306)(
-              [SymbolNode(2302...2306)(
-                 SYMBOL_BEGIN(2302...2303)(":"),
-                 IDENTIFIER(2303...2306)("foo"),
+            StatementsNode(2338...2342)(
+              [SymbolNode(2338...2342)(
+                 SYMBOL_BEGIN(2338...2339)(":"),
+                 IDENTIFIER(2339...2342)("foo"),
                  nil,
                  "foo"
                )]
@@ -2531,69 +2575,26 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (2299...2301),
-          (2314...2318)
+          (2335...2337),
+          (2350...2354)
         )],
        nil,
-       (2289...2293),
-       (2319...2322)
+       (2325...2329),
+       (2355...2358)
      ),
-     CaseNode(2323...2359)(
-       CallNode(2328...2331)(
+     CaseNode(2359...2395)(
+       CallNode(2364...2367)(
          nil,
          nil,
-         IDENTIFIER(2328...2331)("foo"),
+         IDENTIFIER(2364...2367)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2333...2355)(
-          IfNode(2336...2350)(
-            KEYWORD_IF_MODIFIER(2344...2346)("if"),
-            CallNode(2347...2350)(
-              nil,
-              nil,
-              IDENTIFIER(2347...2350)("baz"),
-              nil,
-              nil,
-              nil,
-              nil,
-              "baz"
-            ),
-            StatementsNode(2336...2343)(
-              [SymbolNode(2336...2343)(
-                 SYMBOL_BEGIN(2336...2339)("%s["),
-                 STRING_CONTENT(2339...2342)("foo"),
-                 STRING_END(2342...2343)("]"),
-                 "foo"
-               )]
-            ),
-            nil,
-            nil
-          ),
-          nil,
-          (2333...2335),
-          (2351...2355)
-        )],
-       nil,
-       (2323...2327),
-       (2356...2359)
-     ),
-     CaseNode(2360...2395)(
-       CallNode(2365...2368)(
-         nil,
-         nil,
-         IDENTIFIER(2365...2368)("foo"),
-         nil,
-         nil,
-         nil,
-         nil,
-         "foo"
-       ),
-       [InNode(2370...2391)(
-          IfNode(2375...2386)(
+       [InNode(2369...2391)(
+          IfNode(2372...2386)(
             KEYWORD_IF_MODIFIER(2380...2382)("if"),
             CallNode(2383...2386)(
               nil,
@@ -2605,30 +2606,26 @@ ProgramNode(0...3053)(
               nil,
               "baz"
             ),
-            StatementsNode(2375...2378)(
-              [InterpolatedSymbolNode(2375...2378)(
-                 SYMBOL_BEGIN(2373...2375)(":\""),
-                 [StringNode(2375...2378)(
-                    nil,
-                    STRING_CONTENT(2375...2378)("foo"),
-                    nil,
-                    "foo"
-                  )],
-                 STRING_END(2378...2379)("\"")
+            StatementsNode(2372...2379)(
+              [SymbolNode(2372...2379)(
+                 SYMBOL_BEGIN(2372...2375)("%s["),
+                 STRING_CONTENT(2375...2378)("foo"),
+                 STRING_END(2378...2379)("]"),
+                 "foo"
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2370...2372),
+          (2369...2371),
           (2387...2391)
         )],
        nil,
-       (2360...2364),
+       (2359...2363),
        (2392...2395)
      ),
-     CaseNode(2396...2430)(
+     CaseNode(2396...2431)(
        CallNode(2401...2404)(
          nil,
          nil,
@@ -2639,25 +2636,29 @@ ProgramNode(0...3053)(
          nil,
          "foo"
        ),
-       [InNode(2406...2426)(
-          IfNode(2409...2421)(
-            KEYWORD_IF_MODIFIER(2415...2417)("if"),
-            CallNode(2418...2421)(
+       [InNode(2406...2427)(
+          IfNode(2411...2422)(
+            KEYWORD_IF_MODIFIER(2416...2418)("if"),
+            CallNode(2419...2422)(
               nil,
               nil,
-              IDENTIFIER(2418...2421)("baz"),
+              IDENTIFIER(2419...2422)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2409...2414)(
-              [RegularExpressionNode(2409...2414)(
-                 REGEXP_BEGIN(2409...2410)("/"),
-                 STRING_CONTENT(2410...2413)("foo"),
-                 REGEXP_END(2413...2414)("/"),
-                 "foo"
+            StatementsNode(2411...2414)(
+              [InterpolatedSymbolNode(2411...2414)(
+                 SYMBOL_BEGIN(2409...2411)(":\""),
+                 [StringNode(2411...2414)(
+                    nil,
+                    STRING_CONTENT(2411...2414)("foo"),
+                    nil,
+                    "foo"
+                  )],
+                 STRING_END(2414...2415)("\"")
                )]
             ),
             nil,
@@ -2665,41 +2666,41 @@ ProgramNode(0...3053)(
           ),
           nil,
           (2406...2408),
-          (2422...2426)
+          (2423...2427)
         )],
        nil,
        (2396...2400),
-       (2427...2430)
+       (2428...2431)
      ),
-     CaseNode(2431...2465)(
-       CallNode(2436...2439)(
+     CaseNode(2432...2466)(
+       CallNode(2437...2440)(
          nil,
          nil,
-         IDENTIFIER(2436...2439)("foo"),
+         IDENTIFIER(2437...2440)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2441...2461)(
-          IfNode(2444...2456)(
-            KEYWORD_IF_MODIFIER(2450...2452)("if"),
-            CallNode(2453...2456)(
+       [InNode(2442...2462)(
+          IfNode(2445...2457)(
+            KEYWORD_IF_MODIFIER(2451...2453)("if"),
+            CallNode(2454...2457)(
               nil,
               nil,
-              IDENTIFIER(2453...2456)("baz"),
+              IDENTIFIER(2454...2457)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2444...2449)(
-              [XStringNode(2444...2449)(
-                 BACKTICK(2444...2445)("`"),
-                 STRING_CONTENT(2445...2448)("foo"),
-                 STRING_END(2448...2449)("`"),
+            StatementsNode(2445...2450)(
+              [RegularExpressionNode(2445...2450)(
+                 REGEXP_BEGIN(2445...2446)("/"),
+                 STRING_CONTENT(2446...2449)("foo"),
+                 REGEXP_END(2449...2450)("/"),
                  "foo"
                )]
             ),
@@ -2707,42 +2708,42 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (2441...2443),
-          (2457...2461)
+          (2442...2444),
+          (2458...2462)
         )],
        nil,
-       (2431...2435),
-       (2462...2465)
+       (2432...2436),
+       (2463...2466)
      ),
-     CaseNode(2466...2502)(
-       CallNode(2471...2474)(
+     CaseNode(2467...2501)(
+       CallNode(2472...2475)(
          nil,
          nil,
-         IDENTIFIER(2471...2474)("foo"),
+         IDENTIFIER(2472...2475)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2476...2498)(
-          IfNode(2479...2493)(
-            KEYWORD_IF_MODIFIER(2487...2489)("if"),
-            CallNode(2490...2493)(
+       [InNode(2477...2497)(
+          IfNode(2480...2492)(
+            KEYWORD_IF_MODIFIER(2486...2488)("if"),
+            CallNode(2489...2492)(
               nil,
               nil,
-              IDENTIFIER(2490...2493)("baz"),
+              IDENTIFIER(2489...2492)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2479...2486)(
-              [XStringNode(2479...2486)(
-                 PERCENT_LOWER_X(2479...2482)("%x["),
-                 STRING_CONTENT(2482...2485)("foo"),
-                 STRING_END(2485...2486)("]"),
+            StatementsNode(2480...2485)(
+              [XStringNode(2480...2485)(
+                 BACKTICK(2480...2481)("`"),
+                 STRING_CONTENT(2481...2484)("foo"),
+                 STRING_END(2484...2485)("`"),
                  "foo"
                )]
             ),
@@ -2750,230 +2751,273 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (2476...2478),
-          (2494...2498)
+          (2477...2479),
+          (2493...2497)
         )],
        nil,
-       (2466...2470),
-       (2499...2502)
+       (2467...2471),
+       (2498...2501)
      ),
-     CaseNode(2503...2539)(
-       CallNode(2508...2511)(
+     CaseNode(2502...2538)(
+       CallNode(2507...2510)(
          nil,
          nil,
-         IDENTIFIER(2508...2511)("foo"),
+         IDENTIFIER(2507...2510)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2513...2535)(
-          IfNode(2516...2530)(
-            KEYWORD_IF_MODIFIER(2524...2526)("if"),
-            CallNode(2527...2530)(
+       [InNode(2512...2534)(
+          IfNode(2515...2529)(
+            KEYWORD_IF_MODIFIER(2523...2525)("if"),
+            CallNode(2526...2529)(
               nil,
               nil,
-              IDENTIFIER(2527...2530)("baz"),
+              IDENTIFIER(2526...2529)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2516...2523)(
-              [ArrayNode(2516...2523)(
-                 [SymbolNode(2519...2522)(
+            StatementsNode(2515...2522)(
+              [XStringNode(2515...2522)(
+                 PERCENT_LOWER_X(2515...2518)("%x["),
+                 STRING_CONTENT(2518...2521)("foo"),
+                 STRING_END(2521...2522)("]"),
+                 "foo"
+               )]
+            ),
+            nil,
+            nil
+          ),
+          nil,
+          (2512...2514),
+          (2530...2534)
+        )],
+       nil,
+       (2502...2506),
+       (2535...2538)
+     ),
+     CaseNode(2539...2575)(
+       CallNode(2544...2547)(
+         nil,
+         nil,
+         IDENTIFIER(2544...2547)("foo"),
+         nil,
+         nil,
+         nil,
+         nil,
+         "foo"
+       ),
+       [InNode(2549...2571)(
+          IfNode(2552...2566)(
+            KEYWORD_IF_MODIFIER(2560...2562)("if"),
+            CallNode(2563...2566)(
+              nil,
+              nil,
+              IDENTIFIER(2563...2566)("baz"),
+              nil,
+              nil,
+              nil,
+              nil,
+              "baz"
+            ),
+            StatementsNode(2552...2559)(
+              [ArrayNode(2552...2559)(
+                 [SymbolNode(2555...2558)(
                     nil,
-                    STRING_CONTENT(2519...2522)("foo"),
+                    STRING_CONTENT(2555...2558)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_LOWER_I(2516...2519)("%i["),
-                 STRING_END(2522...2523)("]")
+                 PERCENT_LOWER_I(2552...2555)("%i["),
+                 STRING_END(2558...2559)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2513...2515),
-          (2531...2535)
+          (2549...2551),
+          (2567...2571)
         )],
        nil,
-       (2503...2507),
-       (2536...2539)
+       (2539...2543),
+       (2572...2575)
      ),
-     CaseNode(2540...2576)(
-       CallNode(2545...2548)(
+     CaseNode(2576...2612)(
+       CallNode(2581...2584)(
          nil,
          nil,
-         IDENTIFIER(2545...2548)("foo"),
+         IDENTIFIER(2581...2584)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2550...2572)(
-          IfNode(2553...2567)(
-            KEYWORD_IF_MODIFIER(2561...2563)("if"),
-            CallNode(2564...2567)(
+       [InNode(2586...2608)(
+          IfNode(2589...2603)(
+            KEYWORD_IF_MODIFIER(2597...2599)("if"),
+            CallNode(2600...2603)(
               nil,
               nil,
-              IDENTIFIER(2564...2567)("baz"),
+              IDENTIFIER(2600...2603)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2553...2560)(
-              [ArrayNode(2553...2560)(
-                 [SymbolNode(2556...2559)(
+            StatementsNode(2589...2596)(
+              [ArrayNode(2589...2596)(
+                 [SymbolNode(2592...2595)(
                     nil,
-                    STRING_CONTENT(2556...2559)("foo"),
+                    STRING_CONTENT(2592...2595)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_UPPER_I(2553...2556)("%I["),
-                 STRING_END(2559...2560)("]")
+                 PERCENT_UPPER_I(2589...2592)("%I["),
+                 STRING_END(2595...2596)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2550...2552),
-          (2568...2572)
+          (2586...2588),
+          (2604...2608)
         )],
        nil,
-       (2540...2544),
-       (2573...2576)
+       (2576...2580),
+       (2609...2612)
      ),
-     CaseNode(2577...2613)(
-       CallNode(2582...2585)(
+     CaseNode(2613...2649)(
+       CallNode(2618...2621)(
          nil,
          nil,
-         IDENTIFIER(2582...2585)("foo"),
+         IDENTIFIER(2618...2621)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2587...2609)(
-          IfNode(2590...2604)(
-            KEYWORD_IF_MODIFIER(2598...2600)("if"),
-            CallNode(2601...2604)(
+       [InNode(2623...2645)(
+          IfNode(2626...2640)(
+            KEYWORD_IF_MODIFIER(2634...2636)("if"),
+            CallNode(2637...2640)(
               nil,
               nil,
-              IDENTIFIER(2601...2604)("baz"),
+              IDENTIFIER(2637...2640)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2590...2597)(
-              [ArrayNode(2590...2597)(
-                 [StringNode(2593...2596)(
+            StatementsNode(2626...2633)(
+              [ArrayNode(2626...2633)(
+                 [StringNode(2629...2632)(
                     nil,
-                    STRING_CONTENT(2593...2596)("foo"),
+                    STRING_CONTENT(2629...2632)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_LOWER_W(2590...2593)("%w["),
-                 STRING_END(2596...2597)("]")
+                 PERCENT_LOWER_W(2626...2629)("%w["),
+                 STRING_END(2632...2633)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2587...2589),
-          (2605...2609)
+          (2623...2625),
+          (2641...2645)
         )],
        nil,
-       (2577...2581),
-       (2610...2613)
+       (2613...2617),
+       (2646...2649)
      ),
-     CaseNode(2614...2650)(
-       CallNode(2619...2622)(
+     CaseNode(2650...2686)(
+       CallNode(2655...2658)(
          nil,
          nil,
-         IDENTIFIER(2619...2622)("foo"),
+         IDENTIFIER(2655...2658)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2624...2646)(
-          IfNode(2627...2641)(
-            KEYWORD_IF_MODIFIER(2635...2637)("if"),
-            CallNode(2638...2641)(
+       [InNode(2660...2682)(
+          IfNode(2663...2677)(
+            KEYWORD_IF_MODIFIER(2671...2673)("if"),
+            CallNode(2674...2677)(
               nil,
               nil,
-              IDENTIFIER(2638...2641)("baz"),
+              IDENTIFIER(2674...2677)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2627...2634)(
-              [ArrayNode(2627...2634)(
-                 [StringNode(2630...2633)(
+            StatementsNode(2663...2670)(
+              [ArrayNode(2663...2670)(
+                 [StringNode(2666...2669)(
                     nil,
-                    STRING_CONTENT(2630...2633)("foo"),
+                    STRING_CONTENT(2666...2669)("foo"),
                     nil,
                     "foo"
                   )],
-                 PERCENT_UPPER_W(2627...2630)("%W["),
-                 STRING_END(2633...2634)("]")
+                 PERCENT_UPPER_W(2663...2666)("%W["),
+                 STRING_END(2669...2670)("]")
                )]
             ),
             nil,
             nil
           ),
           nil,
-          (2624...2626),
-          (2642...2646)
+          (2660...2662),
+          (2678...2682)
         )],
        nil,
-       (2614...2618),
-       (2647...2650)
+       (2650...2654),
+       (2683...2686)
      ),
-     CaseNode(2651...2687)(
-       CallNode(2656...2659)(
+     CaseNode(2687...2723)(
+       CallNode(2692...2695)(
          nil,
          nil,
-         IDENTIFIER(2656...2659)("foo"),
+         IDENTIFIER(2692...2695)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2661...2683)(
-          IfNode(2664...2678)(
-            KEYWORD_IF_MODIFIER(2672...2674)("if"),
-            CallNode(2675...2678)(
+       [InNode(2697...2719)(
+          IfNode(2700...2714)(
+            KEYWORD_IF_MODIFIER(2708...2710)("if"),
+            CallNode(2711...2714)(
               nil,
               nil,
-              IDENTIFIER(2675...2678)("baz"),
+              IDENTIFIER(2711...2714)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2664...2671)(
-              [StringNode(2664...2671)(
-                 STRING_BEGIN(2664...2667)("%q["),
-                 STRING_CONTENT(2667...2670)("foo"),
-                 STRING_END(2670...2671)("]"),
+            StatementsNode(2700...2707)(
+              [StringNode(2700...2707)(
+                 STRING_BEGIN(2700...2703)("%q["),
+                 STRING_CONTENT(2703...2706)("foo"),
+                 STRING_END(2706...2707)("]"),
                  "foo"
                )]
             ),
@@ -2981,42 +3025,42 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (2661...2663),
-          (2679...2683)
+          (2697...2699),
+          (2715...2719)
         )],
        nil,
-       (2651...2655),
-       (2684...2687)
+       (2687...2691),
+       (2720...2723)
      ),
-     CaseNode(2688...2724)(
-       CallNode(2693...2696)(
+     CaseNode(2724...2760)(
+       CallNode(2729...2732)(
          nil,
          nil,
-         IDENTIFIER(2693...2696)("foo"),
+         IDENTIFIER(2729...2732)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2698...2720)(
-          IfNode(2701...2715)(
-            KEYWORD_IF_MODIFIER(2709...2711)("if"),
-            CallNode(2712...2715)(
+       [InNode(2734...2756)(
+          IfNode(2737...2751)(
+            KEYWORD_IF_MODIFIER(2745...2747)("if"),
+            CallNode(2748...2751)(
               nil,
               nil,
-              IDENTIFIER(2712...2715)("baz"),
+              IDENTIFIER(2748...2751)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2701...2708)(
-              [StringNode(2701...2708)(
-                 STRING_BEGIN(2701...2704)("%Q["),
-                 STRING_CONTENT(2704...2707)("foo"),
-                 STRING_END(2707...2708)("]"),
+            StatementsNode(2737...2744)(
+              [StringNode(2737...2744)(
+                 STRING_BEGIN(2737...2740)("%Q["),
+                 STRING_CONTENT(2740...2743)("foo"),
+                 STRING_END(2743...2744)("]"),
                  "foo"
                )]
             ),
@@ -3024,42 +3068,42 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (2698...2700),
-          (2716...2720)
+          (2734...2736),
+          (2752...2756)
         )],
        nil,
-       (2688...2692),
-       (2721...2724)
+       (2724...2728),
+       (2757...2760)
      ),
-     CaseNode(2725...2759)(
-       CallNode(2730...2733)(
+     CaseNode(2761...2795)(
+       CallNode(2766...2769)(
          nil,
          nil,
-         IDENTIFIER(2730...2733)("foo"),
+         IDENTIFIER(2766...2769)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2735...2755)(
-          IfNode(2738...2750)(
-            KEYWORD_IF_MODIFIER(2744...2746)("if"),
-            CallNode(2747...2750)(
+       [InNode(2771...2791)(
+          IfNode(2774...2786)(
+            KEYWORD_IF_MODIFIER(2780...2782)("if"),
+            CallNode(2783...2786)(
               nil,
               nil,
-              IDENTIFIER(2747...2750)("baz"),
+              IDENTIFIER(2783...2786)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2738...2743)(
-              [StringNode(2738...2743)(
-                 STRING_BEGIN(2738...2739)("\""),
-                 STRING_CONTENT(2739...2742)("foo"),
-                 STRING_END(2742...2743)("\""),
+            StatementsNode(2774...2779)(
+              [StringNode(2774...2779)(
+                 STRING_BEGIN(2774...2775)("\""),
+                 STRING_CONTENT(2775...2778)("foo"),
+                 STRING_END(2778...2779)("\""),
                  "foo"
                )]
             ),
@@ -3067,299 +3111,299 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (2735...2737),
-          (2751...2755)
+          (2771...2773),
+          (2787...2791)
         )],
        nil,
-       (2725...2729),
-       (2756...2759)
+       (2761...2765),
+       (2792...2795)
      ),
-     CaseNode(2760...2792)(
-       CallNode(2765...2768)(
+     CaseNode(2796...2828)(
+       CallNode(2801...2804)(
          nil,
          nil,
-         IDENTIFIER(2765...2768)("foo"),
+         IDENTIFIER(2801...2804)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2770...2788)(
-          IfNode(2773...2783)(
-            KEYWORD_IF_MODIFIER(2777...2779)("if"),
-            CallNode(2780...2783)(
+       [InNode(2806...2824)(
+          IfNode(2809...2819)(
+            KEYWORD_IF_MODIFIER(2813...2815)("if"),
+            CallNode(2816...2819)(
               nil,
               nil,
-              IDENTIFIER(2780...2783)("baz"),
+              IDENTIFIER(2816...2819)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2773...2776)([NilNode(2773...2776)()]),
+            StatementsNode(2809...2812)([NilNode(2809...2812)()]),
             nil,
             nil
           ),
           nil,
-          (2770...2772),
-          (2784...2788)
+          (2806...2808),
+          (2820...2824)
         )],
        nil,
-       (2760...2764),
-       (2789...2792)
+       (2796...2800),
+       (2825...2828)
      ),
-     CaseNode(2793...2826)(
-       CallNode(2798...2801)(
+     CaseNode(2829...2862)(
+       CallNode(2834...2837)(
          nil,
          nil,
-         IDENTIFIER(2798...2801)("foo"),
+         IDENTIFIER(2834...2837)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2803...2822)(
-          IfNode(2806...2817)(
-            KEYWORD_IF_MODIFIER(2811...2813)("if"),
-            CallNode(2814...2817)(
+       [InNode(2839...2858)(
+          IfNode(2842...2853)(
+            KEYWORD_IF_MODIFIER(2847...2849)("if"),
+            CallNode(2850...2853)(
               nil,
               nil,
-              IDENTIFIER(2814...2817)("baz"),
+              IDENTIFIER(2850...2853)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2806...2810)([SelfNode(2806...2810)()]),
+            StatementsNode(2842...2846)([SelfNode(2842...2846)()]),
             nil,
             nil
           ),
           nil,
-          (2803...2805),
-          (2818...2822)
+          (2839...2841),
+          (2854...2858)
         )],
        nil,
-       (2793...2797),
-       (2823...2826)
+       (2829...2833),
+       (2859...2862)
      ),
-     CaseNode(2827...2860)(
-       CallNode(2832...2835)(
+     CaseNode(2863...2896)(
+       CallNode(2868...2871)(
          nil,
          nil,
-         IDENTIFIER(2832...2835)("foo"),
+         IDENTIFIER(2868...2871)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2837...2856)(
-          IfNode(2840...2851)(
-            KEYWORD_IF_MODIFIER(2845...2847)("if"),
-            CallNode(2848...2851)(
+       [InNode(2873...2892)(
+          IfNode(2876...2887)(
+            KEYWORD_IF_MODIFIER(2881...2883)("if"),
+            CallNode(2884...2887)(
               nil,
               nil,
-              IDENTIFIER(2848...2851)("baz"),
+              IDENTIFIER(2884...2887)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2840...2844)([TrueNode(2840...2844)()]),
+            StatementsNode(2876...2880)([TrueNode(2876...2880)()]),
             nil,
             nil
           ),
           nil,
-          (2837...2839),
-          (2852...2856)
+          (2873...2875),
+          (2888...2892)
         )],
        nil,
-       (2827...2831),
-       (2857...2860)
+       (2863...2867),
+       (2893...2896)
      ),
-     CaseNode(2861...2895)(
-       CallNode(2866...2869)(
+     CaseNode(2897...2931)(
+       CallNode(2902...2905)(
          nil,
          nil,
-         IDENTIFIER(2866...2869)("foo"),
+         IDENTIFIER(2902...2905)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2871...2891)(
-          IfNode(2874...2886)(
-            KEYWORD_IF_MODIFIER(2880...2882)("if"),
-            CallNode(2883...2886)(
+       [InNode(2907...2927)(
+          IfNode(2910...2922)(
+            KEYWORD_IF_MODIFIER(2916...2918)("if"),
+            CallNode(2919...2922)(
               nil,
               nil,
-              IDENTIFIER(2883...2886)("baz"),
+              IDENTIFIER(2919...2922)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2874...2879)([FalseNode(2874...2879)()]),
+            StatementsNode(2910...2915)([FalseNode(2910...2915)()]),
             nil,
             nil
           ),
           nil,
-          (2871...2873),
-          (2887...2891)
+          (2907...2909),
+          (2923...2927)
         )],
        nil,
-       (2861...2865),
-       (2892...2895)
+       (2897...2901),
+       (2928...2931)
      ),
-     CaseNode(2896...2933)(
-       CallNode(2901...2904)(
+     CaseNode(2932...2969)(
+       CallNode(2937...2940)(
          nil,
          nil,
-         IDENTIFIER(2901...2904)("foo"),
+         IDENTIFIER(2937...2940)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2906...2929)(
-          IfNode(2909...2924)(
-            KEYWORD_IF_MODIFIER(2918...2920)("if"),
-            CallNode(2921...2924)(
+       [InNode(2942...2965)(
+          IfNode(2945...2960)(
+            KEYWORD_IF_MODIFIER(2954...2956)("if"),
+            CallNode(2957...2960)(
               nil,
               nil,
-              IDENTIFIER(2921...2924)("baz"),
+              IDENTIFIER(2957...2960)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2909...2917)([SourceFileNode(2909...2917)()]),
+            StatementsNode(2945...2953)([SourceFileNode(2945...2953)()]),
             nil,
             nil
           ),
           nil,
-          (2906...2908),
-          (2925...2929)
+          (2942...2944),
+          (2961...2965)
         )],
        nil,
-       (2896...2900),
-       (2930...2933)
+       (2932...2936),
+       (2966...2969)
      ),
-     CaseNode(2934...2971)(
-       CallNode(2939...2942)(
+     CaseNode(2970...3007)(
+       CallNode(2975...2978)(
          nil,
          nil,
-         IDENTIFIER(2939...2942)("foo"),
+         IDENTIFIER(2975...2978)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2944...2967)(
-          IfNode(2947...2962)(
-            KEYWORD_IF_MODIFIER(2956...2958)("if"),
-            CallNode(2959...2962)(
+       [InNode(2980...3003)(
+          IfNode(2983...2998)(
+            KEYWORD_IF_MODIFIER(2992...2994)("if"),
+            CallNode(2995...2998)(
               nil,
               nil,
-              IDENTIFIER(2959...2962)("baz"),
+              IDENTIFIER(2995...2998)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2947...2955)([SourceLineNode(2947...2955)()]),
+            StatementsNode(2983...2991)([SourceLineNode(2983...2991)()]),
             nil,
             nil
           ),
           nil,
-          (2944...2946),
-          (2963...2967)
+          (2980...2982),
+          (2999...3003)
         )],
        nil,
-       (2934...2938),
-       (2968...2971)
+       (2970...2974),
+       (3004...3007)
      ),
-     CaseNode(2972...3013)(
-       CallNode(2977...2980)(
+     CaseNode(3008...3049)(
+       CallNode(3013...3016)(
          nil,
          nil,
-         IDENTIFIER(2977...2980)("foo"),
+         IDENTIFIER(3013...3016)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(2982...3009)(
-          IfNode(2985...3004)(
-            KEYWORD_IF_MODIFIER(2998...3000)("if"),
-            CallNode(3001...3004)(
+       [InNode(3018...3045)(
+          IfNode(3021...3040)(
+            KEYWORD_IF_MODIFIER(3034...3036)("if"),
+            CallNode(3037...3040)(
               nil,
               nil,
-              IDENTIFIER(3001...3004)("baz"),
+              IDENTIFIER(3037...3040)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(2985...2997)([SourceEncodingNode(2985...2997)()]),
+            StatementsNode(3021...3033)([SourceEncodingNode(3021...3033)()]),
             nil,
             nil
           ),
           nil,
-          (2982...2984),
-          (3005...3009)
+          (3018...3020),
+          (3041...3045)
         )],
        nil,
-       (2972...2976),
-       (3010...3013)
+       (3008...3012),
+       (3046...3049)
      ),
-     CaseNode(3014...3053)(
-       CallNode(3019...3022)(
+     CaseNode(3050...3089)(
+       CallNode(3055...3058)(
          nil,
          nil,
-         IDENTIFIER(3019...3022)("foo"),
+         IDENTIFIER(3055...3058)("foo"),
          nil,
          nil,
          nil,
          nil,
          "foo"
        ),
-       [InNode(3024...3049)(
-          IfNode(3027...3044)(
-            KEYWORD_IF_MODIFIER(3038...3040)("if"),
-            CallNode(3041...3044)(
+       [InNode(3060...3085)(
+          IfNode(3063...3080)(
+            KEYWORD_IF_MODIFIER(3074...3076)("if"),
+            CallNode(3077...3080)(
               nil,
               nil,
-              IDENTIFIER(3041...3044)("baz"),
+              IDENTIFIER(3077...3080)("baz"),
               nil,
               nil,
               nil,
               nil,
               "baz"
             ),
-            StatementsNode(3027...3035)(
-              [LambdaNode(3027...3035)(
-                 Scope(3027...3029)([]),
-                 MINUS_GREATER(3027...3029)("->"),
+            StatementsNode(3063...3071)(
+              [LambdaNode(3063...3071)(
+                 Scope(3063...3065)([]),
+                 MINUS_GREATER(3063...3065)("->"),
                  nil,
                  nil,
                  nil,
-                 StatementsNode(3032...3035)(
-                   [LocalVariableReadNode(3032...3035)(
-                      IDENTIFIER(3032...3035)("bar")
+                 StatementsNode(3068...3071)(
+                   [LocalVariableReadNode(3068...3071)(
+                      IDENTIFIER(3068...3071)("bar")
                     )]
                  )
                )]
@@ -3368,12 +3412,12 @@ ProgramNode(0...3053)(
             nil
           ),
           nil,
-          (3024...3026),
-          (3045...3049)
+          (3060...3062),
+          (3081...3085)
         )],
        nil,
-       (3014...3018),
-       (3050...3053)
+       (3050...3054),
+       (3086...3089)
      )]
   )
 )


### PR DESCRIPTION
The following patterns are now supported:

```ruby
foo => ^(1)
foo => ^(nil)
foo => ^("bar" + "baz")

foo => ::Foo
foo => ::Foo::Bar::Baz

foo => Foo()
foo => Foo(1)
foo => Foo(1, 2, 3)
foo => Foo(bar)
foo => Foo(*bar, baz)
foo => Foo(bar, *baz)
foo => Foo(*bar, baz, *qux)

foo => Foo[]
foo => Foo[1]
foo => Foo[1, 2, 3]
foo => Foo[bar]
foo => Foo[*bar, baz]
foo => Foo[bar, *baz]
foo => Foo[*bar, baz, *qux]

foo => *bar
foo => *bar, baz, qux
foo => bar, *baz, qux
foo => bar, baz, *qux
foo => *bar, baz, *qux

foo => []
foo => [[[[[]]]]]

foo => [*bar]
foo => [*bar, baz, qux]
foo => [bar, *baz, qux]
foo => [bar, baz, *qux]
foo => [*bar, baz, *qux]
```