### PR TITLE
Provide fixed-width to PP.pp for ParseTest

### DIFF
--- a/test/snapshots/keyword_method_names.rb
+++ b/test/snapshots/keyword_method_names.rb
@@ -116,9 +116,7 @@ ProgramNode(0...185)(
      ),
      DefNode(131...149)(
        IDENTIFIER(144...145)("a"),
-       SourceFileNode(135...143)(
-         "/fixtures/keyword_method_names.rb"
-       ),
+       SourceFileNode(135...143)("/fixtures/keyword_method_names.rb"),
        nil,
        nil,
        ScopeNode(131...134)([]),

--- a/test/snapshots/keywords.rb
+++ b/test/snapshots/keywords.rb
@@ -5,9 +5,7 @@ ProgramNode(0...51)(
      RetryNode(6...11)(),
      SelfNode(13...17)(),
      SourceEncodingNode(19...31)(),
-     SourceFileNode(33...41)(
-       "/fixtures/keywords.rb"
-     ),
+     SourceFileNode(33...41)("/fixtures/keywords.rb"),
      SourceLineNode(43...51)()]
   )
 )

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -409,9 +409,7 @@ ProgramNode(0...3655)(
          nil,
          "foo"
        ),
-       SourceFileNode(291...299)(
-         "/fixtures/patterns.rb"
-       ),
+       SourceFileNode(291...299)("/fixtures/patterns.rb"),
        (288...290)
      ),
      MatchRequiredNode(300...315)(
@@ -1021,12 +1019,8 @@ ProgramNode(0...3655)(
          "foo"
        ),
        RangeNode(824...844)(
-         SourceFileNode(824...832)(
-           "/fixtures/patterns.rb"
-         ),
-         SourceFileNode(836...844)(
-           "/fixtures/patterns.rb"
-         ),
+         SourceFileNode(824...832)("/fixtures/patterns.rb"),
+         SourceFileNode(836...844)("/fixtures/patterns.rb"),
          (833...835)
        ),
        (821...823)
@@ -2367,9 +2361,7 @@ ProgramNode(0...3655)(
          nil,
          "foo"
        ),
-       SourceFileNode(1921...1929)(
-         "/fixtures/patterns.rb"
-       ),
+       SourceFileNode(1921...1929)("/fixtures/patterns.rb"),
        (1918...1920)
      ),
      MatchPredicateNode(1930...1945)(
@@ -2978,9 +2970,7 @@ ProgramNode(0...3655)(
          "foo"
        ),
        [InNode(2609...2625)(
-          SourceFileNode(2612...2620)(
-            "/fixtures/patterns.rb"
-          ),
+          SourceFileNode(2612...2620)("/fixtures/patterns.rb"),
           nil,
           (2609...2611),
           (2621...2625)
@@ -3782,9 +3772,7 @@ ProgramNode(0...3655)(
             KEYWORD_IF_MODIFIER(3520...3522)("if"),
             LocalVariableReadNode(3523...3526)(0),
             StatementsNode(3511...3519)(
-              [SourceFileNode(3511...3519)(
-                 "/fixtures/patterns.rb"
-               )]
+              [SourceFileNode(3511...3519)("/fixtures/patterns.rb")]
             ),
             nil,
             nil

--- a/test/snapshots/unparser/corpus/literal/pragma.rb
+++ b/test/snapshots/unparser/corpus/literal/pragma.rb
@@ -2,9 +2,7 @@ ProgramNode(0...38)(
   ScopeNode(0...0)([]),
   StatementsNode(0...38)(
     [SourceEncodingNode(0...12)(),
-     SourceFileNode(13...21)(
-       "/fixtures/unparser/corpus/literal/pragma.rb"
-     ),
+     SourceFileNode(13...21)("/fixtures/unparser/corpus/literal/pragma.rb"),
      SourceLineNode(22...30)(),
      CallNode(31...38)(
        nil,

--- a/test/snapshots/whitequark/pattern_matching__FILE__LINE_literals.rb
+++ b/test/snapshots/whitequark/pattern_matching__FILE__LINE_literals.rb
@@ -3,9 +3,7 @@ ProgramNode(8...111)(
   StatementsNode(8...111)(
     [CaseNode(8...111)(
        ArrayNode(13...51)(
-         [SourceFileNode(14...22)(
-            "/fixtures/whitequark/pattern_matching__FILE__LINE_literals.rb"
-          ),
+         [SourceFileNode(14...22)("/fixtures/whitequark/pattern_matching__FILE__LINE_literals.rb"),
           CallNode(24...36)(
             SourceLineNode(24...32)(),
             nil,
@@ -23,9 +21,7 @@ ProgramNode(8...111)(
        [InNode(62...99)(
           ArrayPatternNode(65...99)(
             nil,
-            [SourceFileNode(66...74)(
-               "/fixtures/whitequark/pattern_matching__FILE__LINE_literals.rb"
-             ),
+            [SourceFileNode(66...74)("/fixtures/whitequark/pattern_matching__FILE__LINE_literals.rb"),
              SourceLineNode(76...84)(),
              SourceEncodingNode(86...98)()],
             nil,

--- a/test/snapshots/whitequark/string___FILE__.rb
+++ b/test/snapshots/whitequark/string___FILE__.rb
@@ -1,8 +1,6 @@
 ProgramNode(0...8)(
   ScopeNode(0...0)([]),
   StatementsNode(0...8)(
-    [SourceFileNode(0...8)(
-       "/fixtures/whitequark/string___FILE__.rb"
-     )]
+    [SourceFileNode(0...8)("/fixtures/whitequark/string___FILE__.rb")]
   )
 )


### PR DESCRIPTION
Because a string buffer is used rather than an IO device with a tty, PP determines the width from its environment.  If `ENV["COLUMNS"]` was set to anything besides `"80"`, then the snapshots will not match the `pp` output.  This will happen when the shell exports the `COLUMNS` variable.

Fixes #727