### PR TITLE
Fix assertions which were doing operations

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2816,6 +2816,7 @@ yp_super_node_create(yp_parser_t *parser, const yp_token_t *keyword, yp_argument
     end = arguments->arguments->base.location.end;
   } else {
     assert(false && "unreachable");
+    end = NULL;
   }
 
   *node = (yp_super_node_t) {
@@ -11020,7 +11021,10 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
         yp_string_list_init(&named_captures);
 
         yp_token_t *content = &((yp_regular_expression_node_t *) node)->content;
-        assert(yp_regexp_named_capture_group_names(content->start, (size_t) (content->end - content->start), &named_captures));
+
+        __attribute__((unused)) bool captured_group_names =
+        yp_regexp_named_capture_group_names(content->start, (size_t) content->end - content->start, &named_captures);
+        assert(captured_group_names);
 
         for (size_t index = 0; index < named_captures.length; index++) {
           yp_string_t *name = &named_captures.strings[index];

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -7819,6 +7819,7 @@ parse_conditional(yp_parser_t *parser, yp_context_t context) {
       parent = (yp_node_t *) yp_unless_node_create(parser, &keyword, predicate, statements);
       break;
     default:
+      parent = NULL;
       assert(false && "unreachable");
       break;
   }
@@ -11023,7 +11024,8 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
         yp_token_t *content = &((yp_regular_expression_node_t *) node)->content;
 
         __attribute__((unused)) bool captured_group_names =
-        yp_regexp_named_capture_group_names(content->start, (size_t) content->end - content->start, &named_captures);
+        yp_regexp_named_capture_group_names(content->start, (size_t) (content->end - content->start), &named_captures);
+	// We assert that the the regex was successfully parsed
         assert(captured_group_names);
 
         for (size_t index = 0; index < named_captures.length; index++) {


### PR DESCRIPTION
When looking into #659, I found that if we disable assertions, we get warnings in two places. This fixes those warnings.