### PR TITLE
Migrate strikes back

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1275,6 +1275,7 @@ nodes:
                 ^^^^^
           end
   - name: OrNode
+    is_migrated: true
     child_nodes:
       - name: left
         type: node

--- a/config.yml
+++ b/config.yml
@@ -1261,6 +1261,7 @@ nodes:
           target ||= value
           ^^^^^^^^^^^^^^^^
   - name: OptionalParameterNode
+    is_migrated: true
     child_nodes:
       - name: name
         type: token

--- a/config.yml
+++ b/config.yml
@@ -1320,6 +1320,7 @@ nodes:
           (10 + 34)
           ^^^^^^^^^
   - name: PinnedExpressionNode
+    is_migrated: true
     child_nodes:
       - name: expression
         type: node
@@ -1336,6 +1337,7 @@ nodes:
           foo in ^(bar)
                  ^^^^^^
   - name: PinnedVariableNode
+    is_migrated: true
     child_nodes:
       - name: variable
         type: node

--- a/config.yml
+++ b/config.yml
@@ -1417,6 +1417,7 @@ nodes:
           redo
           ^^^^
   - name: RegularExpressionNode
+    is_migrated: true
     child_nodes:
       - name: opening
         type: token

--- a/config.yml
+++ b/config.yml
@@ -1405,12 +1405,14 @@ nodes:
           c if a =~ /left/ ... b =~ /right/
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   - name: RationalNode
+    is_migrated: true
     comment: |
       Represents a rational number literal.
 
           1.0r
           ^^^^
   - name: RedoNode
+    is_migrated: true
     comment: |
       Represents the use of the `redo` keyword.
 

--- a/config.yml
+++ b/config.yml
@@ -527,6 +527,7 @@ nodes:
     child_nodes:
       - name: parameters
         type: node?
+        kind: ParametersNode
       - name: locals
         type: token[]
     comment: |
@@ -695,6 +696,7 @@ nodes:
         type: node?
       - name: parameters
         type: node?
+        kind: ParametersNode
       - name: statements
         type: node?
       - name: scope
@@ -1286,6 +1288,7 @@ nodes:
           left or right
           ^^^^^^^^^^^^^
   - name: ParametersNode
+    is_migrated: true
     child_nodes:
       - name: requireds
         type: node[]
@@ -1300,6 +1303,7 @@ nodes:
         type: node?
       - name: block
         type: node?
+        kind: BlockParameterNode
     comment: |
       Represents the list of parameters on a method, block, or lambda definition.
 

--- a/config.yml
+++ b/config.yml
@@ -1222,6 +1222,7 @@ nodes:
                 ^^^^^
           end
   - name: OperatorAndAssignmentNode
+    is_migrated: true
     child_nodes:
       - name: target
         type: node
@@ -1235,6 +1236,7 @@ nodes:
           target &&= value
           ^^^^^^^^^^^^^^^^
   - name: OperatorAssignmentNode
+    is_migrated: true
     child_nodes:
       - name: target
         type: node
@@ -1248,6 +1250,7 @@ nodes:
           foo += bar
           ^^^^^^^^^^
   - name: OperatorOrAssignmentNode
+    is_migrated: true
     child_nodes:
       - name: target
         type: node

--- a/config.yml
+++ b/config.yml
@@ -1389,6 +1389,7 @@ nodes:
         kind: StatementsNode
     comment: The top level node of any parse tree.
   - name: RangeNode
+    is_migrated: true
     child_nodes:
       - name: left
         type: node?

--- a/config.yml
+++ b/config.yml
@@ -1348,6 +1348,7 @@ nodes:
           foo in ^bar
                  ^^^^
   - name: PostExecutionNode
+    is_migrated: true
     child_nodes:
       - name: statements
         type: node
@@ -1364,6 +1365,7 @@ nodes:
           END { foo }
           ^^^^^^^^^^^
   - name: PreExecutionNode
+    is_migrated: true
     child_nodes:
       - name: statements
         type: node

--- a/config.yml
+++ b/config.yml
@@ -1307,6 +1307,7 @@ nodes:
                 ^^^^^^^
           end
   - name: ParenthesesNode
+    is_migrated: true
     child_nodes:
       - name: statements
         type: node?

--- a/config.yml
+++ b/config.yml
@@ -1380,6 +1380,7 @@ nodes:
           BEGIN { foo }
           ^^^^^^^^^^^^^
   - name: ProgramNode
+    is_migrated: true
     child_nodes:
       - name: scope
         type: node

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2246,44 +2246,44 @@ yp_pinned_variable_node_create(yp_parser_t *parser, const yp_token_t *operator, 
 }
 
 // Allocate and initialize a new PostExecutionNode node.
-static yp_node_t *
+static yp_post_execution_node_t *
 yp_post_execution_node_create(yp_parser_t *parser, const yp_token_t *keyword, const yp_token_t *opening, yp_statements_node_t *statements, const yp_token_t *closing) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_post_execution_node_t *node = YP_NODE_ALLOC(yp_post_execution_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_POST_EXECUTION_NODE,
-    .location = {
-      .start = keyword->start,
-      .end = closing->end
+  *node = (yp_post_execution_node_t) {
+    {
+      .type = YP_NODE_POST_EXECUTION_NODE,
+      .location = {
+        .start = keyword->start,
+        .end = closing->end
+      }
     },
-    .as.post_execution_node = {
-      .statements = statements,
-      .keyword_loc = YP_LOCATION_TOKEN_VALUE(keyword),
-      .opening_loc = YP_LOCATION_TOKEN_VALUE(opening),
-      .closing_loc = YP_LOCATION_TOKEN_VALUE(closing)
-    }
+    .statements = statements,
+    .keyword_loc = YP_LOCATION_TOKEN_VALUE(keyword),
+    .opening_loc = YP_LOCATION_TOKEN_VALUE(opening),
+    .closing_loc = YP_LOCATION_TOKEN_VALUE(closing)
   };
 
   return node;
 }
 
 // Allocate and initialize a new PreExecutionNode node.
-static yp_node_t *
+static yp_pre_execution_node_t *
 yp_pre_execution_node_create(yp_parser_t *parser, const yp_token_t *keyword, const yp_token_t *opening, yp_statements_node_t *statements, const yp_token_t *closing) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_pre_execution_node_t *node = YP_NODE_ALLOC(yp_pre_execution_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_PRE_EXECUTION_NODE,
-    .location = {
-      .start = keyword->start,
-      .end = closing->end
+  *node = (yp_pre_execution_node_t) {
+    {
+      .type = YP_NODE_PRE_EXECUTION_NODE,
+      .location = {
+        .start = keyword->start,
+        .end = closing->end
+      }
     },
-    .as.pre_execution_node = {
-      .statements = statements,
-      .keyword_loc = YP_LOCATION_TOKEN_VALUE(keyword),
-      .opening_loc = YP_LOCATION_TOKEN_VALUE(opening),
-      .closing_loc = YP_LOCATION_TOKEN_VALUE(closing)
-    }
+    .statements = statements,
+    .keyword_loc = YP_LOCATION_TOKEN_VALUE(keyword),
+    .opening_loc = YP_LOCATION_TOKEN_VALUE(opening),
+    .closing_loc = YP_LOCATION_TOKEN_VALUE(closing)
   };
 
   return node;
@@ -9365,9 +9365,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       yp_statements_node_t *statements = parse_statements(parser, YP_CONTEXT_PREEXE);
 
       expect(parser, YP_TOKEN_BRACE_RIGHT, "Expected '}' after 'BEGIN' statements.");
-      yp_token_t closing = parser->previous;
-
-      return yp_pre_execution_node_create(parser, &keyword, &opening, statements, &closing);
+      return (yp_node_t *) yp_pre_execution_node_create(parser, &keyword, &opening, statements, &parser->previous);
     }
     case YP_TOKEN_KEYWORD_BREAK:
     case YP_TOKEN_KEYWORD_NEXT:
@@ -9765,9 +9763,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       yp_statements_node_t *statements = parse_statements(parser, YP_CONTEXT_POSTEXE);
 
       expect(parser, YP_TOKEN_BRACE_RIGHT, "Expected '}' after 'END' statements.");
-      yp_token_t closing = parser->previous;
-
-      return yp_post_execution_node_create(parser, &keyword, &opening, statements, &closing);
+      return (yp_node_t *) yp_post_execution_node_create(parser, &keyword, &opening, statements, &parser->previous);
     }
     case YP_TOKEN_KEYWORD_FALSE:
       parser_lex(parser);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2311,17 +2311,23 @@ yp_range_node_create(yp_parser_t *parser, yp_node_t *left, const yp_token_t *ope
 }
 
 // Allocate and initialize a new RationalNode node.
-static yp_node_t *
+static yp_rational_node_t *
 yp_rational_node_create(yp_parser_t *parser, const yp_token_t *token) {
   assert(token->type == YP_TOKEN_RATIONAL_NUMBER);
-  return yp_node_create_from_token(parser, YP_NODE_RATIONAL_NODE, token);
+  yp_rational_node_t *node = YP_NODE_ALLOC(yp_rational_node_t);
+
+  *node = (yp_rational_node_t) {{ .type = YP_NODE_RATIONAL_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+  return node;
 }
 
 // Allocate and initialize a new RedoNode node.
-static yp_node_t *
+static yp_redo_node_t *
 yp_redo_node_create(yp_parser_t *parser, const yp_token_t *token) {
   assert(token->type == YP_TOKEN_KEYWORD_REDO);
-  return yp_node_create_from_token(parser, YP_NODE_REDO_NODE, token);
+  yp_redo_node_t *node = YP_NODE_ALLOC(yp_redo_node_t);
+
+  *node = (yp_redo_node_t) {{ .type = YP_NODE_REDO_NODE, .location = YP_LOCATION_TOKEN_VALUE(token) }};
+  return node;
 }
 
 // Allocate a new RegularExpressionNode node.
@@ -9902,7 +9908,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       return yp_nil_node_create(parser, &parser->previous);
     case YP_TOKEN_KEYWORD_REDO:
       parser_lex(parser);
-      return yp_redo_node_create(parser, &parser->previous);
+      return (yp_node_t *) yp_redo_node_create(parser, &parser->previous);
     case YP_TOKEN_KEYWORD_RETRY:
       parser_lex(parser);
       return (yp_node_t *) yp_retry_node_create(parser, &parser->previous);
@@ -10247,7 +10253,7 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
     }
     case YP_TOKEN_RATIONAL_NUMBER:
       parser_lex(parser);
-      return yp_rational_node_create(parser, &parser->previous);
+      return (yp_node_t *) yp_rational_node_create(parser, &parser->previous);
     case YP_TOKEN_REGEXP_BEGIN: {
       yp_token_t opening = parser->current;
       parser_lex(parser);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2204,42 +2204,42 @@ yp_parentheses_node_create(yp_parser_t *parser, const yp_token_t *opening, yp_no
 }
 
 // Allocate and initialize a new PinnedExpressionNode node.
-static yp_node_t *
+static yp_pinned_expression_node_t *
 yp_pinned_expression_node_create(yp_parser_t *parser, yp_node_t *expression, const yp_token_t *operator, const yp_token_t *lparen, const yp_token_t *rparen) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_pinned_expression_node_t *node = YP_NODE_ALLOC(yp_pinned_expression_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_PINNED_EXPRESSION_NODE,
-    .location = {
-      .start = operator->start,
-      .end = rparen->end
+  *node = (yp_pinned_expression_node_t) {
+    {
+      .type = YP_NODE_PINNED_EXPRESSION_NODE,
+      .location = {
+        .start = operator->start,
+        .end = rparen->end
+      }
     },
-    .as.pinned_expression_node = {
-      .expression = expression,
-      .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
-      .lparen_loc = YP_LOCATION_TOKEN_VALUE(lparen),
-      .rparen_loc = YP_LOCATION_TOKEN_VALUE(rparen)
-    }
+    .expression = expression,
+    .operator_loc = YP_LOCATION_TOKEN_VALUE(operator),
+    .lparen_loc = YP_LOCATION_TOKEN_VALUE(lparen),
+    .rparen_loc = YP_LOCATION_TOKEN_VALUE(rparen)
   };
 
   return node;
 }
 
 // Allocate and initialize a new PinnedVariableNode node.
-static yp_node_t *
+static yp_pinned_variable_node_t *
 yp_pinned_variable_node_create(yp_parser_t *parser, const yp_token_t *operator, yp_node_t *variable) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_pinned_variable_node_t *node = YP_NODE_ALLOC(yp_pinned_variable_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_PINNED_VARIABLE_NODE,
-    .location = {
-      .start = operator->start,
-      .end = variable->location.end
+  *node = (yp_pinned_variable_node_t) {
+    {
+      .type = YP_NODE_PINNED_VARIABLE_NODE,
+      .location = {
+        .start = operator->start,
+        .end = variable->location.end
+      }
     },
-    .as.pinned_variable_node = {
-      .variable = variable,
-      .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
-    }
+    .variable = variable,
+    .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
   };
 
   return node;
@@ -8429,19 +8429,19 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
           parser_lex(parser);
           yp_node_t *variable = yp_local_variable_read_node_create(parser, &parser->previous);
 
-          return yp_pinned_variable_node_create(parser, &operator, variable);
+          return (yp_node_t *) yp_pinned_variable_node_create(parser, &operator, variable);
         }
         case YP_TOKEN_INSTANCE_VARIABLE: {
           parser_lex(parser);
           yp_node_t *variable = yp_instance_variable_read_node_create(parser, &parser->previous);
 
-          return yp_pinned_variable_node_create(parser, &operator, variable);
+          return (yp_node_t *) yp_pinned_variable_node_create(parser, &operator, variable);
         }
         case YP_TOKEN_CLASS_VARIABLE: {
           parser_lex(parser);
           yp_node_t *variable = yp_class_variable_read_node_create(parser, &parser->previous);
 
-          return yp_pinned_variable_node_create(parser, &operator, variable);
+          return (yp_node_t *) yp_pinned_variable_node_create(parser, &operator, variable);
         }
         case YP_TOKEN_GLOBAL_VARIABLE:
         case YP_TOKEN_NTH_REFERENCE:
@@ -8449,7 +8449,7 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
           parser_lex(parser);
           yp_node_t *variable = yp_global_variable_read_node_create(parser, &parser->previous);
 
-          return yp_pinned_variable_node_create(parser, &operator, variable);
+          return (yp_node_t *) yp_pinned_variable_node_create(parser, &operator, variable);
         }
         case YP_TOKEN_PARENTHESIS_LEFT: {
           bool previous_pattern_matching_newlines = parser->pattern_matching_newlines;
@@ -8463,7 +8463,7 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
 
           accept(parser, YP_TOKEN_NEWLINE);
           expect(parser, YP_TOKEN_PARENTHESIS_RIGHT, "Expected a closing parenthesis after the expression.");
-          return yp_pinned_expression_node_create(parser, expression, &operator, &lparen, &parser->previous);
+          return (yp_node_t *) yp_pinned_expression_node_create(parser, expression, &operator, &lparen, &parser->previous);
         }
         default: {
           // If we get here, then we have a pin operator followed by something
@@ -8471,7 +8471,7 @@ parse_pattern_primitive(yp_parser_t *parser, const char *message) {
           yp_diagnostic_list_append(&parser->error_list, operator.start, operator.end, "Expected a variable after the pin operator.");
           yp_node_t *variable = yp_missing_node_create(parser, &(yp_location_t) { .start = operator.start, .end = operator.end });
 
-          return yp_pinned_variable_node_create(parser, &operator, variable);
+          return (yp_node_t *) yp_pinned_variable_node_create(parser, &operator, variable);
         }
       }
     }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2034,21 +2034,21 @@ yp_operator_or_assignment_node_create(yp_parser_t *parser, yp_node_t *target, co
 }
 
 // Allocate a new OptionalParameterNode node.
-static yp_node_t *
+static yp_optional_parameter_node_t *
 yp_optional_parameter_node_create(yp_parser_t *parser, const yp_token_t *name, const yp_token_t *equal_operator, yp_node_t *value) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_optional_parameter_node_t *node = YP_NODE_ALLOC(yp_optional_parameter_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_OPTIONAL_PARAMETER_NODE,
-    .location = {
-      .start = name->start,
-      .end = value->location.end
+  *node = (yp_optional_parameter_node_t) {
+    {
+      .type = YP_NODE_OPTIONAL_PARAMETER_NODE,
+      .location = {
+        .start = name->start,
+        .end = value->location.end
+      }
     },
-    .as.optional_parameter_node = {
-      .name = *name,
-      .equal_operator = *equal_operator,
-      .value = value
-    }
+    .name = *name,
+    .equal_operator = *equal_operator,
+    .value = value
   };
 
   return node;
@@ -2122,9 +2122,9 @@ yp_parameters_node_requireds_append(yp_parameters_node_t *params, yp_node_t *par
 
 // Append an optional parameter to a ParametersNode node.
 static void
-yp_parameters_node_optionals_append(yp_parameters_node_t *params, yp_node_t *param) {
-  yp_parameters_node_location_set(params, param);
-  yp_node_list_append2(&params->optionals, param);
+yp_parameters_node_optionals_append(yp_parameters_node_t *params, yp_optional_parameter_node_t *param) {
+  yp_parameters_node_location_set(params, (yp_node_t *) param);
+  yp_node_list_append2(&params->optionals, (yp_node_t *) param);
 }
 
 // Set the rest parameter on a ParametersNode node.
@@ -7228,7 +7228,7 @@ parse_parameters(
           yp_token_t operator = parser->previous;
           yp_node_t *value = parse_expression(parser, binding_power, "Expected to find a default value for the parameter.");
 
-          yp_node_t *param = yp_optional_parameter_node_create(parser, &name, &operator, value);
+          yp_optional_parameter_node_t *param = yp_optional_parameter_node_create(parser, &name, &operator, value);
           yp_parameters_node_optionals_append(params, param);
 
           // If parsing the value of the parameter resulted in error recovery,

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -1969,65 +1969,65 @@ yp_no_keywords_parameter_node_create(yp_parser_t *parser, const yp_token_t *oper
 }
 
 // Allocate and initialize a new OperatorAndAssignmentNode node.
-static yp_node_t *
+static yp_operator_and_assignment_node_t *
 yp_operator_and_assignment_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
   assert(operator->type == YP_TOKEN_AMPERSAND_AMPERSAND_EQUAL);
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_operator_and_assignment_node_t *node = YP_NODE_ALLOC(yp_operator_and_assignment_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_OPERATOR_AND_ASSIGNMENT_NODE,
-    .location = {
-      .start = target->location.start,
-      .end = value->location.end
+  *node = (yp_operator_and_assignment_node_t) {
+    {
+      .type = YP_NODE_OPERATOR_AND_ASSIGNMENT_NODE,
+      .location = {
+        .start = target->location.start,
+        .end = value->location.end
+      }
     },
-    .as.operator_and_assignment_node = {
-      .target = target,
-      .value = value,
-      .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
-    }
+    .target = target,
+    .value = value,
+    .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
   };
 
   return node;
 }
 
 // Allocate a new OperatorAssignmentNode node.
-static yp_node_t *
+static yp_operator_assignment_node_t *
 yp_operator_assignment_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_operator_assignment_node_t *node = YP_NODE_ALLOC(yp_operator_assignment_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_OPERATOR_ASSIGNMENT_NODE,
-    .location = {
-      .start = target->location.start,
-      .end = value->location.end
+  *node = (yp_operator_assignment_node_t) {
+    {
+      .type = YP_NODE_OPERATOR_ASSIGNMENT_NODE,
+      .location = {
+        .start = target->location.start,
+        .end = value->location.end
+      }
     },
-    .as.operator_assignment_node = {
-      .target = target,
-      .operator = *operator,
-      .value = value
-    }
+    .target = target,
+    .operator = *operator,
+    .value = value
   };
 
   return node;
 }
 
 // Allocate and initialize a new OperatorOrAssignmentNode node.
-static yp_node_t *
+static yp_operator_or_assignment_node_t *
 yp_operator_or_assignment_node_create(yp_parser_t *parser, yp_node_t *target, const yp_token_t *operator, yp_node_t *value) {
   assert(operator->type == YP_TOKEN_PIPE_PIPE_EQUAL);
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_operator_or_assignment_node_t *node = YP_NODE_ALLOC(yp_operator_or_assignment_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_OPERATOR_OR_ASSIGNMENT_NODE,
-    .location = {
-      .start = target->location.start,
-      .end = value->location.end
+  *node = (yp_operator_or_assignment_node_t) {
+    {
+      .type = YP_NODE_OPERATOR_OR_ASSIGNMENT_NODE,
+      .location = {
+        .start = target->location.start,
+        .end = value->location.end
+      }
     },
-    .as.operator_or_assignment_node = {
-      .target = target,
-      .value = value,
-      .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
-    }
+    .target = target,
+    .value = value,
+    .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
   };
 
   return node;
@@ -10750,7 +10750,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
           }
 
           yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after &&=");
-          return yp_operator_and_assignment_node_create(parser, node, &token, value);
+          return (yp_node_t *) yp_operator_and_assignment_node_create(parser, node, &token, value);
         }
         default:
           parser_lex(parser);
@@ -10787,7 +10787,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
           }
 
           yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after ||=");
-          return yp_operator_or_assignment_node_create(parser, node, &token, value);
+          return (yp_node_t *) yp_operator_or_assignment_node_create(parser, node, &token, value);
         }
         default:
           parser_lex(parser);
@@ -10828,7 +10828,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
 
           parser_lex(parser);
           yp_node_t *value = parse_expression(parser, binding_power, "Expected a value after the operator.");
-          return yp_operator_assignment_node_create(parser, node, &token, value);
+          return (yp_node_t *) yp_operator_assignment_node_create(parser, node, &token, value);
         }
         default:
           parser_lex(parser);

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2163,20 +2163,20 @@ yp_parameters_node_block_set(yp_node_t *params, yp_node_t *param) {
 }
 
 // Allocate a new ProgramNode node.
-static yp_node_t *
+static yp_program_node_t *
 yp_program_node_create(yp_parser_t *parser, yp_scope_node_t *scope, yp_statements_node_t *statements) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_program_node_t *node = YP_NODE_ALLOC(yp_program_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_PROGRAM_NODE,
-    .location = {
-      .start = statements == NULL ? parser->start : statements->base.location.start,
-      .end = statements == NULL ? parser->end : statements->base.location.end
+  *node = (yp_program_node_t) {
+    {
+      .type = YP_NODE_PROGRAM_NODE,
+      .location = {
+        .start = statements == NULL ? parser->start : statements->base.location.start,
+        .end = statements == NULL ? parser->end : statements->base.location.end
+      }
     },
-    .as.program_node = {
-      .scope = scope,
-      .statements = statements
-    }
+    .scope = scope,
+    .statements = statements
   };
 
   return node;
@@ -11237,7 +11237,7 @@ parse_program(yp_parser_t *parser) {
     yp_statements_node_location_set(statements, parser->start, parser->start);
   }
 
-  return yp_program_node_create(parser, scope, statements);
+  return (yp_node_t *) yp_program_node_create(parser, scope, statements);
 }
 
 /******************************************************************************/

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -2055,21 +2055,21 @@ yp_optional_parameter_node_create(yp_parser_t *parser, const yp_token_t *name, c
 }
 
 // Allocate and initialize a new OrNode node.
-static yp_node_t *
+static yp_or_node_t *
 yp_or_node_create(yp_parser_t *parser, yp_node_t *left, const yp_token_t *operator, yp_node_t *right) {
-  yp_node_t *node = yp_node_alloc(parser);
+  yp_or_node_t *node = YP_NODE_ALLOC(yp_or_node_t);
 
-  *node = (yp_node_t) {
-    .type = YP_NODE_OR_NODE,
-    .location = {
-      .start = left->location.start,
-      .end = right->location.end
+  *node = (yp_or_node_t) {
+    {
+      .type = YP_NODE_OR_NODE,
+      .location = {
+        .start = left->location.start,
+        .end = right->location.end
+      }
     },
-    .as.or_node = {
-      .left = left,
-      .right = right,
-      .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
-    }
+    .left = left,
+    .right = right,
+    .operator_loc = YP_LOCATION_TOKEN_VALUE(operator)
   };
 
   return node;
@@ -10852,7 +10852,7 @@ parse_expression_infix(yp_parser_t *parser, yp_node_t *node, yp_binding_power_t 
       parser_lex(parser);
 
       yp_node_t *right = parse_expression(parser, binding_power, "Expected a value after the operator.");
-      return yp_or_node_create(parser, node, &token, right);
+      return (yp_node_t *) yp_or_node_create(parser, node, &token, right);
     }
     case YP_TOKEN_EQUAL_TILDE: {
       // Note that we _must_ parse the value before adding the local variables


### PR DESCRIPTION
* RegularExpressionNode
* RedoNode
* RationalNode
* RangeNode
* ProgramNode
* PreExecutionNode
* PostExecutionNode
* PinnedVariableNode
* PinnedExpressionNode
* ParenthesesNode
* ParametersNode
* OrNode
* OptionalParameterNode
* OperatorAssignmentNode
* OperatorAndAssignmentNode
* OperatorOrAssignmentNode