### PR TITLE
Fix up block parameters

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -508,11 +508,19 @@ nodes:
         kind: ParametersNode
       - name: locals
         type: token[]
+      - name: opening_loc
+        type: location?
+      - name: closing_loc
+        type: location?
     comment: |
-      Represents a block variable declaration.
+      Represents a block's parameters declaration.
 
           -> (a, b = 1; local) { }
-              ^^^^^^^^^^^^^^^
+             ^^^^^^^^^^^^^^^^^
+
+          foo do |a, b = 1; local|
+                 ^^^^^^^^^^^^^^^^^
+          end
   - name: BreakNode
     child_nodes:
       - name: arguments
@@ -1064,13 +1072,9 @@ nodes:
         kind: ScopeNode
       - name: opening
         type: token
-      - name: lparen
-        type: token?
       - name: parameters
         type: node?
         kind: BlockParametersNode
-      - name: rparen
-        type: token?
       - name: statements
         type: node?
     comment: |

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -557,18 +557,12 @@ class ErrorsTest < Test::Unit::TestCase
     expected = LambdaNode(
       ScopeNode([IDENTIFIER("a"), IDENTIFIER("b")]),
       MINUS_GREATER("->"),
-      PARENTHESIS_LEFT("("),
       BlockParametersNode(
-        ParametersNode([RequiredParameterNode(), RequiredParameterNode()],
-                       [],
-                       [],
-                       nil,
-                       [],
-                       nil,
-                       nil
-                      ),
-        []),
-      PARENTHESIS_RIGHT(")"),
+        ParametersNode([RequiredParameterNode(), RequiredParameterNode()], [], [], nil, [], nil, nil),
+        [],
+        Location(),
+        Location()
+      ),
       nil
     )
     assert_errors expected, "-> (a, b, ) {}", [

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -73,8 +73,13 @@ module YARP
     end
 
     test "BlockParametersNode" do
-      assert_location(BlockParametersNode, "foo { |bar| baz }", 7...10) { |node| node.block.parameters }
-      assert_location(BlockParametersNode, "foo { |bar; baz| baz }", 7...15) { |node| node.block.parameters }
+      assert_location(BlockParametersNode, "foo { || }", 6...8) { |node| node.block.parameters }
+      assert_location(BlockParametersNode, "foo { |bar| baz }", 6...11) { |node| node.block.parameters }
+      assert_location(BlockParametersNode, "foo { |bar; baz| baz }", 6...16) { |node| node.block.parameters }
+
+      assert_location(BlockParametersNode, "-> () {}", 3...5, &:parameters)
+      assert_location(BlockParametersNode, "-> (bar) { baz }", 3...8, &:parameters)
+      assert_location(BlockParametersNode, "-> (bar; baz) { baz }", 3...13, &:parameters)
     end
 
     test "BreakNode" do

--- a/test/snapshots/blocks.rb
+++ b/test/snapshots/blocks.rb
@@ -115,7 +115,7 @@ ProgramNode(0...402)(
          ScopeNode(51...52)(
            [IDENTIFIER(54...55)("x"), IDENTIFIER(57...61)("memo")]
          ),
-         BlockParametersNode(54...61)(
+         BlockParametersNode(53...62)(
            ParametersNode(54...61)(
              [RequiredParameterNode(54...55)(),
               RequiredParameterNode(57...61)()],
@@ -126,7 +126,9 @@ ProgramNode(0...402)(
              nil,
              nil
            ),
-           []
+           [],
+           (53...54),
+           (61...62)
          ),
          StatementsNode(63...72)(
            [OperatorAssignmentNode(63...72)(
@@ -273,7 +275,7 @@ ProgramNode(0...402)(
        nil,
        BlockNode(151...168)(
          ScopeNode(151...153)([IDENTIFIER(155...156)("a")]),
-         BlockParametersNode(155...163)(
+         BlockParametersNode(154...164)(
            ParametersNode(155...163)(
              [],
              [OptionalParameterNode(155...163)(
@@ -305,7 +307,9 @@ ProgramNode(0...402)(
              nil,
              nil
            ),
-           []
+           [],
+           (154...155),
+           (163...164)
          ),
          nil,
          (151...153),
@@ -453,7 +457,7 @@ ProgramNode(0...402)(
             IDENTIFIER(263...264)("y"),
             LABEL(270...271)("z")]
          ),
-         BlockParametersNode(260...272)(
+         BlockParametersNode(259...273)(
            ParametersNode(260...272)(
              [RequiredParameterNode(260...261)()],
              [OptionalParameterNode(263...268)(
@@ -467,7 +471,9 @@ ProgramNode(0...402)(
              nil,
              nil
            ),
-           []
+           [],
+           (259...260),
+           (272...273)
          ),
          StatementsNode(274...275)([LocalVariableReadNode(274...275)(0)]),
          (257...258),
@@ -484,7 +490,7 @@ ProgramNode(0...402)(
        nil,
        BlockNode(283...290)(
          ScopeNode(283...284)([IDENTIFIER(286...287)("x")]),
-         BlockParametersNode(286...287)(
+         BlockParametersNode(285...288)(
            ParametersNode(286...287)(
              [RequiredParameterNode(286...287)()],
              [],
@@ -494,7 +500,9 @@ ProgramNode(0...402)(
              nil,
              nil
            ),
-           []
+           [],
+           (285...286),
+           (287...288)
          ),
          nil,
          (283...284),
@@ -517,7 +525,7 @@ ProgramNode(0...402)(
        nil,
        BlockNode(306...316)(
          ScopeNode(306...308)([IDENTIFIER(310...311)("a")]),
-         BlockParametersNode(310...311)(
+         BlockParametersNode(309...312)(
            ParametersNode(310...311)(
              [RequiredParameterNode(310...311)()],
              [],
@@ -527,7 +535,9 @@ ProgramNode(0...402)(
              nil,
              nil
            ),
-           []
+           [],
+           (309...310),
+           (311...312)
          ),
          nil,
          (306...308),
@@ -544,7 +554,7 @@ ProgramNode(0...402)(
        nil,
        BlockNode(323...330)(
          ScopeNode(323...324)([IDENTIFIER(326...327)("a")]),
-         BlockParametersNode(326...327)(
+         BlockParametersNode(325...328)(
            ParametersNode(326...327)(
              [RequiredParameterNode(326...327)()],
              [],
@@ -554,7 +564,9 @@ ProgramNode(0...402)(
              nil,
              nil
            ),
-           []
+           [],
+           (325...326),
+           (327...328)
          ),
          nil,
          (323...324),
@@ -611,7 +623,7 @@ ProgramNode(0...402)(
               ScopeNode(359...360)(
                 [LABEL(365...366)("a"), LABEL(373...374)("b")]
               ),
-              BlockParametersNode(365...377)(
+              BlockParametersNode(361...381)(
                 ParametersNode(365...377)(
                   [],
                   [],
@@ -628,7 +640,9 @@ ProgramNode(0...402)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (361...362),
+                (380...381)
               ),
               nil,
               (359...360),
@@ -650,7 +664,7 @@ ProgramNode(0...402)(
        nil,
        BlockNode(389...402)(
          ScopeNode(389...391)([IDENTIFIER(393...396)("bar")]),
-         BlockParametersNode(393...397)(
+         BlockParametersNode(392...398)(
            ParametersNode(393...397)(
              [RequiredParameterNode(393...396)()],
              [],
@@ -660,7 +674,9 @@ ProgramNode(0...402)(
              nil,
              nil
            ),
-           []
+           [],
+           (392...393),
+           (397...398)
          ),
          nil,
          (389...391),

--- a/test/snapshots/break.rb
+++ b/test/snapshots/break.rb
@@ -122,7 +122,7 @@ ProgramNode(0...168)(
          nil,
          BlockNode(149...162)(
            ScopeNode(149...150)([IDENTIFIER(152...153)("a")]),
-           BlockParametersNode(152...153)(
+           BlockParametersNode(151...154)(
              ParametersNode(152...153)(
                [RequiredParameterNode(152...153)()],
                [],
@@ -132,7 +132,9 @@ ProgramNode(0...168)(
                nil,
                nil
              ),
-             []
+             [],
+             (151...152),
+             (153...154)
            ),
            StatementsNode(155...160)([BreakNode(155...160)(nil, (155...160))]),
            (149...150),

--- a/test/snapshots/lambda.rb
+++ b/test/snapshots/lambda.rb
@@ -4,8 +4,7 @@ ProgramNode(0...30)(
     [LambdaNode(0...11)(
        ScopeNode(0...2)([IDENTIFIER(6...9)("foo")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       BlockParametersNode(6...9)(
+       BlockParametersNode(2...11)(
          ParametersNode(6...9)(
            [RequiredParameterNode(6...9)()],
            [],
@@ -15,16 +14,16 @@ ProgramNode(0...30)(
            nil,
            nil
          ),
-         []
+         [],
+         (2...3),
+         (10...11)
        ),
-       PARENTHESIS_RIGHT(10...11)(")"),
        nil
      ),
      LambdaNode(16...30)(
        ScopeNode(16...18)([LABEL(19...20)("x")]),
        MINUS_GREATER(16...18)("->"),
-       PARENTHESIS_LEFT(18...19)("("),
-       BlockParametersNode(19...29)(
+       BlockParametersNode(18...30)(
          ParametersNode(19...29)(
            [],
            [],
@@ -62,9 +61,10 @@ ProgramNode(0...30)(
            nil,
            nil
          ),
-         []
+         [],
+         (18...19),
+         (29...30)
        ),
-       PARENTHESIS_RIGHT(29...30)(")"),
        nil
      )]
   )

--- a/test/snapshots/method_calls.rb
+++ b/test/snapshots/method_calls.rb
@@ -834,7 +834,7 @@ ProgramNode(0...960)(
          ScopeNode(401...403)(
            [IDENTIFIER(405...406)("a"), IDENTIFIER(408...409)("b")]
          ),
-         BlockParametersNode(405...409)(
+         BlockParametersNode(404...410)(
            ParametersNode(405...409)(
              [RequiredParameterNode(405...406)(),
               RequiredParameterNode(408...409)()],
@@ -845,7 +845,9 @@ ProgramNode(0...960)(
              nil,
              nil
            ),
-           []
+           [],
+           (404...405),
+           (409...410)
          ),
          StatementsNode(411...415)(
            [CallNode(411...415)(

--- a/test/snapshots/patterns.rb
+++ b/test/snapshots/patterns.rb
@@ -455,8 +455,6 @@ ProgramNode(0...3655)(
          ScopeNode(343...345)([]),
          MINUS_GREATER(343...345)("->"),
          nil,
-         nil,
-         nil,
          StatementsNode(348...351)([LocalVariableReadNode(348...351)(1)])
        ),
        (340...342)
@@ -1079,15 +1077,11 @@ ProgramNode(0...3655)(
            ScopeNode(916...918)([]),
            MINUS_GREATER(916...918)("->"),
            nil,
-           nil,
-           nil,
            StatementsNode(921...924)([LocalVariableReadNode(921...924)(1)])
          ),
          LambdaNode(930...938)(
            ScopeNode(930...932)([]),
            MINUS_GREATER(930...932)("->"),
-           nil,
-           nil,
            nil,
            StatementsNode(935...938)([LocalVariableReadNode(935...938)(1)])
          ),
@@ -2413,8 +2407,6 @@ ProgramNode(0...3655)(
          ScopeNode(1973...1975)([]),
          MINUS_GREATER(1973...1975)("->"),
          nil,
-         nil,
-         nil,
          StatementsNode(1978...1981)([LocalVariableReadNode(1978...1981)(1)])
        ),
        (1970...1972)
@@ -3044,8 +3036,6 @@ ProgramNode(0...3655)(
           LambdaNode(2709...2717)(
             ScopeNode(2709...2711)([]),
             MINUS_GREATER(2709...2711)("->"),
-            nil,
-            nil,
             nil,
             StatementsNode(2714...2717)(
               [LocalVariableReadNode(2714...2717)(1)]
@@ -3866,8 +3856,6 @@ ProgramNode(0...3655)(
               [LambdaNode(3629...3637)(
                  ScopeNode(3629...3631)([]),
                  MINUS_GREATER(3629...3631)("->"),
-                 nil,
-                 nil,
                  nil,
                  StatementsNode(3634...3637)(
                    [LocalVariableReadNode(3634...3637)(1)]

--- a/test/snapshots/procs.rb
+++ b/test/snapshots/procs.rb
@@ -9,8 +9,7 @@ ProgramNode(0...262)(
           IDENTIFIER(13...14)("d")]
        ),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(3...4)("("),
-       BlockParametersNode(4...14)(
+       BlockParametersNode(3...15)(
          ParametersNode(4...5)(
            [RequiredParameterNode(4...5)()],
            [],
@@ -22,16 +21,15 @@ ProgramNode(0...262)(
          ),
          [IDENTIFIER(7...8)("b"),
           IDENTIFIER(10...11)("c"),
-          IDENTIFIER(13...14)("d")]
+          IDENTIFIER(13...14)("d")],
+         (3...4),
+         (14...15)
        ),
-       PARENTHESIS_RIGHT(14...15)(")"),
        StatementsNode(18...19)([LocalVariableReadNode(18...19)(0)])
      ),
      LambdaNode(23...39)(
        ScopeNode(23...25)([]),
        MINUS_GREATER(23...25)("->"),
-       nil,
-       nil,
        nil,
        BeginNode(0...39)(
          nil,
@@ -49,8 +47,6 @@ ProgramNode(0...262)(
      LambdaNode(41...69)(
        ScopeNode(41...43)([]),
        MINUS_GREATER(41...43)("->"),
-       nil,
-       nil,
        nil,
        BeginNode(0...69)(
          nil,
@@ -80,8 +76,6 @@ ProgramNode(0...262)(
        ScopeNode(71...73)([]),
        MINUS_GREATER(71...73)("->"),
        nil,
-       nil,
-       nil,
        StatementsNode(76...79)(
          [CallNode(76...79)(
             nil,
@@ -98,8 +92,6 @@ ProgramNode(0...262)(
      LambdaNode(83...93)(
        ScopeNode(83...85)([]),
        MINUS_GREATER(83...85)("->"),
-       nil,
-       nil,
        nil,
        StatementsNode(90...93)(
          [CallNode(90...93)(
@@ -123,7 +115,6 @@ ProgramNode(0...262)(
           IDENTIFIER(122...123)("e")]
        ),
        MINUS_GREATER(100...102)("->"),
-       nil,
        BlockParametersNode(103...123)(
          ParametersNode(103...123)(
            [RequiredParameterNode(103...104)()],
@@ -142,9 +133,10 @@ ProgramNode(0...262)(
              (121...122)
            )
          ),
-         []
+         [],
+         nil,
+         nil
        ),
-       nil,
        StatementsNode(126...127)([LocalVariableReadNode(126...127)(0)])
      ),
      LambdaNode(131...169)(
@@ -158,8 +150,7 @@ ProgramNode(0...262)(
           IDENTIFIER(163...164)("g")]
        ),
        MINUS_GREATER(131...133)("->"),
-       PARENTHESIS_LEFT(134...135)("("),
-       BlockParametersNode(135...164)(
+       BlockParametersNode(134...165)(
          ParametersNode(135...164)(
            [RequiredParameterNode(135...136)()],
            [OptionalParameterNode(138...143)(
@@ -183,9 +174,10 @@ ProgramNode(0...262)(
              (162...163)
            )
          ),
-         []
+         [],
+         (134...135),
+         (164...165)
        ),
-       PARENTHESIS_RIGHT(164...165)(")"),
        StatementsNode(168...169)([LocalVariableReadNode(168...169)(0)])
      ),
      LambdaNode(173...214)(
@@ -199,8 +191,7 @@ ProgramNode(0...262)(
           IDENTIFIER(205...206)("g")]
        ),
        MINUS_GREATER(173...175)("->"),
-       PARENTHESIS_LEFT(176...177)("("),
-       BlockParametersNode(177...206)(
+       BlockParametersNode(176...207)(
          ParametersNode(177...206)(
            [RequiredParameterNode(177...178)()],
            [OptionalParameterNode(180...185)(
@@ -224,16 +215,16 @@ ProgramNode(0...262)(
              (204...205)
            )
          ),
-         []
+         [],
+         (176...177),
+         (206...207)
        ),
-       PARENTHESIS_RIGHT(206...207)(")"),
        StatementsNode(213...214)([LocalVariableReadNode(213...214)(0)])
      ),
      LambdaNode(220...241)(
        ScopeNode(220...222)([IDENTIFIER(224...225)("a")]),
        MINUS_GREATER(220...222)("->"),
-       PARENTHESIS_LEFT(223...224)("("),
-       BlockParametersNode(224...225)(
+       BlockParametersNode(223...226)(
          ParametersNode(224...225)(
            [RequiredParameterNode(224...225)()],
            [],
@@ -243,14 +234,14 @@ ProgramNode(0...262)(
            nil,
            nil
          ),
-         []
+         [],
+         (223...224),
+         (225...226)
        ),
-       PARENTHESIS_RIGHT(225...226)(")"),
        StatementsNode(229...241)(
          [LambdaNode(229...241)(
             ScopeNode(229...231)([IDENTIFIER(232...233)("b")]),
             MINUS_GREATER(229...231)("->"),
-            nil,
             BlockParametersNode(232...233)(
               ParametersNode(232...233)(
                 [RequiredParameterNode(232...233)()],
@@ -261,9 +252,10 @@ ProgramNode(0...262)(
                 nil,
                 nil
               ),
-              []
+              [],
+              nil,
+              nil
             ),
-            nil,
             StatementsNode(236...241)(
               [CallNode(236...241)(
                  LocalVariableReadNode(236...237)(1),
@@ -288,8 +280,7 @@ ProgramNode(0...262)(
           IDENTIFIER(260...261)("c")]
        ),
        MINUS_GREATER(247...249)("->"),
-       PARENTHESIS_LEFT(250...251)("("),
-       BlockParametersNode(251...261)(
+       BlockParametersNode(250...262)(
          ParametersNode(251...261)(
            [RequiredDestructuredParameterNode(251...257)(
               [RequiredParameterNode(252...253)(),
@@ -307,9 +298,10 @@ ProgramNode(0...262)(
            nil,
            nil
          ),
-         []
+         [],
+         (250...251),
+         (261...262)
        ),
-       PARENTHESIS_RIGHT(261...262)(")"),
        nil
      )]
   )

--- a/test/snapshots/rescue.rb
+++ b/test/snapshots/rescue.rb
@@ -133,7 +133,7 @@ ProgramNode(0...212)(
        nil,
        BlockNode(161...212)(
          ScopeNode(161...163)([IDENTIFIER(165...166)("x")]),
-         BlockParametersNode(165...166)(
+         BlockParametersNode(164...167)(
            ParametersNode(165...166)(
              [RequiredParameterNode(165...166)()],
              [],
@@ -143,7 +143,9 @@ ProgramNode(0...212)(
              nil,
              nil
            ),
-           []
+           [],
+           (164...165),
+           (166...167)
          ),
          StatementsNode(170...0)(
            [RescueModifierNode(170...0)(

--- a/test/snapshots/seattlerb/block_arg_kwsplat.rb
+++ b/test/snapshots/seattlerb/block_arg_kwsplat.rb
@@ -10,7 +10,7 @@ ProgramNode(0...11)(
        nil,
        BlockNode(2...11)(
          ScopeNode(2...3)([IDENTIFIER(7...8)("b")]),
-         BlockParametersNode(5...8)(
+         BlockParametersNode(4...9)(
            ParametersNode(5...8)(
              [],
              [],
@@ -23,7 +23,9 @@ ProgramNode(0...11)(
              ),
              nil
            ),
-           []
+           [],
+           (4...5),
+           (8...9)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_arg_opt_arg_block.rb
+++ b/test/snapshots/seattlerb/block_arg_opt_arg_block.rb
@@ -15,7 +15,7 @@ ProgramNode(0...21)(
             IDENTIFIER(13...14)("d"),
             IDENTIFIER(17...18)("e")]
          ),
-         BlockParametersNode(5...18)(
+         BlockParametersNode(4...19)(
            ParametersNode(5...18)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...11)(
@@ -29,7 +29,9 @@ ProgramNode(0...21)(
              nil,
              BlockParameterNode(16...18)(IDENTIFIER(17...18)("e"), (16...17))
            ),
-           []
+           [],
+           (4...5),
+           (18...19)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_arg_opt_splat.rb
+++ b/test/snapshots/seattlerb/block_arg_opt_splat.rb
@@ -14,7 +14,7 @@ ProgramNode(0...20)(
             IDENTIFIER(8...9)("c"),
             IDENTIFIER(16...17)("d")]
          ),
-         BlockParametersNode(5...17)(
+         BlockParametersNode(4...18)(
            ParametersNode(5...17)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...13)(
@@ -31,7 +31,9 @@ ProgramNode(0...20)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (17...18)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_arg_opt_splat_arg_block_omfg.rb
+++ b/test/snapshots/seattlerb/block_arg_opt_splat_arg_block_omfg.rb
@@ -16,7 +16,7 @@ ProgramNode(0...25)(
             IDENTIFIER(17...18)("e"),
             IDENTIFIER(21...22)("f")]
          ),
-         BlockParametersNode(5...22)(
+         BlockParametersNode(4...23)(
            ParametersNode(5...22)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...11)(
@@ -33,7 +33,9 @@ ProgramNode(0...25)(
              nil,
              BlockParameterNode(20...22)(IDENTIFIER(21...22)("f"), (20...21))
            ),
-           []
+           [],
+           (4...5),
+           (22...23)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_arg_optional.rb
+++ b/test/snapshots/seattlerb/block_arg_optional.rb
@@ -10,7 +10,7 @@ ProgramNode(0...13)(
        nil,
        BlockNode(2...13)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("b")]),
-         BlockParametersNode(5...10)(
+         BlockParametersNode(4...11)(
            ParametersNode(5...10)(
              [],
              [OptionalParameterNode(5...10)(
@@ -24,7 +24,9 @@ ProgramNode(0...13)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (10...11)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_arg_scope.rb
+++ b/test/snapshots/seattlerb/block_arg_scope.rb
@@ -10,7 +10,7 @@ ProgramNode(0...12)(
        nil,
        BlockNode(2...12)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("b"), IDENTIFIER(8...9)("c")]),
-         BlockParametersNode(5...9)(
+         BlockParametersNode(4...10)(
            ParametersNode(5...6)(
              [RequiredParameterNode(5...6)()],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...12)(
              nil,
              nil
            ),
-           [IDENTIFIER(8...9)("c")]
+           [IDENTIFIER(8...9)("c")],
+           (4...5),
+           (9...10)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_arg_scope2.rb
+++ b/test/snapshots/seattlerb/block_arg_scope2.rb
@@ -14,7 +14,7 @@ ProgramNode(0...14)(
             IDENTIFIER(7...8)("c"),
             IDENTIFIER(10...11)("d")]
          ),
-         BlockParametersNode(4...11)(
+         BlockParametersNode(3...12)(
            ParametersNode(4...5)(
              [RequiredParameterNode(4...5)()],
              [],
@@ -24,7 +24,9 @@ ProgramNode(0...14)(
              nil,
              nil
            ),
-           [IDENTIFIER(7...8)("c"), IDENTIFIER(10...11)("d")]
+           [IDENTIFIER(7...8)("c"), IDENTIFIER(10...11)("d")],
+           (3...4),
+           (11...12)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_arg_splat_arg.rb
+++ b/test/snapshots/seattlerb/block_arg_splat_arg.rb
@@ -14,7 +14,7 @@ ProgramNode(0...16)(
             IDENTIFIER(9...10)("c"),
             IDENTIFIER(12...13)("d")]
          ),
-         BlockParametersNode(5...13)(
+         BlockParametersNode(4...14)(
            ParametersNode(5...13)(
              [RequiredParameterNode(5...6)()],
              [],
@@ -27,7 +27,9 @@ ProgramNode(0...16)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (13...14)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_args_kwargs.rb
+++ b/test/snapshots/seattlerb/block_args_kwargs.rb
@@ -10,7 +10,7 @@ ProgramNode(0...23)(
        nil,
        BlockNode(2...23)(
          ScopeNode(2...3)([IDENTIFIER(7...13)("kwargs")]),
-         BlockParametersNode(5...13)(
+         BlockParametersNode(4...14)(
            ParametersNode(5...13)(
              [],
              [],
@@ -23,7 +23,9 @@ ProgramNode(0...23)(
              ),
              nil
            ),
-           []
+           [],
+           (4...5),
+           (13...14)
          ),
          StatementsNode(15...21)([LocalVariableReadNode(15...21)(0)]),
          (2...3),

--- a/test/snapshots/seattlerb/block_args_no_kwargs.rb
+++ b/test/snapshots/seattlerb/block_args_no_kwargs.rb
@@ -10,7 +10,7 @@ ProgramNode(0...13)(
        nil,
        BlockNode(2...13)(
          ScopeNode(2...3)([]),
-         BlockParametersNode(5...10)(
+         BlockParametersNode(4...11)(
            ParametersNode(5...10)(
              [],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...13)(
              NoKeywordsParameterNode(5...10)((5...7), (7...10)),
              nil
            ),
-           []
+           [],
+           (4...5),
+           (10...11)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_args_opt1.rb
+++ b/test/snapshots/seattlerb/block_args_opt1.rb
@@ -10,7 +10,7 @@ ProgramNode(0...24)(
        nil,
        BlockNode(2...24)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(8...9)("b")]),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -24,7 +24,9 @@ ProgramNode(0...24)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          StatementsNode(16...22)(
            [ArrayNode(16...22)(

--- a/test/snapshots/seattlerb/block_args_opt2.rb
+++ b/test/snapshots/seattlerb/block_args_opt2.rb
@@ -10,7 +10,7 @@ ProgramNode(0...18)(
        nil,
        BlockNode(2...18)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("b"), IDENTIFIER(11...12)("c")]),
-         BlockParametersNode(6...14)(
+         BlockParametersNode(4...16)(
            ParametersNode(6...14)(
              [],
              [OptionalParameterNode(6...9)(
@@ -29,7 +29,9 @@ ProgramNode(0...18)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (15...16)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_args_opt2_2.rb
+++ b/test/snapshots/seattlerb/block_args_opt2_2.rb
@@ -14,7 +14,7 @@ ProgramNode(0...35)(
             IDENTIFIER(8...9)("b"),
             IDENTIFIER(16...17)("c")]
          ),
-         BlockParametersNode(5...22)(
+         BlockParametersNode(4...23)(
            ParametersNode(5...22)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -33,7 +33,9 @@ ProgramNode(0...35)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (22...23)
          ),
          StatementsNode(24...33)(
            [ArrayNode(24...33)(

--- a/test/snapshots/seattlerb/block_args_opt3.rb
+++ b/test/snapshots/seattlerb/block_args_opt3.rb
@@ -15,7 +15,7 @@ ProgramNode(0...42)(
             IDENTIFIER(16...17)("c"),
             IDENTIFIER(25...26)("d")]
          ),
-         BlockParametersNode(5...26)(
+         BlockParametersNode(4...27)(
            ParametersNode(5...26)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -34,7 +34,9 @@ ProgramNode(0...42)(
              nil,
              BlockParameterNode(24...26)(IDENTIFIER(25...26)("d"), (24...25))
            ),
-           []
+           [],
+           (4...5),
+           (26...27)
          ),
          StatementsNode(28...40)(
            [ArrayNode(28...40)(

--- a/test/snapshots/seattlerb/block_break.rb
+++ b/test/snapshots/seattlerb/block_break.rb
@@ -23,7 +23,7 @@ ProgramNode(0...26)(
             nil,
             BlockNode(14...26)(
               ScopeNode(14...16)([IDENTIFIER(18...21)("bar")]),
-              BlockParametersNode(18...21)(
+              BlockParametersNode(17...22)(
                 ParametersNode(18...21)(
                   [RequiredParameterNode(18...21)()],
                   [],
@@ -33,7 +33,9 @@ ProgramNode(0...26)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (17...18),
+                (21...22)
               ),
               nil,
               (14...16),

--- a/test/snapshots/seattlerb/block_call_dot_op2_brace_block.rb
+++ b/test/snapshots/seattlerb/block_call_dot_op2_brace_block.rb
@@ -56,7 +56,7 @@ ProgramNode(0...31)(
        nil,
        BlockNode(19...31)(
          ScopeNode(19...21)([IDENTIFIER(23...24)("f")]),
-         BlockParametersNode(23...24)(
+         BlockParametersNode(22...25)(
            ParametersNode(23...24)(
              [RequiredParameterNode(23...24)()],
              [],
@@ -66,7 +66,9 @@ ProgramNode(0...31)(
              nil,
              nil
            ),
-           []
+           [],
+           (22...23),
+           (24...25)
          ),
          StatementsNode(26...27)(
            [CallNode(26...27)(

--- a/test/snapshots/seattlerb/block_call_dot_op2_cmd_args_do_block.rb
+++ b/test/snapshots/seattlerb/block_call_dot_op2_cmd_args_do_block.rb
@@ -67,7 +67,7 @@ ProgramNode(0...33)(
        nil,
        BlockNode(21...33)(
          ScopeNode(21...23)([IDENTIFIER(25...26)("g")]),
-         BlockParametersNode(25...26)(
+         BlockParametersNode(24...27)(
            ParametersNode(25...26)(
              [RequiredParameterNode(25...26)()],
              [],
@@ -77,7 +77,9 @@ ProgramNode(0...33)(
              nil,
              nil
            ),
-           []
+           [],
+           (24...25),
+           (26...27)
          ),
          StatementsNode(28...29)(
            [CallNode(28...29)(

--- a/test/snapshots/seattlerb/block_decomp_anon_splat_arg.rb
+++ b/test/snapshots/seattlerb/block_decomp_anon_splat_arg.rb
@@ -10,7 +10,7 @@ ProgramNode(0...14)(
        nil,
        BlockNode(2...14)(
          ScopeNode(2...3)([IDENTIFIER(9...10)("a")]),
-         BlockParametersNode(5...11)(
+         BlockParametersNode(4...12)(
            ParametersNode(5...11)(
              [RequiredDestructuredParameterNode(5...11)(
                 [SplatNode(6...7)(USTAR(6...7)("*"), nil),
@@ -25,7 +25,9 @@ ProgramNode(0...14)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (11...12)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_decomp_arg_splat.rb
+++ b/test/snapshots/seattlerb/block_decomp_arg_splat.rb
@@ -10,7 +10,7 @@ ProgramNode(0...14)(
        nil,
        BlockNode(2...14)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("b")]),
-         BlockParametersNode(5...11)(
+         BlockParametersNode(4...12)(
            ParametersNode(5...11)(
              [RequiredDestructuredParameterNode(5...11)(
                 [RequiredParameterNode(6...7)(),
@@ -25,7 +25,9 @@ ProgramNode(0...14)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (11...12)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_decomp_arg_splat_arg.rb
+++ b/test/snapshots/seattlerb/block_decomp_arg_splat_arg.rb
@@ -14,7 +14,7 @@ ProgramNode(0...18)(
             IDENTIFIER(10...11)("b"),
             IDENTIFIER(13...14)("c")]
          ),
-         BlockParametersNode(5...15)(
+         BlockParametersNode(4...16)(
            ParametersNode(5...15)(
              [RequiredDestructuredParameterNode(5...15)(
                 [RequiredParameterNode(6...7)(),
@@ -33,7 +33,9 @@ ProgramNode(0...18)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (15...16)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_decomp_splat.rb
+++ b/test/snapshots/seattlerb/block_decomp_splat.rb
@@ -10,7 +10,7 @@ ProgramNode(0...12)(
        nil,
        BlockNode(2...12)(
          ScopeNode(2...3)([IDENTIFIER(7...8)("a")]),
-         BlockParametersNode(5...9)(
+         BlockParametersNode(4...10)(
            ParametersNode(5...9)(
              [RequiredDestructuredParameterNode(5...9)(
                 [SplatNode(6...8)(
@@ -27,7 +27,9 @@ ProgramNode(0...12)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (9...10)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_kw.rb
+++ b/test/snapshots/seattlerb/block_kw.rb
@@ -10,7 +10,7 @@ ProgramNode(0...15)(
        nil,
        BlockNode(5...15)(
          ScopeNode(5...6)([LABEL(8...9)("k")]),
-         BlockParametersNode(8...12)(
+         BlockParametersNode(7...13)(
            ParametersNode(8...12)(
              [],
              [],
@@ -23,7 +23,9 @@ ProgramNode(0...15)(
              nil,
              nil
            ),
-           []
+           [],
+           (7...8),
+           (12...13)
          ),
          nil,
          (5...6),

--- a/test/snapshots/seattlerb/block_kw__required.rb
+++ b/test/snapshots/seattlerb/block_kw__required.rb
@@ -10,7 +10,7 @@ ProgramNode(0...16)(
        nil,
        BlockNode(5...16)(
          ScopeNode(5...7)([LABEL(9...10)("k")]),
-         BlockParametersNode(9...11)(
+         BlockParametersNode(8...12)(
            ParametersNode(9...11)(
              [],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...16)(
              nil,
              nil
            ),
-           []
+           [],
+           (8...9),
+           (11...12)
          ),
          nil,
          (5...7),

--- a/test/snapshots/seattlerb/block_kwarg_lvar.rb
+++ b/test/snapshots/seattlerb/block_kwarg_lvar.rb
@@ -10,7 +10,7 @@ ProgramNode(0...20)(
        nil,
        BlockNode(3...20)(
          ScopeNode(3...4)([LABEL(6...8)("kw")]),
-         BlockParametersNode(6...14)(
+         BlockParametersNode(5...15)(
            ParametersNode(6...14)(
              [],
              [],
@@ -28,7 +28,9 @@ ProgramNode(0...20)(
              nil,
              nil
            ),
-           []
+           [],
+           (5...6),
+           (14...15)
          ),
          StatementsNode(16...18)([LocalVariableReadNode(16...18)(0)]),
          (3...4),

--- a/test/snapshots/seattlerb/block_kwarg_lvar_multiple.rb
+++ b/test/snapshots/seattlerb/block_kwarg_lvar_multiple.rb
@@ -10,7 +10,7 @@ ProgramNode(0...33)(
        nil,
        BlockNode(3...33)(
          ScopeNode(3...4)([LABEL(6...8)("kw"), LABEL(16...19)("kw2")]),
-         BlockParametersNode(6...26)(
+         BlockParametersNode(5...28)(
            ParametersNode(6...26)(
              [],
              [],
@@ -37,7 +37,9 @@ ProgramNode(0...33)(
              nil,
              nil
            ),
-           []
+           [],
+           (5...6),
+           (27...28)
          ),
          StatementsNode(29...31)([LocalVariableReadNode(29...31)(0)]),
          (3...4),

--- a/test/snapshots/seattlerb/block_next.rb
+++ b/test/snapshots/seattlerb/block_next.rb
@@ -23,7 +23,7 @@ ProgramNode(0...25)(
             nil,
             BlockNode(13...25)(
               ScopeNode(13...15)([IDENTIFIER(17...20)("bar")]),
-              BlockParametersNode(17...20)(
+              BlockParametersNode(16...21)(
                 ParametersNode(17...20)(
                   [RequiredParameterNode(17...20)()],
                   [],
@@ -33,7 +33,9 @@ ProgramNode(0...25)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (16...17),
+                (20...21)
               ),
               nil,
               (13...15),

--- a/test/snapshots/seattlerb/block_opt_arg.rb
+++ b/test/snapshots/seattlerb/block_opt_arg.rb
@@ -10,7 +10,7 @@ ProgramNode(0...14)(
        nil,
        BlockNode(2...14)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("b"), IDENTIFIER(10...11)("c")]),
-         BlockParametersNode(5...11)(
+         BlockParametersNode(4...12)(
            ParametersNode(5...11)(
              [],
              [OptionalParameterNode(5...8)(
@@ -24,7 +24,9 @@ ProgramNode(0...14)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (11...12)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_opt_splat.rb
+++ b/test/snapshots/seattlerb/block_opt_splat.rb
@@ -10,7 +10,7 @@ ProgramNode(0...17)(
        nil,
        BlockNode(2...17)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("b"), IDENTIFIER(13...14)("c")]),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [],
              [OptionalParameterNode(5...10)(
@@ -27,7 +27,9 @@ ProgramNode(0...17)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_opt_splat_arg_block_omfg.rb
+++ b/test/snapshots/seattlerb/block_opt_splat_arg_block_omfg.rb
@@ -15,7 +15,7 @@ ProgramNode(0...22)(
             IDENTIFIER(14...15)("d"),
             IDENTIFIER(18...19)("e")]
          ),
-         BlockParametersNode(5...19)(
+         BlockParametersNode(4...20)(
            ParametersNode(5...19)(
              [],
              [OptionalParameterNode(5...8)(
@@ -32,7 +32,9 @@ ProgramNode(0...22)(
              nil,
              BlockParameterNode(17...19)(IDENTIFIER(18...19)("e"), (17...18))
            ),
-           []
+           [],
+           (4...5),
+           (19...20)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_optarg.rb
+++ b/test/snapshots/seattlerb/block_optarg.rb
@@ -10,7 +10,7 @@ ProgramNode(0...14)(
        nil,
        BlockNode(2...14)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("b")]),
-         BlockParametersNode(5...11)(
+         BlockParametersNode(4...12)(
            ParametersNode(5...11)(
              [],
              [OptionalParameterNode(5...11)(
@@ -29,7 +29,9 @@ ProgramNode(0...14)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (11...12)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_paren_splat.rb
+++ b/test/snapshots/seattlerb/block_paren_splat.rb
@@ -10,7 +10,7 @@ ProgramNode(0...15)(
        nil,
        BlockNode(2...15)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("b"), IDENTIFIER(10...11)("c")]),
-         BlockParametersNode(5...12)(
+         BlockParametersNode(4...13)(
            ParametersNode(5...12)(
              [RequiredDestructuredParameterNode(5...12)(
                 [RequiredParameterNode(6...7)(),
@@ -28,7 +28,9 @@ ProgramNode(0...15)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (12...13)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_reg_optarg.rb
+++ b/test/snapshots/seattlerb/block_reg_optarg.rb
@@ -10,7 +10,7 @@ ProgramNode(0...17)(
        nil,
        BlockNode(2...17)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("b"), IDENTIFIER(8...9)("c")]),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -29,7 +29,9 @@ ProgramNode(0...17)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/block_return.rb
+++ b/test/snapshots/seattlerb/block_return.rb
@@ -24,7 +24,7 @@ ProgramNode(0...27)(
             nil,
             BlockNode(15...27)(
               ScopeNode(15...17)([IDENTIFIER(19...22)("bar")]),
-              BlockParametersNode(19...22)(
+              BlockParametersNode(18...23)(
                 ParametersNode(19...22)(
                   [RequiredParameterNode(19...22)()],
                   [],
@@ -34,7 +34,9 @@ ProgramNode(0...27)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (18...19),
+                (22...23)
               ),
               nil,
               (15...17),

--- a/test/snapshots/seattlerb/block_scope.rb
+++ b/test/snapshots/seattlerb/block_scope.rb
@@ -10,7 +10,12 @@ ProgramNode(0...10)(
        nil,
        BlockNode(2...10)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("b")]),
-         BlockParametersNode(0...7)(nil, [IDENTIFIER(6...7)("b")]),
+         BlockParametersNode(4...8)(
+           nil,
+           [IDENTIFIER(6...7)("b")],
+           (4...5),
+           (7...8)
+         ),
          nil,
          (2...3),
          (9...10)

--- a/test/snapshots/seattlerb/block_splat_reg.rb
+++ b/test/snapshots/seattlerb/block_splat_reg.rb
@@ -10,7 +10,7 @@ ProgramNode(0...13)(
        nil,
        BlockNode(2...13)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("b"), IDENTIFIER(9...10)("c")]),
-         BlockParametersNode(5...10)(
+         BlockParametersNode(4...11)(
            ParametersNode(5...10)(
              [],
              [],
@@ -23,7 +23,9 @@ ProgramNode(0...13)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (10...11)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/bug236.rb
+++ b/test/snapshots/seattlerb/bug236.rb
@@ -10,7 +10,7 @@ ProgramNode(0...15)(
        nil,
        BlockNode(1...7)(
          ScopeNode(1...2)([IDENTIFIER(3...4)("a")]),
-         BlockParametersNode(3...5)(
+         BlockParametersNode(2...6)(
            ParametersNode(3...5)(
              [RequiredParameterNode(3...4)()],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...15)(
              nil,
              nil
            ),
-           []
+           [],
+           (2...3),
+           (5...6)
          ),
          nil,
          (1...2),
@@ -37,7 +39,7 @@ ProgramNode(0...15)(
        nil,
        BlockNode(10...15)(
          ScopeNode(10...11)([IDENTIFIER(12...13)("a")]),
-         BlockParametersNode(12...13)(
+         BlockParametersNode(11...14)(
            ParametersNode(12...13)(
              [RequiredParameterNode(12...13)()],
              [],
@@ -47,7 +49,9 @@ ProgramNode(0...15)(
              nil,
              nil
            ),
-           []
+           [],
+           (11...12),
+           (13...14)
          ),
          nil,
          (10...11),

--- a/test/snapshots/seattlerb/bug_args__19.rb
+++ b/test/snapshots/seattlerb/bug_args__19.rb
@@ -10,7 +10,7 @@ ProgramNode(0...16)(
        nil,
        BlockNode(2...16)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("a"), IDENTIFIER(9...10)("b")]),
-         BlockParametersNode(5...11)(
+         BlockParametersNode(4...12)(
            ParametersNode(5...11)(
              [RequiredDestructuredParameterNode(5...11)(
                 [RequiredParameterNode(6...7)(),
@@ -25,7 +25,9 @@ ProgramNode(0...16)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (11...12)
          ),
          StatementsNode(13...14)(
            [CallNode(13...14)(

--- a/test/snapshots/seattlerb/bug_args_masgn.rb
+++ b/test/snapshots/seattlerb/bug_args_masgn.rb
@@ -14,7 +14,7 @@ ProgramNode(0...17)(
             IDENTIFIER(9...10)("b"),
             IDENTIFIER(13...14)("c")]
          ),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [RequiredDestructuredParameterNode(5...11)(
                 [RequiredParameterNode(6...7)(),
@@ -30,7 +30,9 @@ ProgramNode(0...17)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/bug_args_masgn2.rb
+++ b/test/snapshots/seattlerb/bug_args_masgn2.rb
@@ -15,7 +15,7 @@ ProgramNode(0...22)(
             IDENTIFIER(14...15)("c"),
             IDENTIFIER(18...19)("d")]
          ),
-         BlockParametersNode(5...19)(
+         BlockParametersNode(4...20)(
            ParametersNode(5...19)(
              [RequiredDestructuredParameterNode(5...16)(
                 [RequiredDestructuredParameterNode(6...12)(
@@ -36,7 +36,9 @@ ProgramNode(0...22)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (19...20)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/bug_args_masgn_outer_parens__19.rb
+++ b/test/snapshots/seattlerb/bug_args_masgn_outer_parens__19.rb
@@ -14,7 +14,7 @@ ProgramNode(0...19)(
             IDENTIFIER(10...11)("v"),
             IDENTIFIER(14...15)("i")]
          ),
-         BlockParametersNode(5...16)(
+         BlockParametersNode(4...17)(
            ParametersNode(5...16)(
              [RequiredDestructuredParameterNode(5...16)(
                 [RequiredDestructuredParameterNode(6...12)(
@@ -34,7 +34,9 @@ ProgramNode(0...19)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (16...17)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/bug_masgn_right.rb
+++ b/test/snapshots/seattlerb/bug_masgn_right.rb
@@ -14,7 +14,7 @@ ProgramNode(0...17)(
             IDENTIFIER(9...10)("b"),
             IDENTIFIER(12...13)("c")]
          ),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...14)(
@@ -30,7 +30,9 @@ ProgramNode(0...17)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/call_array_lambda_block_call.rb
+++ b/test/snapshots/seattlerb/call_array_lambda_block_call.rb
@@ -11,9 +11,7 @@ ProgramNode(0...18)(
             [LambdaNode(3...7)(
                ScopeNode(3...5)([]),
                MINUS_GREATER(3...5)("->"),
-               PARENTHESIS_LEFT(5...6)("("),
-               nil,
-               PARENTHESIS_RIGHT(6...7)(")"),
+               BlockParametersNode(5...7)(nil, [], (5...6), (6...7)),
                nil
              )],
             BRACKET_LEFT_ARRAY(2...3)("["),

--- a/test/snapshots/seattlerb/call_stabby_do_end_with_block.rb
+++ b/test/snapshots/seattlerb/call_stabby_do_end_with_block.rb
@@ -11,8 +11,6 @@ ProgramNode(0...22)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
             nil,
-            nil,
-            nil,
             StatementsNode(8...9)([IntegerNode(8...9)()])
           )]
        ),

--- a/test/snapshots/seattlerb/call_stabby_with_braces_block.rb
+++ b/test/snapshots/seattlerb/call_stabby_with_braces_block.rb
@@ -11,8 +11,6 @@ ProgramNode(0...19)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
             nil,
-            nil,
-            nil,
             StatementsNode(7...8)([IntegerNode(7...8)()])
           )]
        ),

--- a/test/snapshots/seattlerb/case_in.rb
+++ b/test/snapshots/seattlerb/case_in.rb
@@ -444,8 +444,7 @@ ProgramNode(0...747)(
             [LambdaNode(446...458)(
                ScopeNode(446...448)([IDENTIFIER(449...450)("b")]),
                MINUS_GREATER(446...448)("->"),
-               PARENTHESIS_LEFT(448...449)("("),
-               BlockParametersNode(449...450)(
+               BlockParametersNode(448...451)(
                  ParametersNode(449...450)(
                    [RequiredParameterNode(449...450)()],
                    [],
@@ -455,9 +454,10 @@ ProgramNode(0...747)(
                    nil,
                    nil
                  ),
-                 []
+                 [],
+                 (448...449),
+                 (450...451)
                ),
-               PARENTHESIS_RIGHT(450...451)(")"),
                StatementsNode(454...458)([TrueNode(454...458)()])
              ),
              LocalVariableWriteNode(462...463)((462...463), nil, nil, 0)],

--- a/test/snapshots/seattlerb/do_bug.rb
+++ b/test/snapshots/seattlerb/do_bug.rb
@@ -29,7 +29,7 @@ ProgramNode(0...33)(
        nil,
        BlockNode(8...33)(
          ScopeNode(8...10)([IDENTIFIER(12...13)("c")]),
-         BlockParametersNode(12...13)(
+         BlockParametersNode(11...14)(
            ParametersNode(12...13)(
              [RequiredParameterNode(12...13)()],
              [],
@@ -39,7 +39,9 @@ ProgramNode(0...33)(
              nil,
              nil
            ),
-           []
+           [],
+           (11...12),
+           (13...14)
          ),
          nil,
          (8...10),

--- a/test/snapshots/seattlerb/do_lambda.rb
+++ b/test/snapshots/seattlerb/do_lambda.rb
@@ -4,9 +4,7 @@ ProgramNode(0...4)(
     [LambdaNode(0...4)(
        ScopeNode(0...2)([]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       nil,
-       PARENTHESIS_RIGHT(3...4)(")"),
+       BlockParametersNode(2...4)(nil, [], (2...3), (3...4)),
        nil
      )]
   )

--- a/test/snapshots/seattlerb/iter_args_1.rb
+++ b/test/snapshots/seattlerb/iter_args_1.rb
@@ -10,7 +10,7 @@ ProgramNode(0...11)(
        nil,
        BlockNode(2...11)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(7...8)("b")]),
-         BlockParametersNode(5...8)(
+         BlockParametersNode(4...9)(
            ParametersNode(5...8)(
              [RequiredParameterNode(5...6)(), RequiredParameterNode(7...8)()],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...11)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (8...9)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_10_1.rb
+++ b/test/snapshots/seattlerb/iter_args_10_1.rb
@@ -14,7 +14,7 @@ ProgramNode(0...21)(
             IDENTIFIER(8...9)("b"),
             IDENTIFIER(17...18)("c")]
          ),
-         BlockParametersNode(5...18)(
+         BlockParametersNode(4...19)(
            ParametersNode(5...18)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -31,7 +31,9 @@ ProgramNode(0...21)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (18...19)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_10_2.rb
+++ b/test/snapshots/seattlerb/iter_args_10_2.rb
@@ -15,7 +15,7 @@ ProgramNode(0...25)(
             IDENTIFIER(17...18)("c"),
             IDENTIFIER(21...22)("d")]
          ),
-         BlockParametersNode(5...22)(
+         BlockParametersNode(4...23)(
            ParametersNode(5...22)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -32,7 +32,9 @@ ProgramNode(0...25)(
              nil,
              BlockParameterNode(20...22)(IDENTIFIER(21...22)("d"), (20...21))
            ),
-           []
+           [],
+           (4...5),
+           (22...23)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_11_1.rb
+++ b/test/snapshots/seattlerb/iter_args_11_1.rb
@@ -15,7 +15,7 @@ ProgramNode(0...24)(
             IDENTIFIER(17...18)("c"),
             IDENTIFIER(20...21)("d")]
          ),
-         BlockParametersNode(5...21)(
+         BlockParametersNode(4...22)(
            ParametersNode(5...21)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -32,7 +32,9 @@ ProgramNode(0...24)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (21...22)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_11_2.rb
+++ b/test/snapshots/seattlerb/iter_args_11_2.rb
@@ -16,7 +16,7 @@ ProgramNode(0...28)(
             IDENTIFIER(20...21)("d"),
             IDENTIFIER(24...25)("e")]
          ),
-         BlockParametersNode(5...25)(
+         BlockParametersNode(4...26)(
            ParametersNode(5...25)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...14)(
@@ -33,7 +33,9 @@ ProgramNode(0...28)(
              nil,
              BlockParameterNode(23...25)(IDENTIFIER(24...25)("e"), (23...24))
            ),
-           []
+           [],
+           (4...5),
+           (25...26)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_2__19.rb
+++ b/test/snapshots/seattlerb/iter_args_2__19.rb
@@ -10,7 +10,7 @@ ProgramNode(0...14)(
        nil,
        BlockNode(2...14)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("a"), IDENTIFIER(9...10)("b")]),
-         BlockParametersNode(5...11)(
+         BlockParametersNode(4...12)(
            ParametersNode(5...11)(
              [RequiredDestructuredParameterNode(5...11)(
                 [RequiredParameterNode(6...7)(),
@@ -25,7 +25,9 @@ ProgramNode(0...14)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (11...12)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_3.rb
+++ b/test/snapshots/seattlerb/iter_args_3.rb
@@ -15,7 +15,7 @@ ProgramNode(0...20)(
             IDENTIFIER(12...13)("c"),
             IDENTIFIER(16...17)("d")]
          ),
-         BlockParametersNode(5...17)(
+         BlockParametersNode(4...18)(
            ParametersNode(5...17)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...14)(
@@ -32,7 +32,9 @@ ProgramNode(0...20)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (17...18)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_4.rb
+++ b/test/snapshots/seattlerb/iter_args_4.rb
@@ -14,7 +14,7 @@ ProgramNode(0...16)(
             IDENTIFIER(9...10)("b"),
             IDENTIFIER(12...13)("c")]
          ),
-         BlockParametersNode(5...13)(
+         BlockParametersNode(4...14)(
            ParametersNode(5...13)(
              [RequiredParameterNode(5...6)()],
              [],
@@ -27,7 +27,9 @@ ProgramNode(0...16)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (13...14)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_5.rb
+++ b/test/snapshots/seattlerb/iter_args_5.rb
@@ -10,7 +10,7 @@ ProgramNode(0...13)(
        nil,
        BlockNode(2...13)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(9...10)("b")]),
-         BlockParametersNode(5...10)(
+         BlockParametersNode(4...11)(
            ParametersNode(5...10)(
              [RequiredParameterNode(5...6)()],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...13)(
              nil,
              BlockParameterNode(8...10)(IDENTIFIER(9...10)("b"), (8...9))
            ),
-           []
+           [],
+           (4...5),
+           (10...11)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_6.rb
+++ b/test/snapshots/seattlerb/iter_args_6.rb
@@ -14,7 +14,7 @@ ProgramNode(0...18)(
             IDENTIFIER(8...9)("b"),
             IDENTIFIER(14...15)("c")]
          ),
-         BlockParametersNode(5...15)(
+         BlockParametersNode(4...16)(
            ParametersNode(5...15)(
              [RequiredParameterNode(5...6)()],
              [OptionalParameterNode(8...12)(
@@ -28,7 +28,9 @@ ProgramNode(0...18)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (15...16)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_7_1.rb
+++ b/test/snapshots/seattlerb/iter_args_7_1.rb
@@ -10,7 +10,7 @@ ProgramNode(0...18)(
        nil,
        BlockNode(2...18)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(14...15)("b")]),
-         BlockParametersNode(5...15)(
+         BlockParametersNode(4...16)(
            ParametersNode(5...15)(
              [],
              [OptionalParameterNode(5...11)(
@@ -27,7 +27,9 @@ ProgramNode(0...18)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (15...16)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_7_2.rb
+++ b/test/snapshots/seattlerb/iter_args_7_2.rb
@@ -14,7 +14,7 @@ ProgramNode(0...22)(
             IDENTIFIER(14...15)("b"),
             IDENTIFIER(18...19)("c")]
          ),
-         BlockParametersNode(5...19)(
+         BlockParametersNode(4...20)(
            ParametersNode(5...19)(
              [],
              [OptionalParameterNode(5...11)(
@@ -31,7 +31,9 @@ ProgramNode(0...22)(
              nil,
              BlockParameterNode(17...19)(IDENTIFIER(18...19)("c"), (17...18))
            ),
-           []
+           [],
+           (4...5),
+           (19...20)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_8_1.rb
+++ b/test/snapshots/seattlerb/iter_args_8_1.rb
@@ -14,7 +14,7 @@ ProgramNode(0...21)(
             IDENTIFIER(14...15)("b"),
             IDENTIFIER(17...18)("c")]
          ),
-         BlockParametersNode(5...18)(
+         BlockParametersNode(4...19)(
            ParametersNode(5...18)(
              [],
              [OptionalParameterNode(5...11)(
@@ -31,7 +31,9 @@ ProgramNode(0...21)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (18...19)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_8_2.rb
+++ b/test/snapshots/seattlerb/iter_args_8_2.rb
@@ -15,7 +15,7 @@ ProgramNode(0...25)(
             IDENTIFIER(17...18)("c"),
             IDENTIFIER(21...22)("d")]
          ),
-         BlockParametersNode(5...22)(
+         BlockParametersNode(4...23)(
            ParametersNode(5...22)(
              [],
              [OptionalParameterNode(5...11)(
@@ -32,7 +32,9 @@ ProgramNode(0...25)(
              nil,
              BlockParameterNode(20...22)(IDENTIFIER(21...22)("d"), (20...21))
            ),
-           []
+           [],
+           (4...5),
+           (22...23)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_9_1.rb
+++ b/test/snapshots/seattlerb/iter_args_9_1.rb
@@ -10,7 +10,7 @@ ProgramNode(0...17)(
        nil,
        BlockNode(2...17)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(13...14)("b")]),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [],
              [OptionalParameterNode(5...11)(
@@ -24,7 +24,9 @@ ProgramNode(0...17)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_args_9_2.rb
+++ b/test/snapshots/seattlerb/iter_args_9_2.rb
@@ -14,7 +14,7 @@ ProgramNode(0...21)(
             IDENTIFIER(13...14)("b"),
             IDENTIFIER(17...18)("c")]
          ),
-         BlockParametersNode(5...18)(
+         BlockParametersNode(4...19)(
            ParametersNode(5...18)(
              [],
              [OptionalParameterNode(5...11)(
@@ -28,7 +28,9 @@ ProgramNode(0...21)(
              nil,
              BlockParameterNode(16...18)(IDENTIFIER(17...18)("c"), (16...17))
            ),
-           []
+           [],
+           (4...5),
+           (18...19)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_kwarg.rb
+++ b/test/snapshots/seattlerb/iter_kwarg.rb
@@ -10,7 +10,7 @@ ProgramNode(0...12)(
        nil,
        BlockNode(2...12)(
          ScopeNode(2...3)([LABEL(5...6)("b")]),
-         BlockParametersNode(5...9)(
+         BlockParametersNode(4...10)(
            ParametersNode(5...9)(
              [],
              [],
@@ -23,7 +23,9 @@ ProgramNode(0...12)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (9...10)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/iter_kwarg_kwsplat.rb
+++ b/test/snapshots/seattlerb/iter_kwarg_kwsplat.rb
@@ -10,7 +10,7 @@ ProgramNode(0...17)(
        nil,
        BlockNode(2...17)(
          ScopeNode(2...3)([LABEL(5...6)("b"), IDENTIFIER(13...14)("c")]),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [],
              [],
@@ -26,7 +26,9 @@ ProgramNode(0...17)(
              ),
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me.rb
+++ b/test/snapshots/seattlerb/kill_me.rb
@@ -14,7 +14,7 @@ ProgramNode(0...18)(
             IDENTIFIER(9...10)("b"),
             IDENTIFIER(13...14)("c")]
          ),
-         BlockParametersNode(5...15)(
+         BlockParametersNode(4...16)(
            ParametersNode(5...15)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...15)(
@@ -33,7 +33,9 @@ ProgramNode(0...18)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (15...16)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me2.rb
+++ b/test/snapshots/seattlerb/kill_me2.rb
@@ -10,7 +10,7 @@ ProgramNode(0...13)(
        nil,
        BlockNode(2...13)(
          ScopeNode(2...3)([IDENTIFIER(6...7)("a"), IDENTIFIER(9...10)("b")]),
-         BlockParametersNode(5...10)(
+         BlockParametersNode(4...11)(
            ParametersNode(5...10)(
              [],
              [],
@@ -23,7 +23,9 @@ ProgramNode(0...13)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (10...11)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me3.rb
+++ b/test/snapshots/seattlerb/kill_me3.rb
@@ -14,7 +14,7 @@ ProgramNode(0...17)(
             IDENTIFIER(9...10)("b"),
             IDENTIFIER(13...14)("c")]
          ),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [],
              [],
@@ -27,7 +27,9 @@ ProgramNode(0...17)(
              nil,
              BlockParameterNode(12...14)(IDENTIFIER(13...14)("c"), (12...13))
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me5.rb
+++ b/test/snapshots/seattlerb/kill_me5.rb
@@ -10,9 +10,7 @@ ProgramNode(0...1)(
          [LambdaNode(2...17)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
-            PARENTHESIS_LEFT(4...5)("("),
-            nil,
-            PARENTHESIS_RIGHT(5...6)(")"),
+            BlockParametersNode(4...6)(nil, [], (4...5), (5...6)),
             StatementsNode(9...17)(
               [CallNode(9...17)(
                  nil,

--- a/test/snapshots/seattlerb/kill_me_10.rb
+++ b/test/snapshots/seattlerb/kill_me_10.rb
@@ -14,7 +14,7 @@ ProgramNode(0...18)(
             IDENTIFIER(10...11)("b"),
             IDENTIFIER(13...14)("c")]
          ),
-         BlockParametersNode(5...15)(
+         BlockParametersNode(4...16)(
            ParametersNode(5...15)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...15)(
@@ -33,7 +33,9 @@ ProgramNode(0...18)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (15...16)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me_11.rb
+++ b/test/snapshots/seattlerb/kill_me_11.rb
@@ -10,7 +10,7 @@ ProgramNode(0...14)(
        nil,
        BlockNode(2...14)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a")]),
-         BlockParametersNode(5...11)(
+         BlockParametersNode(4...12)(
            ParametersNode(5...11)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...11)(
@@ -25,7 +25,9 @@ ProgramNode(0...14)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (11...12)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me_12.rb
+++ b/test/snapshots/seattlerb/kill_me_12.rb
@@ -10,7 +10,7 @@ ProgramNode(0...17)(
        nil,
        BlockNode(2...17)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(12...13)("b")]),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...14)(
@@ -26,7 +26,9 @@ ProgramNode(0...17)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me_6.rb
+++ b/test/snapshots/seattlerb/kill_me_6.rb
@@ -15,7 +15,7 @@ ProgramNode(0...21)(
             IDENTIFIER(13...14)("c"),
             IDENTIFIER(16...17)("d")]
          ),
-         BlockParametersNode(5...18)(
+         BlockParametersNode(4...19)(
            ParametersNode(5...18)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...18)(
@@ -35,7 +35,9 @@ ProgramNode(0...21)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (18...19)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me_7.rb
+++ b/test/snapshots/seattlerb/kill_me_7.rb
@@ -10,7 +10,7 @@ ProgramNode(0...17)(
        nil,
        BlockNode(2...17)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(9...10)("b")]),
-         BlockParametersNode(5...14)(
+         BlockParametersNode(4...15)(
            ParametersNode(5...14)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...14)(
@@ -26,7 +26,9 @@ ProgramNode(0...17)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (14...15)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me_8.rb
+++ b/test/snapshots/seattlerb/kill_me_8.rb
@@ -14,7 +14,7 @@ ProgramNode(0...20)(
             IDENTIFIER(9...10)("b"),
             IDENTIFIER(15...16)("c")]
          ),
-         BlockParametersNode(5...17)(
+         BlockParametersNode(4...18)(
            ParametersNode(5...17)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...17)(
@@ -31,7 +31,9 @@ ProgramNode(0...20)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (17...18)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/kill_me_9.rb
+++ b/test/snapshots/seattlerb/kill_me_9.rb
@@ -10,7 +10,7 @@ ProgramNode(0...15)(
        nil,
        BlockNode(2...15)(
          ScopeNode(2...3)([IDENTIFIER(5...6)("a"), IDENTIFIER(10...11)("b")]),
-         BlockParametersNode(5...12)(
+         BlockParametersNode(4...13)(
            ParametersNode(5...12)(
              [RequiredParameterNode(5...6)(),
               RequiredDestructuredParameterNode(8...12)(
@@ -28,7 +28,9 @@ ProgramNode(0...15)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (12...13)
          ),
          nil,
          (2...3),

--- a/test/snapshots/seattlerb/lambda_do_vs_brace.rb
+++ b/test/snapshots/seattlerb/lambda_do_vs_brace.rb
@@ -11,8 +11,6 @@ ProgramNode(0...38)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
             nil,
-            nil,
-            nil,
             nil
           )]
        ),
@@ -30,8 +28,6 @@ ProgramNode(0...38)(
             ScopeNode(15...17)([]),
             MINUS_GREATER(15...17)("->"),
             nil,
-            nil,
-            nil,
             nil
           )]
        ),
@@ -48,9 +44,7 @@ ProgramNode(0...38)(
          [LambdaNode(24...28)(
             ScopeNode(24...26)([]),
             MINUS_GREATER(24...26)("->"),
-            PARENTHESIS_LEFT(26...27)("("),
-            nil,
-            PARENTHESIS_RIGHT(27...28)(")"),
+            BlockParametersNode(26...28)(nil, [], (26...27), (27...28)),
             nil
           )]
        ),
@@ -67,9 +61,7 @@ ProgramNode(0...38)(
          [LambdaNode(39...43)(
             ScopeNode(39...41)([]),
             MINUS_GREATER(39...41)("->"),
-            PARENTHESIS_LEFT(41...42)("("),
-            nil,
-            PARENTHESIS_RIGHT(42...43)(")"),
+            BlockParametersNode(41...43)(nil, [], (41...42), (42...43)),
             nil
           )]
        ),

--- a/test/snapshots/seattlerb/parse_line_call_no_args.rb
+++ b/test/snapshots/seattlerb/parse_line_call_no_args.rb
@@ -10,7 +10,7 @@ ProgramNode(0...23)(
        nil,
        BlockNode(2...23)(
          ScopeNode(2...4)([IDENTIFIER(6...7)("x"), IDENTIFIER(9...10)("y")]),
-         BlockParametersNode(6...10)(
+         BlockParametersNode(5...11)(
            ParametersNode(6...10)(
              [RequiredParameterNode(6...7)(), RequiredParameterNode(9...10)()],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...23)(
              nil,
              nil
            ),
-           []
+           [],
+           (5...6),
+           (10...11)
          ),
          StatementsNode(14...19)(
            [CallNode(14...19)(

--- a/test/snapshots/seattlerb/parse_line_iter_call_no_parens.rb
+++ b/test/snapshots/seattlerb/parse_line_iter_call_no_parens.rb
@@ -21,7 +21,7 @@ ProgramNode(0...25)(
        nil,
        BlockNode(4...25)(
          ScopeNode(4...6)([IDENTIFIER(8...9)("x"), IDENTIFIER(11...12)("y")]),
-         BlockParametersNode(8...12)(
+         BlockParametersNode(7...13)(
            ParametersNode(8...12)(
              [RequiredParameterNode(8...9)(),
               RequiredParameterNode(11...12)()],
@@ -32,7 +32,9 @@ ProgramNode(0...25)(
              nil,
              nil
            ),
-           []
+           [],
+           (7...8),
+           (12...13)
          ),
          StatementsNode(16...21)(
            [CallNode(16...21)(

--- a/test/snapshots/seattlerb/parse_line_iter_call_parens.rb
+++ b/test/snapshots/seattlerb/parse_line_iter_call_parens.rb
@@ -21,7 +21,7 @@ ProgramNode(0...26)(
        PARENTHESIS_RIGHT(3...4)(")"),
        BlockNode(5...26)(
          ScopeNode(5...7)([IDENTIFIER(9...10)("x"), IDENTIFIER(12...13)("y")]),
-         BlockParametersNode(9...13)(
+         BlockParametersNode(8...14)(
            ParametersNode(9...13)(
              [RequiredParameterNode(9...10)(),
               RequiredParameterNode(12...13)()],
@@ -32,7 +32,9 @@ ProgramNode(0...26)(
              nil,
              nil
            ),
-           []
+           [],
+           (8...9),
+           (13...14)
          ),
          StatementsNode(17...22)(
            [CallNode(17...22)(

--- a/test/snapshots/seattlerb/pipe_semicolon.rb
+++ b/test/snapshots/seattlerb/pipe_semicolon.rb
@@ -19,7 +19,12 @@ ProgramNode(0...18)(
        nil,
        BlockNode(4...18)(
          ScopeNode(4...6)([IDENTIFIER(11...12)("c")]),
-         BlockParametersNode(0...12)(nil, [IDENTIFIER(11...12)("c")]),
+         BlockParametersNode(7...14)(
+           nil,
+           [IDENTIFIER(11...12)("c")],
+           (7...8),
+           (13...14)
+         ),
          nil,
          (4...6),
          (15...18)

--- a/test/snapshots/seattlerb/pipe_space.rb
+++ b/test/snapshots/seattlerb/pipe_space.rb
@@ -17,7 +17,13 @@ ProgramNode(0...14)(
        nil,
        nil,
        nil,
-       BlockNode(4...14)(ScopeNode(4...6)([]), nil, nil, (4...6), (11...14)),
+       BlockNode(4...14)(
+         ScopeNode(4...6)([]),
+         BlockParametersNode(7...10)(nil, [], (7...8), (9...10)),
+         nil,
+         (4...6),
+         (11...14)
+       ),
        "b"
      )]
   )

--- a/test/snapshots/seattlerb/stabby_arg_no_paren.rb
+++ b/test/snapshots/seattlerb/stabby_arg_no_paren.rb
@@ -1,10 +1,9 @@
-ProgramNode(0...2)(
+ProgramNode(0...3)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...2)(
-    [LambdaNode(0...2)(
+  StatementsNode(0...3)(
+    [LambdaNode(0...3)(
        ScopeNode(0...2)([IDENTIFIER(2...3)("a")]),
        MINUS_GREATER(0...2)("->"),
-       nil,
        BlockParametersNode(2...3)(
          ParametersNode(2...3)(
            [RequiredParameterNode(2...3)()],
@@ -15,9 +14,10 @@ ProgramNode(0...2)(
            nil,
            nil
          ),
-         []
+         [],
+         nil,
+         nil
        ),
-       nil,
        nil
      )]
   )

--- a/test/snapshots/seattlerb/stabby_arg_opt_splat_arg_block_omfg.rb
+++ b/test/snapshots/seattlerb/stabby_arg_opt_splat_arg_block_omfg.rb
@@ -10,8 +10,7 @@ ProgramNode(0...21)(
           IDENTIFIER(19...20)("f")]
        ),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       BlockParametersNode(3...20)(
+       BlockParametersNode(2...21)(
          ParametersNode(3...20)(
            [RequiredParameterNode(3...4)()],
            [OptionalParameterNode(6...9)(
@@ -28,9 +27,10 @@ ProgramNode(0...21)(
            nil,
            BlockParameterNode(18...20)(IDENTIFIER(19...20)("f"), (18...19))
          ),
-         []
+         [],
+         (2...3),
+         (20...21)
        ),
-       PARENTHESIS_RIGHT(20...21)(")"),
        nil
      )]
   )

--- a/test/snapshots/seattlerb/stabby_block_iter_call.rb
+++ b/test/snapshots/seattlerb/stabby_block_iter_call.rb
@@ -10,9 +10,7 @@ ProgramNode(0...1)(
          [LambdaNode(2...21)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
-            PARENTHESIS_LEFT(5...6)("("),
-            nil,
-            PARENTHESIS_RIGHT(6...7)(")"),
+            BlockParametersNode(5...7)(nil, [], (5...6), (6...7)),
             StatementsNode(11...21)(
               [CallNode(11...21)(
                  CallNode(11...12)(

--- a/test/snapshots/seattlerb/stabby_block_iter_call_no_target_with_arg.rb
+++ b/test/snapshots/seattlerb/stabby_block_iter_call_no_target_with_arg.rb
@@ -10,9 +10,7 @@ ProgramNode(0...1)(
          [LambdaNode(2...22)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
-            PARENTHESIS_LEFT(5...6)("("),
-            nil,
-            PARENTHESIS_RIGHT(6...7)(")"),
+            BlockParametersNode(5...7)(nil, [], (5...6), (6...7)),
             StatementsNode(11...22)(
               [CallNode(11...22)(
                  nil,

--- a/test/snapshots/seattlerb/stabby_block_kw.rb
+++ b/test/snapshots/seattlerb/stabby_block_kw.rb
@@ -4,8 +4,7 @@ ProgramNode(0...9)(
     [LambdaNode(0...9)(
        ScopeNode(0...2)([LABEL(4...5)("k")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(3...4)("("),
-       BlockParametersNode(4...8)(
+       BlockParametersNode(3...9)(
          ParametersNode(4...8)(
            [],
            [],
@@ -18,9 +17,10 @@ ProgramNode(0...9)(
            nil,
            nil
          ),
-         []
+         [],
+         (3...4),
+         (8...9)
        ),
-       PARENTHESIS_RIGHT(8...9)(")"),
        nil
      )]
   )

--- a/test/snapshots/seattlerb/stabby_block_kw__required.rb
+++ b/test/snapshots/seattlerb/stabby_block_kw__required.rb
@@ -4,8 +4,7 @@ ProgramNode(0...7)(
     [LambdaNode(0...7)(
        ScopeNode(0...2)([LABEL(4...5)("k")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(3...4)("("),
-       BlockParametersNode(4...6)(
+       BlockParametersNode(3...7)(
          ParametersNode(4...6)(
            [],
            [],
@@ -15,9 +14,10 @@ ProgramNode(0...7)(
            nil,
            nil
          ),
-         []
+         [],
+         (3...4),
+         (6...7)
        ),
-       PARENTHESIS_RIGHT(6...7)(")"),
        nil
      )]
   )

--- a/test/snapshots/seattlerb/stabby_proc_scope.rb
+++ b/test/snapshots/seattlerb/stabby_proc_scope.rb
@@ -4,8 +4,7 @@ ProgramNode(0...8)(
     [LambdaNode(0...8)(
        ScopeNode(0...2)([IDENTIFIER(3...4)("a"), IDENTIFIER(6...7)("b")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       BlockParametersNode(3...7)(
+       BlockParametersNode(2...8)(
          ParametersNode(3...4)(
            [RequiredParameterNode(3...4)()],
            [],
@@ -15,9 +14,10 @@ ProgramNode(0...8)(
            nil,
            nil
          ),
-         [IDENTIFIER(6...7)("b")]
+         [IDENTIFIER(6...7)("b")],
+         (2...3),
+         (7...8)
        ),
-       PARENTHESIS_RIGHT(7...8)(")"),
        nil
      )]
   )

--- a/test/snapshots/seattlerb/wtf.rb
+++ b/test/snapshots/seattlerb/wtf.rb
@@ -4,8 +4,7 @@ ProgramNode(0...16)(
     [LambdaNode(0...16)(
        ScopeNode(0...2)([IDENTIFIER(3...4)("a"), IDENTIFIER(6...7)("b")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       BlockParametersNode(3...11)(
+       BlockParametersNode(2...12)(
          ParametersNode(3...11)(
            [RequiredParameterNode(3...4)()],
            [OptionalParameterNode(6...11)(
@@ -19,9 +18,10 @@ ProgramNode(0...16)(
            nil,
            nil
          ),
-         []
+         [],
+         (2...3),
+         (11...12)
        ),
-       PARENTHESIS_RIGHT(11...12)(")"),
        StatementsNode(15...16)(
          [CallNode(15...16)(
             nil,

--- a/test/snapshots/unparser/corpus/literal/block.rb
+++ b/test/snapshots/unparser/corpus/literal/block.rb
@@ -20,7 +20,7 @@ ProgramNode(0...737)(
        nil,
        BlockNode(12...19)(
          ScopeNode(12...13)([IDENTIFIER(15...16)("a")]),
-         BlockParametersNode(15...16)(
+         BlockParametersNode(14...17)(
            ParametersNode(15...16)(
              [RequiredParameterNode(15...16)()],
              [],
@@ -30,7 +30,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (14...15),
+           (16...17)
          ),
          nil,
          (12...13),
@@ -47,7 +49,7 @@ ProgramNode(0...737)(
        nil,
        BlockNode(24...32)(
          ScopeNode(24...25)([IDENTIFIER(27...28)("a")]),
-         BlockParametersNode(27...29)(
+         BlockParametersNode(26...30)(
            ParametersNode(27...29)(
              [RequiredParameterNode(27...28)()],
              [],
@@ -57,7 +59,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (26...27),
+           (29...30)
          ),
          nil,
          (24...25),
@@ -76,7 +80,7 @@ ProgramNode(0...737)(
          ScopeNode(37...38)(
            [IDENTIFIER(40...41)("a"), IDENTIFIER(44...45)("x")]
          ),
-         BlockParametersNode(40...45)(
+         BlockParametersNode(39...46)(
            ParametersNode(40...42)(
              [RequiredParameterNode(40...41)()],
              [],
@@ -86,7 +90,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           [IDENTIFIER(44...45)("x")]
+           [IDENTIFIER(44...45)("x")],
+           (39...40),
+           (45...46)
          ),
          nil,
          (37...38),
@@ -105,7 +111,7 @@ ProgramNode(0...737)(
          ScopeNode(53...54)(
            [IDENTIFIER(56...57)("a"), IDENTIFIER(59...60)("b")]
          ),
-         BlockParametersNode(56...60)(
+         BlockParametersNode(55...61)(
            ParametersNode(56...60)(
              [RequiredParameterNode(56...57)(),
               RequiredParameterNode(59...60)()],
@@ -116,7 +122,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (55...56),
+           (60...61)
          ),
          nil,
          (53...54),
@@ -151,7 +159,7 @@ ProgramNode(0...737)(
          ScopeNode(85...86)(
            [IDENTIFIER(88...89)("a"), IDENTIFIER(92...93)("b")]
          ),
-         BlockParametersNode(88...93)(
+         BlockParametersNode(87...94)(
            ParametersNode(88...93)(
              [RequiredParameterNode(88...89)()],
              [],
@@ -164,7 +172,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (87...88),
+           (93...94)
          ),
          StatementsNode(97...100)([NilNode(97...100)()]),
          (85...86),
@@ -183,7 +193,7 @@ ProgramNode(0...737)(
          ScopeNode(107...108)(
            [IDENTIFIER(110...111)("a"), USTAR(113...114)("*")]
          ),
-         BlockParametersNode(110...114)(
+         BlockParametersNode(109...115)(
            ParametersNode(110...114)(
              [RequiredParameterNode(110...111)()],
              [],
@@ -193,7 +203,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (109...110),
+           (114...115)
          ),
          StatementsNode(118...121)([NilNode(118...121)()]),
          (107...108),
@@ -250,7 +262,7 @@ ProgramNode(0...737)(
             IDENTIFIER(153...154)("b"),
             IDENTIFIER(157...158)("c")]
          ),
-         BlockParametersNode(149...158)(
+         BlockParametersNode(148...159)(
            ParametersNode(149...158)(
              [RequiredDestructuredParameterNode(149...155)(
                 [RequiredParameterNode(150...151)(),
@@ -266,7 +278,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (148...149),
+           (158...159)
          ),
          StatementsNode(162...163)(
            [CallNode(162...163)(
@@ -305,7 +319,7 @@ ProgramNode(0...737)(
          ScopeNode(174...175)(
            [IDENTIFIER(178...179)("a"), IDENTIFIER(181...182)("b")]
          ),
-         BlockParametersNode(177...182)(
+         BlockParametersNode(176...183)(
            ParametersNode(177...179)(
              [],
              [],
@@ -318,7 +332,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           [IDENTIFIER(181...182)("b")]
+           [IDENTIFIER(181...182)("b")],
+           (176...177),
+           (182...183)
          ),
          nil,
          (174...175),
@@ -346,7 +362,7 @@ ProgramNode(0...737)(
          ScopeNode(194...195)(
            [IDENTIFIER(197...198)("a"), IDENTIFIER(200...201)("b")]
          ),
-         BlockParametersNode(197...201)(
+         BlockParametersNode(196...202)(
            ParametersNode(197...198)(
              [RequiredParameterNode(197...198)()],
              [],
@@ -356,7 +372,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           [IDENTIFIER(200...201)("b")]
+           [IDENTIFIER(200...201)("b")],
+           (196...197),
+           (201...202)
          ),
          nil,
          (194...195),
@@ -384,9 +402,11 @@ ProgramNode(0...737)(
          ScopeNode(213...214)(
            [IDENTIFIER(218...219)("a"), IDENTIFIER(221...222)("b")]
          ),
-         BlockParametersNode(0...222)(
+         BlockParametersNode(215...223)(
            nil,
-           [IDENTIFIER(218...219)("a"), IDENTIFIER(221...222)("b")]
+           [IDENTIFIER(218...219)("a"), IDENTIFIER(221...222)("b")],
+           (215...216),
+           (222...223)
          ),
          nil,
          (213...214),
@@ -412,7 +432,7 @@ ProgramNode(0...737)(
        nil,
        BlockNode(234...245)(
          ScopeNode(234...235)([USTAR(237...238)("*")]),
-         BlockParametersNode(237...238)(
+         BlockParametersNode(236...239)(
            ParametersNode(237...238)(
              [],
              [],
@@ -422,7 +442,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (236...237),
+           (238...239)
          ),
          StatementsNode(242...243)(
            [CallNode(242...243)(
@@ -459,7 +481,7 @@ ProgramNode(0...737)(
        nil,
        BlockNode(254...267)(
          ScopeNode(254...255)([]),
-         BlockParametersNode(257...260)(
+         BlockParametersNode(256...261)(
            ParametersNode(257...260)(
              [RequiredDestructuredParameterNode(257...260)(
                 [SplatNode(258...259)(USTAR(258...259)("*"), nil)],
@@ -473,7 +495,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (256...257),
+           (260...261)
          ),
          StatementsNode(264...265)(
            [CallNode(264...265)(
@@ -510,7 +534,7 @@ ProgramNode(0...737)(
        nil,
        BlockNode(276...291)(
          ScopeNode(276...277)([]),
-         BlockParametersNode(279...284)(
+         BlockParametersNode(278...285)(
            ParametersNode(279...284)(
              [RequiredDestructuredParameterNode(279...284)(
                 [RequiredDestructuredParameterNode(280...283)(
@@ -528,7 +552,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (278...279),
+           (284...285)
          ),
          StatementsNode(288...289)(
            [CallNode(288...289)(
@@ -565,7 +591,7 @@ ProgramNode(0...737)(
        nil,
        BlockNode(300...318)(
          ScopeNode(300...301)([IDENTIFIER(304...305)("a")]),
-         BlockParametersNode(303...311)(
+         BlockParametersNode(302...312)(
            ParametersNode(303...311)(
              [RequiredDestructuredParameterNode(303...311)(
                 [RequiredParameterNode(304...305)(),
@@ -584,7 +610,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (302...303),
+           (311...312)
          ),
          StatementsNode(315...316)(
            [CallNode(315...316)(
@@ -623,7 +651,7 @@ ProgramNode(0...737)(
          ScopeNode(327...328)(
            [IDENTIFIER(331...332)("a"), IDENTIFIER(334...335)("b")]
          ),
-         BlockParametersNode(330...336)(
+         BlockParametersNode(329...337)(
            ParametersNode(330...336)(
              [RequiredDestructuredParameterNode(330...336)(
                 [RequiredParameterNode(331...332)(),
@@ -638,7 +666,9 @@ ProgramNode(0...737)(
              nil,
              nil
            ),
-           []
+           [],
+           (329...330),
+           (336...337)
          ),
          StatementsNode(340...341)(
            [CallNode(340...341)(

--- a/test/snapshots/unparser/corpus/literal/defs.rb
+++ b/test/snapshots/unparser/corpus/literal/defs.rb
@@ -108,7 +108,7 @@ ProgramNode(0...266)(
            nil,
            BlockNode(104...113)(
              ScopeNode(104...105)([IDENTIFIER(107...110)("bar")]),
-             BlockParametersNode(107...110)(
+             BlockParametersNode(106...111)(
                ParametersNode(107...110)(
                  [RequiredParameterNode(107...110)()],
                  [],
@@ -118,7 +118,9 @@ ProgramNode(0...266)(
                  nil,
                  nil
                ),
-               []
+               [],
+               (106...107),
+               (110...111)
              ),
              nil,
              (104...105),

--- a/test/snapshots/unparser/corpus/literal/dstr.rb
+++ b/test/snapshots/unparser/corpus/literal/dstr.rb
@@ -259,7 +259,7 @@ ProgramNode(0...299)(
        PARENTHESIS_RIGHT(273...274)(")"),
        BlockNode(275...299)(
          ScopeNode(275...276)([IDENTIFIER(278...279)("x")]),
-         BlockParametersNode(278...279)(
+         BlockParametersNode(277...280)(
            ParametersNode(278...279)(
              [RequiredParameterNode(278...279)()],
              [],
@@ -269,7 +269,9 @@ ProgramNode(0...299)(
              nil,
              nil
            ),
-           []
+           [],
+           (277...278),
+           (279...280)
          ),
          nil,
          (275...276),

--- a/test/snapshots/unparser/corpus/literal/if.rb
+++ b/test/snapshots/unparser/corpus/literal/if.rb
@@ -179,7 +179,7 @@ ProgramNode(0...242)(
          nil,
          BlockNode(205...222)(
            ScopeNode(205...206)([IDENTIFIER(208...212)("pair")]),
-           BlockParametersNode(208...212)(
+           BlockParametersNode(207...213)(
              ParametersNode(208...212)(
                [RequiredParameterNode(208...212)()],
                [],
@@ -189,7 +189,9 @@ ProgramNode(0...242)(
                nil,
                nil
              ),
-             []
+             [],
+             (207...208),
+             (212...213)
            ),
            StatementsNode(216...220)([LocalVariableReadNode(216...220)(0)]),
            (205...206),

--- a/test/snapshots/unparser/corpus/literal/lambda.rb
+++ b/test/snapshots/unparser/corpus/literal/lambda.rb
@@ -22,7 +22,7 @@ ProgramNode(0...76)(
          ScopeNode(18...19)(
            [IDENTIFIER(21...22)("a"), IDENTIFIER(24...25)("b")]
          ),
-         BlockParametersNode(21...25)(
+         BlockParametersNode(20...26)(
            ParametersNode(21...25)(
              [RequiredParameterNode(21...22)(),
               RequiredParameterNode(24...25)()],
@@ -33,7 +33,9 @@ ProgramNode(0...76)(
              nil,
              nil
            ),
-           []
+           [],
+           (20...21),
+           (25...26)
          ),
          StatementsNode(29...30)([LocalVariableReadNode(29...30)(0)]),
          (18...19),
@@ -44,16 +46,13 @@ ProgramNode(0...76)(
      LambdaNode(33...37)(
        ScopeNode(33...35)([]),
        MINUS_GREATER(33...35)("->"),
-       PARENTHESIS_LEFT(35...36)("("),
-       nil,
-       PARENTHESIS_RIGHT(36...37)(")"),
+       BlockParametersNode(35...37)(nil, [], (35...36), (36...37)),
        nil
      ),
      LambdaNode(42...47)(
        ScopeNode(42...44)([IDENTIFIER(45...46)("a")]),
        MINUS_GREATER(42...44)("->"),
-       PARENTHESIS_LEFT(44...45)("("),
-       BlockParametersNode(45...46)(
+       BlockParametersNode(44...47)(
          ParametersNode(45...46)(
            [RequiredParameterNode(45...46)()],
            [],
@@ -63,9 +62,10 @@ ProgramNode(0...76)(
            nil,
            nil
          ),
-         []
+         [],
+         (44...45),
+         (46...47)
        ),
-       PARENTHESIS_RIGHT(46...47)(")"),
        nil
      ),
      LambdaNode(52...60)(
@@ -73,8 +73,7 @@ ProgramNode(0...76)(
          [IDENTIFIER(55...56)("a"), IDENTIFIER(58...59)("b")]
        ),
        MINUS_GREATER(52...54)("->"),
-       PARENTHESIS_LEFT(54...55)("("),
-       BlockParametersNode(55...59)(
+       BlockParametersNode(54...60)(
          ParametersNode(55...59)(
            [RequiredParameterNode(55...56)(),
             RequiredParameterNode(58...59)()],
@@ -85,9 +84,10 @@ ProgramNode(0...76)(
            nil,
            nil
          ),
-         []
+         [],
+         (54...55),
+         (59...60)
        ),
-       PARENTHESIS_RIGHT(59...60)(")"),
        nil
      ),
      LambdaNode(65...76)(
@@ -97,8 +97,7 @@ ProgramNode(0...76)(
           IDENTIFIER(74...75)("c")]
        ),
        MINUS_GREATER(65...67)("->"),
-       PARENTHESIS_LEFT(67...68)("("),
-       BlockParametersNode(68...75)(
+       BlockParametersNode(67...76)(
          ParametersNode(68...72)(
            [RequiredParameterNode(68...69)(),
             RequiredParameterNode(71...72)()],
@@ -109,9 +108,10 @@ ProgramNode(0...76)(
            nil,
            nil
          ),
-         [IDENTIFIER(74...75)("c")]
+         [IDENTIFIER(74...75)("c")],
+         (67...68),
+         (75...76)
        ),
-       PARENTHESIS_RIGHT(75...76)(")"),
        nil
      )]
   )

--- a/test/snapshots/unparser/corpus/literal/since/27.rb
+++ b/test/snapshots/unparser/corpus/literal/since/27.rb
@@ -5,8 +5,6 @@ ProgramNode(0...22)(
        ScopeNode(0...2)([]),
        MINUS_GREATER(0...2)("->"),
        nil,
-       nil,
-       nil,
        StatementsNode(7...14)(
          [CallNode(7...14)(
             CallNode(7...9)(

--- a/test/snapshots/unparser/corpus/literal/while.rb
+++ b/test/snapshots/unparser/corpus/literal/while.rb
@@ -17,7 +17,7 @@ ProgramNode(0...616)(
               ScopeNode(15...16)(
                 [IDENTIFIER(18...21)("bar"), IDENTIFIER(43...46)("foo")]
               ),
-              BlockParametersNode(18...21)(
+              BlockParametersNode(17...22)(
                 ParametersNode(18...21)(
                   [RequiredParameterNode(18...21)()],
                   [],
@@ -27,7 +27,9 @@ ProgramNode(0...616)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (17...18),
+                (21...22)
               ),
               StatementsNode(27...52)(
                 [WhileNode(27...52)(
@@ -227,7 +229,7 @@ ProgramNode(0...616)(
               ScopeNode(246...247)(
                 [IDENTIFIER(249...252)("baz"), IDENTIFIER(274...277)("foo")]
               ),
-              BlockParametersNode(249...252)(
+              BlockParametersNode(248...253)(
                 ParametersNode(249...252)(
                   [RequiredParameterNode(249...252)()],
                   [],
@@ -237,7 +239,9 @@ ProgramNode(0...616)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (248...249),
+                (252...253)
               ),
               StatementsNode(258...283)(
                 [WhileNode(258...283)(
@@ -293,7 +297,7 @@ ProgramNode(0...616)(
             nil,
             BlockNode(317...366)(
               ScopeNode(317...318)([IDENTIFIER(320...323)("foo")]),
-              BlockParametersNode(320...323)(
+              BlockParametersNode(319...324)(
                 ParametersNode(320...323)(
                   [RequiredParameterNode(320...323)()],
                   [],
@@ -303,7 +307,9 @@ ProgramNode(0...616)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (319...320),
+                (323...324)
               ),
               StatementsNode(329...354)(
                 [WhileNode(329...354)(

--- a/test/snapshots/unparser/corpus/semantic/block.rb
+++ b/test/snapshots/unparser/corpus/semantic/block.rb
@@ -73,7 +73,7 @@ ProgramNode(0...148)(
        nil,
        BlockNode(70...80)(
          ScopeNode(70...72)([IDENTIFIER(74...75)("a")]),
-         BlockParametersNode(74...75)(
+         BlockParametersNode(73...76)(
            ParametersNode(74...75)(
              [RequiredParameterNode(74...75)()],
              [],
@@ -83,7 +83,9 @@ ProgramNode(0...148)(
              nil,
              nil
            ),
-           []
+           [],
+           (73...74),
+           (75...76)
          ),
          nil,
          (70...72),
@@ -112,7 +114,7 @@ ProgramNode(0...148)(
        PARENTHESIS_RIGHT(92...93)(")"),
        BlockNode(94...116)(
          ScopeNode(94...96)([IDENTIFIER(98...99)("a")]),
-         BlockParametersNode(98...99)(
+         BlockParametersNode(97...100)(
            ParametersNode(98...99)(
              [RequiredParameterNode(98...99)()],
              [],
@@ -122,7 +124,9 @@ ProgramNode(0...148)(
              nil,
              nil
            ),
-           []
+           [],
+           (97...98),
+           (99...100)
          ),
          StatementsNode(111...112)([LocalVariableReadNode(111...112)(0)]),
          (94...96),

--- a/test/snapshots/whitequark/arg_label.rb
+++ b/test/snapshots/whitequark/arg_label.rb
@@ -72,7 +72,7 @@ ProgramNode(0...49)(
        nil,
        BlockNode(39...49)(
          ScopeNode(39...40)([]),
-         nil,
+         BlockParametersNode(41...43)(nil, [], (41...42), (42...43)),
          StatementsNode(44...45)(
            [CallNode(44...45)(
               nil,

--- a/test/snapshots/whitequark/arg_scope.rb
+++ b/test/snapshots/whitequark/arg_scope.rb
@@ -10,7 +10,12 @@ ProgramNode(0...13)(
        nil,
        BlockNode(6...13)(
          ScopeNode(6...7)([IDENTIFIER(9...10)("a")]),
-         BlockParametersNode(0...10)(nil, [IDENTIFIER(9...10)("a")]),
+         BlockParametersNode(7...11)(
+           nil,
+           [IDENTIFIER(9...10)("a")],
+           (7...8),
+           (10...11)
+         ),
          StatementsNode(11...12)([LocalVariableReadNode(11...12)(0)]),
          (6...7),
          (12...13)

--- a/test/snapshots/whitequark/blockargs.rb
+++ b/test/snapshots/whitequark/blockargs.rb
@@ -18,7 +18,13 @@ ProgramNode(0...550)(
        nil,
        nil,
        nil,
-       BlockNode(8...15)(ScopeNode(8...9)([]), nil, nil, (8...9), (14...15)),
+       BlockNode(8...15)(
+         ScopeNode(8...9)([]),
+         BlockParametersNode(10...13)(nil, [], (10...11), (12...13)),
+         nil,
+         (8...9),
+         (14...15)
+       ),
        "f"
      ),
      CallNode(17...26)(
@@ -30,7 +36,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(18...26)(
          ScopeNode(18...19)([IDENTIFIER(22...23)("b")]),
-         BlockParametersNode(21...23)(
+         BlockParametersNode(20...24)(
            ParametersNode(21...23)(
              [],
              [],
@@ -40,7 +46,9 @@ ProgramNode(0...550)(
              nil,
              BlockParameterNode(21...23)(IDENTIFIER(22...23)("b"), (21...22))
            ),
-           []
+           [],
+           (20...21),
+           (23...24)
          ),
          nil,
          (18...19),
@@ -59,7 +67,7 @@ ProgramNode(0...550)(
          ScopeNode(29...30)(
            [IDENTIFIER(34...37)("baz"), IDENTIFIER(40...41)("b")]
          ),
-         BlockParametersNode(32...41)(
+         BlockParametersNode(31...42)(
            ParametersNode(32...41)(
              [],
              [],
@@ -72,7 +80,9 @@ ProgramNode(0...550)(
              ),
              BlockParameterNode(39...41)(IDENTIFIER(40...41)("b"), (39...40))
            ),
-           []
+           [],
+           (31...32),
+           (41...42)
          ),
          nil,
          (29...30),
@@ -89,7 +99,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(47...58)(
          ScopeNode(47...48)([USTAR(50...51)("*"), IDENTIFIER(54...55)("b")]),
-         BlockParametersNode(50...55)(
+         BlockParametersNode(49...56)(
            ParametersNode(50...55)(
              [],
              [],
@@ -99,7 +109,9 @@ ProgramNode(0...550)(
              nil,
              BlockParameterNode(53...55)(IDENTIFIER(54...55)("b"), (53...54))
            ),
-           []
+           [],
+           (49...50),
+           (55...56)
          ),
          nil,
          (47...48),
@@ -120,7 +132,7 @@ ProgramNode(0...550)(
             IDENTIFIER(68...69)("p"),
             IDENTIFIER(72...73)("b")]
          ),
-         BlockParametersNode(64...73)(
+         BlockParametersNode(63...74)(
            ParametersNode(64...73)(
              [],
              [],
@@ -133,7 +145,9 @@ ProgramNode(0...550)(
              nil,
              BlockParameterNode(71...73)(IDENTIFIER(72...73)("b"), (71...72))
            ),
-           []
+           [],
+           (63...64),
+           (73...74)
          ),
          nil,
          (61...62),
@@ -152,7 +166,7 @@ ProgramNode(0...550)(
          ScopeNode(79...80)(
            [IDENTIFIER(83...84)("s"), IDENTIFIER(87...88)("b")]
          ),
-         BlockParametersNode(82...88)(
+         BlockParametersNode(81...89)(
            ParametersNode(82...88)(
              [],
              [],
@@ -165,7 +179,9 @@ ProgramNode(0...550)(
              nil,
              BlockParameterNode(86...88)(IDENTIFIER(87...88)("b"), (86...87))
            ),
-           []
+           [],
+           (81...82),
+           (88...89)
          ),
          nil,
          (79...80),
@@ -182,7 +198,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(94...102)(
          ScopeNode(94...95)([IDENTIFIER(98...99)("s")]),
-         BlockParametersNode(97...99)(
+         BlockParametersNode(96...100)(
            ParametersNode(97...99)(
              [],
              [],
@@ -195,7 +211,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (96...97),
+           (99...100)
          ),
          nil,
          (94...95),
@@ -212,7 +230,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(105...112)(
          ScopeNode(105...106)([USTAR(108...109)("*")]),
-         BlockParametersNode(108...109)(
+         BlockParametersNode(107...110)(
            ParametersNode(108...109)(
              [],
              [],
@@ -222,7 +240,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (107...108),
+           (109...110)
          ),
          nil,
          (105...106),
@@ -239,7 +259,12 @@ ProgramNode(0...550)(
        nil,
        BlockNode(115...125)(
          ScopeNode(115...116)([IDENTIFIER(120...121)("a")]),
-         BlockParametersNode(0...121)(nil, [IDENTIFIER(120...121)("a")]),
+         BlockParametersNode(117...123)(
+           nil,
+           [IDENTIFIER(120...121)("a")],
+           (117...118),
+           (122...123)
+         ),
          nil,
          (115...116),
          (124...125)
@@ -255,7 +280,12 @@ ProgramNode(0...550)(
        nil,
        BlockNode(128...136)(
          ScopeNode(128...129)([IDENTIFIER(132...133)("a")]),
-         BlockParametersNode(0...133)(nil, [IDENTIFIER(132...133)("a")]),
+         BlockParametersNode(130...134)(
+           nil,
+           [IDENTIFIER(132...133)("a")],
+           (130...131),
+           (133...134)
+         ),
          nil,
          (128...129),
          (135...136)
@@ -273,7 +303,7 @@ ProgramNode(0...550)(
          ScopeNode(139...140)(
            [IDENTIFIER(142...143)("a"), IDENTIFIER(146...147)("b")]
          ),
-         BlockParametersNode(142...147)(
+         BlockParametersNode(141...148)(
            ParametersNode(142...147)(
              [RequiredParameterNode(142...143)()],
              [],
@@ -286,7 +316,9 @@ ProgramNode(0...550)(
                (145...146)
              )
            ),
-           []
+           [],
+           (141...142),
+           (147...148)
          ),
          nil,
          (139...140),
@@ -307,7 +339,7 @@ ProgramNode(0...550)(
             USTAR(159...160)("*"),
             IDENTIFIER(163...164)("b")]
          ),
-         BlockParametersNode(156...164)(
+         BlockParametersNode(155...165)(
            ParametersNode(156...164)(
              [RequiredParameterNode(156...157)()],
              [],
@@ -320,7 +352,9 @@ ProgramNode(0...550)(
                (162...163)
              )
            ),
-           []
+           [],
+           (155...156),
+           (164...165)
          ),
          nil,
          (153...154),
@@ -342,7 +376,7 @@ ProgramNode(0...550)(
             IDENTIFIER(180...181)("p"),
             IDENTIFIER(184...185)("b")]
          ),
-         BlockParametersNode(173...185)(
+         BlockParametersNode(172...186)(
            ParametersNode(173...185)(
              [RequiredParameterNode(173...174)()],
              [],
@@ -358,7 +392,9 @@ ProgramNode(0...550)(
                (183...184)
              )
            ),
-           []
+           [],
+           (172...173),
+           (185...186)
          ),
          nil,
          (170...171),
@@ -379,7 +415,7 @@ ProgramNode(0...550)(
             IDENTIFIER(198...199)("s"),
             IDENTIFIER(202...203)("b")]
          ),
-         BlockParametersNode(194...203)(
+         BlockParametersNode(193...204)(
            ParametersNode(194...203)(
              [RequiredParameterNode(194...195)()],
              [],
@@ -395,7 +431,9 @@ ProgramNode(0...550)(
                (201...202)
              )
            ),
-           []
+           [],
+           (193...194),
+           (203...204)
          ),
          nil,
          (191...192),
@@ -414,7 +452,7 @@ ProgramNode(0...550)(
          ScopeNode(209...210)(
            [IDENTIFIER(212...213)("a"), IDENTIFIER(216...217)("s")]
          ),
-         BlockParametersNode(212...217)(
+         BlockParametersNode(211...218)(
            ParametersNode(212...217)(
              [RequiredParameterNode(212...213)()],
              [],
@@ -427,7 +465,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (211...212),
+           (217...218)
          ),
          nil,
          (209...210),
@@ -446,7 +486,7 @@ ProgramNode(0...550)(
          ScopeNode(223...224)(
            [IDENTIFIER(226...227)("a"), USTAR(229...230)("*")]
          ),
-         BlockParametersNode(226...230)(
+         BlockParametersNode(225...231)(
            ParametersNode(226...230)(
              [RequiredParameterNode(226...227)()],
              [],
@@ -456,7 +496,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (225...226),
+           (230...231)
          ),
          nil,
          (223...224),
@@ -475,7 +517,7 @@ ProgramNode(0...550)(
          ScopeNode(236...237)(
            [IDENTIFIER(239...240)("a"), IDENTIFIER(242...243)("b")]
          ),
-         BlockParametersNode(239...244)(
+         BlockParametersNode(238...245)(
            ParametersNode(239...244)(
              [RequiredParameterNode(239...240)(),
               RequiredParameterNode(242...243)()],
@@ -486,7 +528,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (238...239),
+           (244...245)
          ),
          nil,
          (236...237),
@@ -505,7 +549,7 @@ ProgramNode(0...550)(
          ScopeNode(250...251)(
            [IDENTIFIER(253...254)("a"), IDENTIFIER(256...257)("c")]
          ),
-         BlockParametersNode(253...257)(
+         BlockParametersNode(252...258)(
            ParametersNode(253...257)(
              [RequiredParameterNode(253...254)(),
               RequiredParameterNode(256...257)()],
@@ -516,7 +560,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (252...253),
+           (257...258)
          ),
          nil,
          (250...251),
@@ -537,7 +583,7 @@ ProgramNode(0...550)(
             IDENTIFIER(269...270)("o"),
             IDENTIFIER(275...276)("b")]
          ),
-         BlockParametersNode(266...276)(
+         BlockParametersNode(265...277)(
            ParametersNode(266...276)(
              [RequiredParameterNode(266...267)()],
              [OptionalParameterNode(269...272)(
@@ -554,7 +600,9 @@ ProgramNode(0...550)(
                (274...275)
              )
            ),
-           []
+           [],
+           (265...266),
+           (276...277)
          ),
          nil,
          (263...264),
@@ -577,7 +625,7 @@ ProgramNode(0...550)(
             IDENTIFIER(297...298)("p"),
             IDENTIFIER(301...302)("b")]
          ),
-         BlockParametersNode(285...302)(
+         BlockParametersNode(284...303)(
            ParametersNode(285...302)(
              [RequiredParameterNode(285...286)()],
              [OptionalParameterNode(288...291)(
@@ -597,7 +645,9 @@ ProgramNode(0...550)(
                (300...301)
              )
            ),
-           []
+           [],
+           (284...285),
+           (302...303)
          ),
          nil,
          (282...283),
@@ -620,7 +670,7 @@ ProgramNode(0...550)(
             IDENTIFIER(326...327)("r"),
             IDENTIFIER(330...331)("b")]
          ),
-         BlockParametersNode(311...331)(
+         BlockParametersNode(310...332)(
            ParametersNode(311...331)(
              [RequiredParameterNode(311...312)()],
              [OptionalParameterNode(314...317)(
@@ -645,7 +695,9 @@ ProgramNode(0...550)(
                (329...330)
              )
            ),
-           []
+           [],
+           (310...311),
+           (331...332)
          ),
          nil,
          (308...309),
@@ -667,7 +719,7 @@ ProgramNode(0...550)(
             IDENTIFIER(348...349)("p"),
             IDENTIFIER(352...353)("b")]
          ),
-         BlockParametersNode(340...353)(
+         BlockParametersNode(339...354)(
            ParametersNode(340...353)(
              [RequiredParameterNode(340...341)()],
              [OptionalParameterNode(343...346)(
@@ -684,7 +736,9 @@ ProgramNode(0...550)(
                (351...352)
              )
            ),
-           []
+           [],
+           (339...340),
+           (353...354)
          ),
          nil,
          (337...338),
@@ -701,7 +755,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(359...367)(
          ScopeNode(359...360)([IDENTIFIER(362...363)("a")]),
-         BlockParametersNode(362...364)(
+         BlockParametersNode(361...365)(
            ParametersNode(362...364)(
              [RequiredParameterNode(362...363)()],
              [],
@@ -711,7 +765,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (361...362),
+           (364...365)
          ),
          nil,
          (359...360),
@@ -728,7 +784,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(370...377)(
          ScopeNode(370...371)([IDENTIFIER(373...374)("a")]),
-         BlockParametersNode(373...374)(
+         BlockParametersNode(372...375)(
            ParametersNode(373...374)(
              [RequiredParameterNode(373...374)()],
              [],
@@ -738,7 +794,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (372...373),
+           (374...375)
          ),
          nil,
          (370...371),
@@ -755,7 +813,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(380...387)(
          ScopeNode(380...381)([IDENTIFIER(383...384)("a")]),
-         BlockParametersNode(383...384)(
+         BlockParametersNode(382...385)(
            ParametersNode(383...384)(
              [RequiredParameterNode(383...384)()],
              [],
@@ -765,7 +823,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (382...383),
+           (384...385)
          ),
          nil,
          (380...381),
@@ -782,7 +842,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(390...397)(
          ScopeNode(390...391)([IDENTIFIER(393...394)("a")]),
-         BlockParametersNode(393...394)(
+         BlockParametersNode(392...395)(
            ParametersNode(393...394)(
              [RequiredParameterNode(393...394)()],
              [],
@@ -792,7 +852,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (392...393),
+           (394...395)
          ),
          nil,
          (390...391),
@@ -811,7 +873,7 @@ ProgramNode(0...550)(
          ScopeNode(400...401)(
            [LABEL(403...406)("foo"), IDENTIFIER(412...413)("b")]
          ),
-         BlockParametersNode(403...413)(
+         BlockParametersNode(402...414)(
            ParametersNode(403...413)(
              [],
              [],
@@ -827,7 +889,9 @@ ProgramNode(0...550)(
                (411...412)
              )
            ),
-           []
+           [],
+           (402...403),
+           (413...414)
          ),
          nil,
          (400...401),
@@ -849,7 +913,7 @@ ProgramNode(0...550)(
             IDENTIFIER(440...443)("baz"),
             IDENTIFIER(446...447)("b")]
          ),
-         BlockParametersNode(422...447)(
+         BlockParametersNode(421...448)(
            ParametersNode(422...447)(
              [],
              [],
@@ -872,7 +936,9 @@ ProgramNode(0...550)(
                (445...446)
              )
            ),
-           []
+           [],
+           (421...422),
+           (447...448)
          ),
          nil,
          (419...420),
@@ -889,7 +955,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(453...463)(
          ScopeNode(453...454)([LABEL(456...459)("foo")]),
-         BlockParametersNode(456...460)(
+         BlockParametersNode(455...461)(
            ParametersNode(456...460)(
              [],
              [],
@@ -899,7 +965,9 @@ ProgramNode(0...550)(
              nil,
              nil
            ),
-           []
+           [],
+           (455...456),
+           (460...461)
          ),
          nil,
          (453...454),
@@ -918,7 +986,7 @@ ProgramNode(0...550)(
          ScopeNode(466...467)(
            [IDENTIFIER(469...470)("o"), IDENTIFIER(475...476)("b")]
          ),
-         BlockParametersNode(469...476)(
+         BlockParametersNode(468...477)(
            ParametersNode(469...476)(
              [],
              [OptionalParameterNode(469...472)(
@@ -935,7 +1003,9 @@ ProgramNode(0...550)(
                (474...475)
              )
            ),
-           []
+           [],
+           (468...469),
+           (476...477)
          ),
          nil,
          (466...467),
@@ -956,7 +1026,7 @@ ProgramNode(0...550)(
             IDENTIFIER(491...492)("r"),
             IDENTIFIER(495...496)("b")]
          ),
-         BlockParametersNode(485...496)(
+         BlockParametersNode(484...497)(
            ParametersNode(485...496)(
              [],
              [OptionalParameterNode(485...488)(
@@ -976,7 +1046,9 @@ ProgramNode(0...550)(
                (494...495)
              )
            ),
-           []
+           [],
+           (484...485),
+           (496...497)
          ),
          nil,
          (482...483),
@@ -998,7 +1070,7 @@ ProgramNode(0...550)(
             IDENTIFIER(514...515)("p"),
             IDENTIFIER(518...519)("b")]
          ),
-         BlockParametersNode(505...519)(
+         BlockParametersNode(504...520)(
            ParametersNode(505...519)(
              [],
              [OptionalParameterNode(505...508)(
@@ -1018,7 +1090,9 @@ ProgramNode(0...550)(
                (517...518)
              )
            ),
-           []
+           [],
+           (504...505),
+           (519...520)
          ),
          nil,
          (502...503),
@@ -1039,7 +1113,7 @@ ProgramNode(0...550)(
             IDENTIFIER(533...534)("p"),
             IDENTIFIER(537...538)("b")]
          ),
-         BlockParametersNode(528...538)(
+         BlockParametersNode(527...539)(
            ParametersNode(528...538)(
              [],
              [OptionalParameterNode(528...531)(
@@ -1056,7 +1130,9 @@ ProgramNode(0...550)(
                (536...537)
              )
            ),
-           []
+           [],
+           (527...528),
+           (538...539)
          ),
          nil,
          (525...526),
@@ -1073,7 +1149,7 @@ ProgramNode(0...550)(
        nil,
        BlockNode(544...550)(
          ScopeNode(544...545)([]),
-         nil,
+         BlockParametersNode(546...548)(nil, [], (546...547), (547...548)),
          nil,
          (544...545),
          (549...550)

--- a/test/snapshots/whitequark/bug_435.rb
+++ b/test/snapshots/whitequark/bug_435.rb
@@ -5,11 +5,10 @@ ProgramNode(0...14)(
        STRING_BEGIN(0...1)("\""),
        [StringInterpolatedNode(1...13)(
           EMBEXPR_BEGIN(1...3)("\#{"),
-          StatementsNode(3...5)(
-            [LambdaNode(3...5)(
+          StatementsNode(3...9)(
+            [LambdaNode(3...9)(
                ScopeNode(3...5)([IDENTIFIER(6...9)("foo")]),
                MINUS_GREATER(3...5)("->"),
-               nil,
                BlockParametersNode(6...9)(
                  ParametersNode(6...9)(
                    [RequiredParameterNode(6...9)()],
@@ -20,9 +19,10 @@ ProgramNode(0...14)(
                    nil,
                    nil
                  ),
-                 []
+                 [],
+                 nil,
+                 nil
                ),
-               nil,
                nil
              )]
           ),

--- a/test/snapshots/whitequark/bug_cmdarg.rb
+++ b/test/snapshots/whitequark/bug_cmdarg.rb
@@ -66,8 +66,6 @@ ProgramNode(0...31)(
                  ScopeNode(35...37)([]),
                  MINUS_GREATER(35...37)("->"),
                  nil,
-                 nil,
-                 nil,
                  StatementsNode(41...52)(
                    [CallNode(41...52)(
                       nil,

--- a/test/snapshots/whitequark/bug_lambda_leakage.rb
+++ b/test/snapshots/whitequark/bug_lambda_leakage.rb
@@ -4,8 +4,7 @@ ProgramNode(0...19)(
     [LambdaNode(0...9)(
        ScopeNode(0...2)([IDENTIFIER(3...8)("scope")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       BlockParametersNode(3...8)(
+       BlockParametersNode(2...9)(
          ParametersNode(3...8)(
            [RequiredParameterNode(3...8)()],
            [],
@@ -15,9 +14,10 @@ ProgramNode(0...19)(
            nil,
            nil
          ),
-         []
+         [],
+         (2...3),
+         (8...9)
        ),
-       PARENTHESIS_RIGHT(8...9)(")"),
        nil
      ),
      CallNode(14...19)(

--- a/test/snapshots/whitequark/kwnilarg.rb
+++ b/test/snapshots/whitequark/kwnilarg.rb
@@ -4,8 +4,7 @@ ProgramNode(0...46)(
     [LambdaNode(0...9)(
        ScopeNode(0...2)([]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       BlockParametersNode(3...8)(
+       BlockParametersNode(2...9)(
          ParametersNode(3...8)(
            [],
            [],
@@ -15,9 +14,10 @@ ProgramNode(0...46)(
            NoKeywordsParameterNode(3...8)((3...5), (5...8)),
            nil
          ),
-         []
+         [],
+         (2...3),
+         (8...9)
        ),
-       PARENTHESIS_RIGHT(8...9)(")"),
        nil
      ),
      DefNode(14...31)(
@@ -50,7 +50,7 @@ ProgramNode(0...46)(
        nil,
        BlockNode(35...46)(
          ScopeNode(35...36)([]),
-         BlockParametersNode(38...43)(
+         BlockParametersNode(37...44)(
            ParametersNode(38...43)(
              [],
              [],
@@ -60,7 +60,9 @@ ProgramNode(0...46)(
              NoKeywordsParameterNode(38...43)((38...40), (40...43)),
              nil
            ),
-           []
+           [],
+           (37...38),
+           (43...44)
          ),
          nil,
          (35...36),

--- a/test/snapshots/whitequark/numbered_args_after_27.rb
+++ b/test/snapshots/whitequark/numbered_args_after_27.rb
@@ -5,8 +5,6 @@ ProgramNode(0...65)(
        ScopeNode(0...2)([]),
        MINUS_GREATER(0...2)("->"),
        nil,
-       nil,
-       nil,
        StatementsNode(6...13)(
          [CallNode(6...13)(
             CallNode(6...8)(
@@ -43,8 +41,6 @@ ProgramNode(0...65)(
      LambdaNode(19...31)(
        ScopeNode(19...21)([]),
        MINUS_GREATER(19...21)("->"),
-       nil,
-       nil,
        nil,
        StatementsNode(24...31)(
          [CallNode(24...31)(

--- a/test/snapshots/whitequark/parser_bug_272.rb
+++ b/test/snapshots/whitequark/parser_bug_272.rb
@@ -10,7 +10,7 @@ ProgramNode(0...15)(
        nil,
        BlockNode(5...15)(
          ScopeNode(5...7)([IDENTIFIER(9...10)("c")]),
-         BlockParametersNode(9...10)(
+         BlockParametersNode(8...11)(
            ParametersNode(9...10)(
              [RequiredParameterNode(9...10)()],
              [],
@@ -20,7 +20,9 @@ ProgramNode(0...15)(
              nil,
              nil
            ),
-           []
+           [],
+           (8...9),
+           (10...11)
          ),
          StatementsNode(0...0)([]),
          (5...7),

--- a/test/snapshots/whitequark/parser_bug_507.rb
+++ b/test/snapshots/whitequark/parser_bug_507.rb
@@ -1,12 +1,11 @@
-ProgramNode(0...6)(
+ProgramNode(0...12)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("m")]),
-  StatementsNode(0...6)(
-    [LocalVariableWriteNode(0...6)(
+  StatementsNode(0...12)(
+    [LocalVariableWriteNode(0...12)(
        (0...1),
-       LambdaNode(4...6)(
+       LambdaNode(4...12)(
          ScopeNode(4...6)([IDENTIFIER(8...12)("args")]),
          MINUS_GREATER(4...6)("->"),
-         nil,
          BlockParametersNode(7...12)(
            ParametersNode(7...12)(
              [],
@@ -20,9 +19,10 @@ ProgramNode(0...6)(
              nil,
              nil
            ),
-           []
+           [],
+           nil,
+           nil
          ),
-         nil,
          nil
        ),
        (2...3),

--- a/test/snapshots/whitequark/parser_bug_645.rb
+++ b/test/snapshots/whitequark/parser_bug_645.rb
@@ -4,8 +4,7 @@ ProgramNode(0...11)(
     [LambdaNode(0...11)(
        ScopeNode(0...2)([IDENTIFIER(4...7)("arg")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(3...4)("("),
-       BlockParametersNode(4...9)(
+       BlockParametersNode(3...11)(
          ParametersNode(4...9)(
            [],
            [OptionalParameterNode(4...9)(
@@ -23,9 +22,10 @@ ProgramNode(0...11)(
            nil,
            nil
          ),
-         []
+         [],
+         (3...4),
+         (10...11)
        ),
-       PARENTHESIS_RIGHT(10...11)(")"),
        nil
      )]
   )

--- a/test/snapshots/whitequark/pattern_match.rb
+++ b/test/snapshots/whitequark/pattern_match.rb
@@ -761,8 +761,6 @@ ProgramNode(0...2908)(
             ScopeNode(896...898)([]),
             MINUS_GREATER(896...898)("->"),
             nil,
-            nil,
-            nil,
             StatementsNode(900...902)([IntegerNode(900...902)()])
           ),
           StatementsNode(910...914)([TrueNode(910...914)()]),

--- a/test/snapshots/whitequark/procarg0.rb
+++ b/test/snapshots/whitequark/procarg0.rb
@@ -12,7 +12,7 @@ ProgramNode(0...32)(
          ScopeNode(2...3)(
            [IDENTIFIER(6...9)("foo"), IDENTIFIER(11...14)("bar")]
          ),
-         BlockParametersNode(5...15)(
+         BlockParametersNode(4...16)(
            ParametersNode(5...15)(
              [RequiredDestructuredParameterNode(5...15)(
                 [RequiredParameterNode(6...9)(),
@@ -27,7 +27,9 @@ ProgramNode(0...32)(
              nil,
              nil
            ),
-           []
+           [],
+           (4...5),
+           (15...16)
          ),
          nil,
          (2...3),
@@ -44,7 +46,7 @@ ProgramNode(0...32)(
        nil,
        BlockNode(23...32)(
          ScopeNode(23...24)([IDENTIFIER(26...29)("foo")]),
-         BlockParametersNode(26...29)(
+         BlockParametersNode(25...30)(
            ParametersNode(26...29)(
              [RequiredParameterNode(26...29)()],
              [],
@@ -54,7 +56,9 @@ ProgramNode(0...32)(
              nil,
              nil
            ),
-           []
+           [],
+           (25...26),
+           (29...30)
          ),
          nil,
          (23...24),

--- a/test/snapshots/whitequark/rescue_in_lambda_block.rb
+++ b/test/snapshots/whitequark/rescue_in_lambda_block.rb
@@ -5,8 +5,6 @@ ProgramNode(0...17)(
        ScopeNode(0...2)([]),
        MINUS_GREATER(0...2)("->"),
        nil,
-       nil,
-       nil,
        BeginNode(0...17)(
          nil,
          nil,

--- a/test/snapshots/whitequark/ruby_bug_10653.rb
+++ b/test/snapshots/whitequark/ruby_bug_10653.rb
@@ -104,7 +104,7 @@ ProgramNode(6...93)(
             nil,
             BlockNode(75...89)(
               ScopeNode(75...77)([IDENTIFIER(79...80)("n")]),
-              BlockParametersNode(79...80)(
+              BlockParametersNode(78...81)(
                 ParametersNode(79...80)(
                   [RequiredParameterNode(79...80)()],
                   [],
@@ -114,7 +114,9 @@ ProgramNode(6...93)(
                   nil,
                   nil
                 ),
-                []
+                [],
+                (78...79),
+                (80...81)
               ),
               StatementsNode(82...83)(
                 [CallNode(82...83)(

--- a/test/snapshots/whitequark/ruby_bug_11107.rb
+++ b/test/snapshots/whitequark/ruby_bug_11107.rb
@@ -10,9 +10,7 @@ ProgramNode(0...1)(
          [LambdaNode(2...20)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
-            PARENTHESIS_LEFT(4...5)("("),
-            nil,
-            PARENTHESIS_RIGHT(5...6)(")"),
+            BlockParametersNode(4...6)(nil, [], (4...5), (5...6)),
             StatementsNode(10...20)(
               [CallNode(10...20)(
                  nil,

--- a/test/snapshots/whitequark/ruby_bug_11380.rb
+++ b/test/snapshots/whitequark/ruby_bug_11380.rb
@@ -11,8 +11,6 @@ ProgramNode(0...28)(
             ScopeNode(2...4)([]),
             MINUS_GREATER(2...4)("->"),
             nil,
-            nil,
-            nil,
             StatementsNode(7...13)(
               [SymbolNode(7...13)(
                  SYMBOL_BEGIN(7...8)(":"),

--- a/test/snapshots/whitequark/ruby_bug_15789.rb
+++ b/test/snapshots/whitequark/ruby_bug_15789.rb
@@ -10,8 +10,7 @@ ProgramNode(0...23)(
          [LambdaNode(2...19)(
             ScopeNode(2...4)([IDENTIFIER(5...6)("a")]),
             MINUS_GREATER(2...4)("->"),
-            PARENTHESIS_LEFT(4...5)("("),
-            BlockParametersNode(5...14)(
+            BlockParametersNode(4...16)(
               ParametersNode(5...14)(
                 [],
                 [OptionalParameterNode(5...14)(
@@ -20,8 +19,6 @@ ProgramNode(0...23)(
                    LambdaNode(9...14)(
                      ScopeNode(9...11)([]),
                      MINUS_GREATER(9...11)("->"),
-                     nil,
-                     nil,
                      nil,
                      StatementsNode(12...14)(
                        [CallNode(12...14)(
@@ -43,9 +40,10 @@ ProgramNode(0...23)(
                 nil,
                 nil
               ),
-              []
+              [],
+              (4...5),
+              (15...16)
             ),
-            PARENTHESIS_RIGHT(15...16)(")"),
             StatementsNode(18...19)([LocalVariableReadNode(18...19)(0)])
           )]
        ),
@@ -62,8 +60,7 @@ ProgramNode(0...23)(
          [LambdaNode(24...40)(
             ScopeNode(24...26)([LABEL(27...28)("a")]),
             MINUS_GREATER(24...26)("->"),
-            PARENTHESIS_LEFT(26...27)("("),
-            BlockParametersNode(27...35)(
+            BlockParametersNode(26...37)(
               ParametersNode(27...35)(
                 [],
                 [],
@@ -74,8 +71,6 @@ ProgramNode(0...23)(
                    LambdaNode(30...35)(
                      ScopeNode(30...32)([]),
                      MINUS_GREATER(30...32)("->"),
-                     nil,
-                     nil,
                      nil,
                      StatementsNode(33...35)(
                        [CallNode(33...35)(
@@ -94,9 +89,10 @@ ProgramNode(0...23)(
                 nil,
                 nil
               ),
-              []
+              [],
+              (26...27),
+              (36...37)
             ),
-            PARENTHESIS_RIGHT(36...37)(")"),
             StatementsNode(39...40)([LocalVariableReadNode(39...40)(0)])
           )]
        ),

--- a/test/snapshots/whitequark/send_lambda.rb
+++ b/test/snapshots/whitequark/send_lambda.rb
@@ -1,10 +1,9 @@
 ProgramNode(0...23)(
   ScopeNode(0...0)([]),
   StatementsNode(0...23)(
-    [LambdaNode(0...2)(
+    [LambdaNode(0...4)(
        ScopeNode(0...2)([STAR(3...4)("*")]),
        MINUS_GREATER(0...2)("->"),
-       nil,
        BlockParametersNode(3...4)(
          ParametersNode(3...4)(
            [],
@@ -15,24 +14,21 @@ ProgramNode(0...23)(
            nil,
            nil
          ),
-         []
+         [],
+         nil,
+         nil
        ),
-       nil,
        nil
      ),
      LambdaNode(10...12)(
        ScopeNode(10...12)([]),
        MINUS_GREATER(10...12)("->"),
        nil,
-       nil,
-       nil,
        nil
      ),
      LambdaNode(21...23)(
        ScopeNode(21...23)([]),
        MINUS_GREATER(21...23)("->"),
-       nil,
-       nil,
        nil,
        nil
      )]

--- a/test/snapshots/whitequark/send_lambda_args.rb
+++ b/test/snapshots/whitequark/send_lambda_args.rb
@@ -4,8 +4,7 @@ ProgramNode(0...17)(
     [LambdaNode(0...6)(
        ScopeNode(0...2)([IDENTIFIER(4...5)("a")]),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(3...4)("("),
-       BlockParametersNode(4...5)(
+       BlockParametersNode(3...6)(
          ParametersNode(4...5)(
            [RequiredParameterNode(4...5)()],
            [],
@@ -15,16 +14,16 @@ ProgramNode(0...17)(
            nil,
            nil
          ),
-         []
+         [],
+         (3...4),
+         (5...6)
        ),
-       PARENTHESIS_RIGHT(5...6)(")"),
        nil
      ),
      LambdaNode(12...17)(
        ScopeNode(12...14)([IDENTIFIER(15...16)("a")]),
        MINUS_GREATER(12...14)("->"),
-       PARENTHESIS_LEFT(14...15)("("),
-       BlockParametersNode(15...16)(
+       BlockParametersNode(14...17)(
          ParametersNode(15...16)(
            [RequiredParameterNode(15...16)()],
            [],
@@ -34,9 +33,10 @@ ProgramNode(0...17)(
            nil,
            nil
          ),
-         []
+         [],
+         (14...15),
+         (16...17)
        ),
-       PARENTHESIS_RIGHT(16...17)(")"),
        nil
      )]
   )

--- a/test/snapshots/whitequark/send_lambda_args_noparen.rb
+++ b/test/snapshots/whitequark/send_lambda_args_noparen.rb
@@ -1,10 +1,9 @@
-ProgramNode(0...15)(
+ProgramNode(0...18)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...15)(
-    [LambdaNode(0...2)(
+  StatementsNode(0...18)(
+    [LambdaNode(0...7)(
        ScopeNode(0...2)([LABEL(3...4)("a")]),
        MINUS_GREATER(0...2)("->"),
-       nil,
        BlockParametersNode(3...7)(
          ParametersNode(3...7)(
            [],
@@ -18,15 +17,15 @@ ProgramNode(0...15)(
            nil,
            nil
          ),
-         []
+         [],
+         nil,
+         nil
        ),
-       nil,
        nil
      ),
-     LambdaNode(13...15)(
+     LambdaNode(13...18)(
        ScopeNode(13...15)([LABEL(16...17)("a")]),
        MINUS_GREATER(13...15)("->"),
-       nil,
        BlockParametersNode(16...18)(
          ParametersNode(16...18)(
            [],
@@ -37,9 +36,10 @@ ProgramNode(0...15)(
            nil,
            nil
          ),
-         []
+         [],
+         nil,
+         nil
        ),
-       nil,
        nil
      )]
   )

--- a/test/snapshots/whitequark/send_lambda_args_shadow.rb
+++ b/test/snapshots/whitequark/send_lambda_args_shadow.rb
@@ -8,8 +8,7 @@ ProgramNode(0...15)(
           IDENTIFIER(11...14)("bar")]
        ),
        MINUS_GREATER(0...2)("->"),
-       PARENTHESIS_LEFT(2...3)("("),
-       BlockParametersNode(3...14)(
+       BlockParametersNode(2...15)(
          ParametersNode(3...4)(
            [RequiredParameterNode(3...4)()],
            [],
@@ -19,9 +18,10 @@ ProgramNode(0...15)(
            nil,
            nil
          ),
-         [IDENTIFIER(6...9)("foo"), IDENTIFIER(11...14)("bar")]
+         [IDENTIFIER(6...9)("foo"), IDENTIFIER(11...14)("bar")],
+         (2...3),
+         (14...15)
        ),
-       PARENTHESIS_RIGHT(14...15)(")"),
        nil
      )]
   )

--- a/test/snapshots/whitequark/send_lambda_legacy.rb
+++ b/test/snapshots/whitequark/send_lambda_legacy.rb
@@ -5,8 +5,6 @@ ProgramNode(0...2)(
        ScopeNode(0...2)([]),
        MINUS_GREATER(0...2)("->"),
        nil,
-       nil,
-       nil,
        nil
      )]
   )


### PR DESCRIPTION
Block parameters were previously holding the parameters and the set of locals, but didn't include their bounds (either `(`/`)` for lambdas or `|`/`|` for blocks). Lambdas were holding their parentheses, but blocks held nothing. Location information was therefore pretty confusing.

I've updated it so that block parameters are now created even for empty `||`/`()` and that they hold their locations properly. Parentheses are no longer held on lambdas, which makes them a nice 16 bytes smaller as well.