### PR TITLE
Fix Unicode character literal

### DIFF
--- a/include/yarp/unescape.h
+++ b/include/yarp/unescape.h
@@ -33,6 +33,6 @@ __attribute__((__visibility__("default"))) extern void
 yp_unescape_manipulate_string(const char *value, size_t length, yp_string_t *string, yp_unescape_type_t unescape_type, yp_list_t *error_list);
 
 __attribute__((__visibility__("default"))) extern size_t
-yp_unescape_calculate_difference(const char *value, const char *end, yp_unescape_type_t unescape_type, yp_list_t *error_list);
+yp_unescape_calculate_difference(const char *value, const char *end, yp_unescape_type_t unescape_type, bool expect_single_codepoint, yp_list_t *error_list);
 
 #endif

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -227,7 +227,12 @@ unescape(char *dest, size_t *dest_length, const char *backslash, const char *end
 
         while ((*unicode_cursor != '}') && (unicode_cursor < end)) {
           const char *unicode_start = unicode_cursor;
-          unicode_cursor += yp_strspn_hexidecimal_digit(unicode_cursor, end - unicode_cursor);
+
+          // \u{nnnn} character literal allows only 1-6 hexadecimal digits
+          int hexadecimal_length = yp_strspn_hexidecimal_digit(unicode_cursor, end - unicode_cursor);
+          if (hexadecimal_length > 6)
+            yp_diagnostic_list_append(error_list, unicode_cursor, unicode_cursor + hexadecimal_length, "invalid Unicode escape.");
+          unicode_cursor += hexadecimal_length;
 
           uint32_t value;
           unescape_unicode(unicode_start, (size_t) (unicode_cursor - unicode_start), &value);

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -155,7 +155,8 @@ unescape_unicode_write(char *dest, uint32_t value, const char *start, const char
 typedef enum {
   YP_UNESCAPE_FLAG_NONE = 0,
   YP_UNESCAPE_FLAG_CONTROL = 1,
-  YP_UNESCAPE_FLAG_META = 2
+  YP_UNESCAPE_FLAG_META = 2,
+  YP_UNESCAPE_FLAG_EXPECT_SINGLE = 4
 } yp_unescape_flag_t;
 
 // Unescape a single character value based on the given flags.
@@ -216,13 +217,16 @@ unescape(char *dest, size_t *dest_length, const char *backslash, const char *end
     // \u{nnnn ...} Unicode character(s), where each nnnn is 1-6 hexadecimal digits ([0-9a-fA-F])
     // \unnnn       Unicode character, where nnnn is exactly 4 hexadecimal digits ([0-9a-fA-F])
     case 'u': {
-      if (flags != YP_UNESCAPE_FLAG_NONE) {
+      if ((flags & YP_UNESCAPE_FLAG_CONTROL) | (flags & YP_UNESCAPE_FLAG_META)) {
         yp_diagnostic_list_append(error_list, backslash, backslash + 2, "Unicode escape sequence cannot be used with control or meta flags.");
         return backslash + 2;
       }
 
       if ((backslash + 3) < end && backslash[2] == '{') {
         const char *unicode_cursor = backslash + 3;
+        const char *extra_codepoints_start;
+        int codepoints_count = 0;
+
         unicode_cursor += yp_strspn_whitespace(unicode_cursor, end - unicode_cursor);
 
         while ((*unicode_cursor != '}') && (unicode_cursor < end)) {
@@ -241,6 +245,10 @@ unescape(char *dest, size_t *dest_length, const char *backslash, const char *end
 
           unicode_cursor += hexadecimal_length;
 
+          codepoints_count++;
+          if (flags & YP_UNESCAPE_FLAG_EXPECT_SINGLE && codepoints_count == 2)
+            extra_codepoints_start = unicode_start;
+
           uint32_t value;
           unescape_unicode(unicode_start, (size_t) (unicode_cursor - unicode_start), &value);
           if (write_to_str) {
@@ -249,6 +257,10 @@ unescape(char *dest, size_t *dest_length, const char *backslash, const char *end
 
           unicode_cursor += yp_strspn_whitespace(unicode_cursor, end - unicode_cursor);
         }
+
+        // ?\u{nnnn} character literal should contain only one codepoint and cannot be like ?\u{nnnn mmmm}
+        if (flags & YP_UNESCAPE_FLAG_EXPECT_SINGLE && codepoints_count > 1)
+          yp_diagnostic_list_append(error_list, extra_codepoints_start, unicode_cursor - 1, "Multiple codepoints at single character literal");
 
         return unicode_cursor + 1;
       }
@@ -498,7 +510,7 @@ yp_unescape_manipulate_string(const char *value, size_t length, yp_string_t *str
 // actually perform any string manipulations. Instead, it calculates how long
 // the unescaped character is, and returns that value
 __attribute__((__visibility__("default"))) extern size_t
-yp_unescape_calculate_difference(const char *backslash, const char *end, yp_unescape_type_t unescape_type, yp_list_t *error_list) {
+yp_unescape_calculate_difference(const char *backslash, const char *end, yp_unescape_type_t unescape_type, bool expect_single_codepoint, yp_list_t *error_list) {
   assert(unescape_type != YP_UNESCAPE_NONE);
 
   switch (backslash[1]) {
@@ -512,7 +524,11 @@ yp_unescape_calculate_difference(const char *backslash, const char *end, yp_unes
       // handle all of the different unescapes.
       assert(unescape_type == YP_UNESCAPE_ALL);
 
-      const char *cursor = unescape(NULL, 0, backslash, end, error_list, YP_UNESCAPE_FLAG_NONE, false);
+      unsigned char flags = YP_UNESCAPE_FLAG_NONE;
+      if (expect_single_codepoint)
+        flags |= YP_UNESCAPE_FLAG_EXPECT_SINGLE;
+
+      const char *cursor = unescape(NULL, 0, backslash, end, error_list, flags, false);
       assert(cursor > backslash);
 
       return (size_t) (cursor - backslash);

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -227,11 +227,18 @@ unescape(char *dest, size_t *dest_length, const char *backslash, const char *end
 
         while ((*unicode_cursor != '}') && (unicode_cursor < end)) {
           const char *unicode_start = unicode_cursor;
+          int hexadecimal_length = yp_strspn_hexidecimal_digit(unicode_cursor, end - unicode_cursor);
 
           // \u{nnnn} character literal allows only 1-6 hexadecimal digits
-          int hexadecimal_length = yp_strspn_hexidecimal_digit(unicode_cursor, end - unicode_cursor);
           if (hexadecimal_length > 6)
             yp_diagnostic_list_append(error_list, unicode_cursor, unicode_cursor + hexadecimal_length, "invalid Unicode escape.");
+
+          // there are not hexadecimal characters
+          if (hexadecimal_length == 0) {
+            yp_diagnostic_list_append(error_list, unicode_cursor, unicode_cursor + hexadecimal_length, "unterminated Unicode escape");
+            return unicode_cursor;
+          }
+
           unicode_cursor += hexadecimal_length;
 
           uint32_t value;

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4386,7 +4386,7 @@ lex_question_mark(yp_parser_t *parser) {
   lex_state_set(parser, YP_LEX_STATE_END);
 
   if (parser->current.start[1] == '\\') {
-    parser->current.end += yp_unescape_calculate_difference(parser->current.start + 1, parser->end, YP_UNESCAPE_ALL, &parser->error_list);
+    parser->current.end += yp_unescape_calculate_difference(parser->current.start + 1, parser->end, YP_UNESCAPE_ALL, true, &parser->error_list);
   } else {
     parser->current.end += parser->encoding.char_width(parser->current.end);
   }
@@ -5766,7 +5766,7 @@ parser_lex(yp_parser_t *parser) {
             // If we hit escapes, then we need to treat the next token
             // literally. In this case we'll skip past the next character and
             // find the next breakpoint.
-            size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, YP_UNESCAPE_ALL, &parser->error_list);
+            size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, YP_UNESCAPE_ALL, false, &parser->error_list);
             breakpoint = yp_strpbrk(breakpoint + difference, breakpoints, parser->end - (breakpoint + difference));
             break;
           }
@@ -5866,7 +5866,7 @@ parser_lex(yp_parser_t *parser) {
             // If we hit escapes, then we need to treat the next token
             // literally. In this case we'll skip past the next character and
             // find the next breakpoint.
-            size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, YP_UNESCAPE_ALL, &parser->error_list);
+            size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, YP_UNESCAPE_ALL, false, &parser->error_list);
             breakpoint = yp_strpbrk(breakpoint + difference, breakpoints, parser->end - (breakpoint + difference));
             break;
           }
@@ -6037,7 +6037,7 @@ parser_lex(yp_parser_t *parser) {
             // literally. In this case we'll skip past the next character and
             // find the next breakpoint.
             yp_unescape_type_t unescape_type = parser->lex_modes.current->as.string.interpolation ? YP_UNESCAPE_ALL : YP_UNESCAPE_MINIMAL;
-            size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, unescape_type, &parser->error_list);
+            size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, unescape_type, false, &parser->error_list);
             breakpoint = yp_strpbrk(breakpoint + difference, breakpoints, parser->end - (breakpoint + difference));
             break;
           }
@@ -6176,7 +6176,7 @@ parser_lex(yp_parser_t *parser) {
             if (breakpoint[1] == '\n') {
               breakpoint++;
             } else {
-              size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, YP_UNESCAPE_ALL, &parser->error_list);
+              size_t difference = yp_unescape_calculate_difference(breakpoint, parser->end, YP_UNESCAPE_ALL, false, &parser->error_list);
               breakpoint = yp_strpbrk(breakpoint + difference, breakpoints, parser->end - (breakpoint + difference));
             }
             break;

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -555,6 +555,45 @@ class ErrorsTest < Test::Unit::TestCase
     ]
   end
 
+  test "do not allow multiple codepoints in a single character literal" do
+    expected = StringNode(
+      STRING_BEGIN("?"),
+      STRING_CONTENT('\u{0001 0002}'),
+      nil,
+      "\u0001\u0002"
+    )
+    assert_errors expected, '?\u{0001 0002}', [
+      "Multiple codepoints at single character literal"
+    ]
+  end
+
+  test "do not allow more than 6 hexadecimal digits in \u{} Unicode character notation" do
+    expected = StringNode(
+      STRING_BEGIN('"'),
+      STRING_CONTENT('\u{0000001}'),
+      STRING_END('"'),
+      "\u0001"
+    )
+    assert_errors expected, '"\u{0000001}"', [
+      "invalid Unicode escape.",
+      "invalid Unicode escape."
+    ]
+  end
+
+  test "do not allow characters other than 0-9, a-f and A-F in \u{} Unicode character notation" do
+    expected = StringNode(
+      STRING_BEGIN('"'),
+      STRING_CONTENT('\u{000z}'),
+      STRING_END('"'),
+      "\u0000z}"
+    )
+    assert_errors expected, '"\u{000z}"', [
+      "unterminated Unicode escape",
+      "unterminated Unicode escape"
+    ]
+  end
+
+
   private
 
   def assert_errors(expected, source, errors)


### PR DESCRIPTION
Github issue https://github.com/Shopify/yarp/issues/569

Changes:
- add error when `?\u{nnnn}` literal contain more than one codepoint (e.g. `?\u{0000 0001}`)
- add error when `\u{nnnn}` contains more than 6 digits
- add error when `\u{nnnn}` contains not hexadecimal characters