### PR TITLE
Heredoc stuff

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -900,23 +900,6 @@ nodes:
 
           foo => { a: 1, b: 2, **c }
                  ^^^^^^^^^^^^^^^^^^^
-  - name: HeredocNode
-    child_nodes:
-      - name: opening
-        type: token
-      - name: parts
-        type: node[]
-      - name: closing
-        type: token
-      - name: dedent
-        type: integer
-    comment: |
-      Represents the use of a heredoc.
-
-          <<~HERE
-            Content.
-          HERE
-          ^^^^^^^^^^
   - name: IfNode
     child_nodes:
       - name: if_keyword

--- a/include/yarp/util/yp_string.h
+++ b/include/yarp/util/yp_string.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 
 // This struct represents a string value.
 typedef struct {
@@ -45,6 +46,11 @@ yp_string_constant_init(yp_string_t *string, const char *source, size_t length);
 // Returns the memory size associated with the string.
 size_t
 yp_string_memsize(const yp_string_t *string);
+
+// Ensure the string is owned. If it is not, then reinitialize it as owned and
+// copy over the previous source.
+void
+yp_string_ensure_owned(yp_string_t *string);
 
 // Returns the length associated with the string.
 __attribute__ ((__visibility__("default"))) extern size_t

--- a/src/util/yp_string.c
+++ b/src/util/yp_string.c
@@ -52,6 +52,19 @@ yp_string_memsize(const yp_string_t *string) {
   return size;
 }
 
+// Ensure the string is owned. If it is not, then reinitialize it as owned and
+// copy over the previous source.
+void
+yp_string_ensure_owned(yp_string_t *string) {
+  if (string->type == YP_STRING_OWNED) return;
+
+  size_t length = yp_string_length(string);
+  const char *source = yp_string_source(string);
+
+  yp_string_owned_init(string, malloc(length), length);
+  memcpy(string->as.owned.source, source, length);
+}
+
 // Returns the length associated with the string.
 __attribute__ ((__visibility__("default"))) extern size_t
 yp_string_length(const yp_string_t *string) {

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -8211,6 +8211,14 @@ parse_heredoc_common_whitespace(yp_parser_t *parser, yp_node_list_t *nodes) {
           cur_char++;
         }
 
+        // If we hit a newline, then we have encountered a line that contains
+        // only whitespace, and it shouldn't be considered in the calculation of
+        // common leading whitespace.
+        if (*cur_char == '\n') {
+          cur_char++;
+          continue;
+        }
+
         if (cur_whitespace < common_whitespace || common_whitespace == -1) {
           common_whitespace = cur_whitespace;
         }

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -8191,7 +8191,7 @@ parse_heredoc_common_whitespace(yp_parser_t *parser, yp_node_list_t *nodes) {
     // If the previous node wasn't a string node, we don't want to trim
     // whitespace. This could happen after an interpolated expression or
     // variable.
-    if (*content->start != '\n' && (index == 0 || nodes->nodes[index - 1]->type == YP_NODE_STRING_NODE)) {
+    if (index == 0 || nodes->nodes[index - 1]->type == YP_NODE_STRING_NODE) {
       int cur_whitespace;
       const char *cur_char = content->start;
 

--- a/src/yarp.c
+++ b/src/yarp.c
@@ -8247,14 +8247,7 @@ parse_heredoc_dedent(yp_parser_t *parser, yp_node_t *node, yp_heredoc_quote_t qu
     if (node->type != YP_NODE_STRING_NODE) continue;
     yp_string_t *node_str = &((yp_string_node_t *) node)->unescaped;
 
-    // We convert all strings to be "owned" to make it simpler to manipulate memory
-    if (node_str->type != YP_STRING_OWNED) {
-      size_t length = yp_string_length(node_str);
-      const char *original = yp_string_source(node_str);
-      yp_string_owned_init(node_str, malloc(length), length);
-      memcpy(node_str->as.owned.source, original, length);
-    }
-
+    yp_string_ensure_owned(node_str);
     const char *cur_char = node_str->as.owned.source;
     size_t new_size = node_str->as.owned.length;
 

--- a/test/fixtures/tilde_heredocs.rb
+++ b/test/fixtures/tilde_heredocs.rb
@@ -59,3 +59,23 @@ EOF
   	a
         b
 EOF
+
+<<~EOF
+  a
+ 
+  b
+EOF
+
+<<~EOF
+  a
+    
+  b
+EOF
+
+<<~EOF
+  a
+    
+
+    
+  b
+EOF

--- a/test/fixtures/tilde_heredocs.rb
+++ b/test/fixtures/tilde_heredocs.rb
@@ -79,3 +79,8 @@ EOF
     
   b
 EOF
+
+<<~EOF
+
+  #{1}a
+    EOF

--- a/test/fixtures/tilde_heredocs.rb
+++ b/test/fixtures/tilde_heredocs.rb
@@ -18,20 +18,18 @@ EOF
 
 <<~EOF
   a
- #{b}
+ #{1}
 EOF
 
 <<~EOF
   a
-  #{b}
+  #{1}
 EOF
 
 <<~EOF
   a
   b
 EOF
-
-[]
 
 <<~EOF
   a
@@ -55,4 +53,9 @@ EOF
 <<~EOF
 	 a
 	b
+EOF
+
+<<~EOF
+  	a
+        b
 EOF

--- a/test/heredoc_dedent_test.rb
+++ b/test/heredoc_dedent_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module YARP
+  class HeredocDedentTest < Test::Unit::TestCase
+    File.read(File.expand_path("fixtures/tilde_heredocs.rb", __dir__)).split(/(?=\n)\n(?=<)/).each_with_index do |heredoc, index|
+      test "heredoc #{index}" do
+        parts = YARP.parse(heredoc).value.statements.body.first.parts
+        actual = parts.map { |part| part.is_a?(StringNode) ? part.unescaped : "1" }.join
+
+        assert_equal(eval(heredoc), actual, "Expected heredocs to match.")
+      end
+    end
+  end
+end

--- a/test/heredoc_dedent_test.rb
+++ b/test/heredoc_dedent_test.rb
@@ -4,7 +4,9 @@ require "test_helper"
 
 module YARP
   class HeredocDedentTest < Test::Unit::TestCase
-    File.read(File.expand_path("fixtures/tilde_heredocs.rb", __dir__)).split(/(?=\n)\n(?=<)/).each_with_index do |heredoc, index|
+    filepath = File.expand_path("fixtures/tilde_heredocs.rb", __dir__)
+
+    File.read(filepath).split(/(?=\n)\n(?=<)/).each_with_index do |heredoc, index|
       test "heredoc #{index}" do
         parts = YARP.parse(heredoc).value.statements.body.first.parts
         actual = parts.map { |part| part.is_a?(StringNode) ? part.unescaped : "1" }.join

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -14,7 +14,6 @@ class ParseTest < Test::Unit::TestCase
   known_failures = %w[
     seattlerb/heredoc__backslash_dos_format.rb
     seattlerb/heredoc_nested.rb
-    seattlerb/heredoc_squiggly_visually_blank_lines.rb
     seattlerb/heredoc_trailing_slash_continued_call.rb
     seattlerb/pct_w_heredoc_interp_nested.rb
     seattlerb/required_kwarg_no_value.rb

--- a/test/snapshots/dash_heredocs.rb
+++ b/test/snapshots/dash_heredocs.rb
@@ -1,7 +1,7 @@
 ProgramNode(7...219)(
   ScopeNode(0...0)([]),
   StatementsNode(7...219)(
-    [HeredocNode(7...11)(
+    [InterpolatedStringNode(7...11)(
        HEREDOC_START(0...6)("<<-EOF"),
        [StringNode(7...11)(
           nil,
@@ -9,11 +9,10 @@ ProgramNode(7...219)(
           nil,
           "  a\n"
         )],
-       HEREDOC_END(11...15)("EOF\n"),
-       0
+       HEREDOC_END(11...15)("EOF\n")
      ),
      CallNode(37...51)(
-       HeredocNode(37...41)(
+       InterpolatedStringNode(37...41)(
          HEREDOC_START(16...24)("<<-FIRST"),
          [StringNode(37...41)(
             nil,
@@ -21,14 +20,13 @@ ProgramNode(7...219)(
             nil,
             "  a\n"
           )],
-         HEREDOC_END(41...47)("FIRST\n"),
-         0
+         HEREDOC_END(41...47)("FIRST\n")
        ),
        nil,
        PLUS(25...26)("+"),
        nil,
        ArgumentsNode(47...51)(
-         [HeredocNode(47...51)(
+         [InterpolatedStringNode(47...51)(
             HEREDOC_START(27...36)("<<-SECOND"),
             [StringNode(47...51)(
                nil,
@@ -36,8 +34,7 @@ ProgramNode(7...219)(
                nil,
                "  b\n"
              )],
-            HEREDOC_END(51...58)("SECOND\n"),
-            0
+            HEREDOC_END(51...58)("SECOND\n")
           )]
        ),
        nil,
@@ -71,7 +68,7 @@ ProgramNode(7...219)(
         StringNode(76...77)(nil, STRING_CONTENT(76...77)("\n"), nil, "\n")],
        HEREDOC_END(77...81)("EOF\n")
      ),
-     HeredocNode(98...102)(
+     InterpolatedStringNode(98...102)(
        HEREDOC_START(82...88)("<<-EOF"),
        [StringNode(98...102)(
           nil,
@@ -79,10 +76,9 @@ ProgramNode(7...219)(
           nil,
           "  a\n"
         )],
-       HEREDOC_END(102...106)("EOF\n"),
-       0
+       HEREDOC_END(102...106)("EOF\n")
      ),
-     HeredocNode(114...122)(
+     InterpolatedStringNode(114...122)(
        HEREDOC_START(107...113)("<<-EOF"),
        [StringNode(114...122)(
           nil,
@@ -90,10 +86,9 @@ ProgramNode(7...219)(
           nil,
           "  a\n" + "  b\n"
         )],
-       HEREDOC_END(122...128)("  EOF\n"),
-       0
+       HEREDOC_END(122...128)("  EOF\n")
      ),
-     HeredocNode(138...147)(
+     InterpolatedStringNode(138...147)(
        HEREDOC_START(129...137)("<<-\"EOF\""),
        [StringNode(138...142)(
           nil,
@@ -123,10 +118,9 @@ ProgramNode(7...219)(
           nil,
           "\n"
         )],
-       HEREDOC_END(147...151)("EOF\n"),
-       0
+       HEREDOC_END(147...151)("EOF\n")
      ),
-     HeredocNode(159...168)(
+     InterpolatedStringNode(159...168)(
        HEREDOC_START(152...158)("<<-EOF"),
        [StringNode(159...163)(
           nil,
@@ -156,8 +150,7 @@ ProgramNode(7...219)(
           nil,
           "\n"
         )],
-       HEREDOC_END(168...172)("EOF\n"),
-       0
+       HEREDOC_END(168...172)("EOF\n")
      ),
      StringNode(173...179)(
        STRING_BEGIN(173...175)("%#"),
@@ -165,7 +158,7 @@ ProgramNode(7...219)(
        STRING_END(178...179)("#"),
        "abc"
      ),
-     HeredocNode(188...196)(
+     InterpolatedStringNode(188...196)(
        HEREDOC_START(181...187)("<<-EOF"),
        [StringNode(188...196)(
           nil,
@@ -173,10 +166,9 @@ ProgramNode(7...219)(
           nil,
           "  a\n" + "  b\n"
         )],
-       HEREDOC_END(196...200)("EOF\n"),
-       0
+       HEREDOC_END(196...200)("EOF\n")
      ),
-     HeredocNode(210...219)(
+     InterpolatedStringNode(210...219)(
        HEREDOC_START(201...209)("<<-'EOF'"),
        [StringNode(210...219)(
           nil,
@@ -184,8 +176,7 @@ ProgramNode(7...219)(
           nil,
           "  a \#{1}\n"
         )],
-       HEREDOC_END(219...223)("EOF\n"),
-       0
+       HEREDOC_END(219...223)("EOF\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_backslash_nl.rb
+++ b/test/snapshots/seattlerb/heredoc_backslash_nl.rb
@@ -9,7 +9,7 @@ ProgramNode(0...88)(
        STRING_END(39...40)("\""),
        "  why would someone do this? \n" + "  blah\n"
      ),
-     HeredocNode(50...88)(
+     InterpolatedStringNode(50...88)(
        HEREDOC_START(42...49)("<<-DESC"),
        [StringNode(50...88)(
           nil,
@@ -19,8 +19,7 @@ ProgramNode(0...88)(
           nil,
           "  why would someone do this? \n" + "  blah\n"
         )],
-       HEREDOC_END(88...93)("DESC\n"),
-       0
+       HEREDOC_END(88...93)("DESC\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_bad_hex_escape.rb
+++ b/test/snapshots/seattlerb/heredoc_bad_hex_escape.rb
@@ -3,7 +3,7 @@ ProgramNode(0...17)(
   StatementsNode(0...17)(
     [LocalVariableWriteNode(0...17)(
        (0...1),
-       HeredocNode(10...17)(
+       InterpolatedStringNode(10...17)(
          HEREDOC_START(4...9)("<<eos"),
          [StringNode(10...17)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(0...17)(
             nil,
             "a\xE9b\n"
           )],
-         HEREDOC_END(17...21)("eos\n"),
-         0
+         HEREDOC_END(17...21)("eos\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_bad_oct_escape.rb
+++ b/test/snapshots/seattlerb/heredoc_bad_oct_escape.rb
@@ -3,7 +3,7 @@ ProgramNode(0...23)(
   StatementsNode(0...23)(
     [LocalVariableWriteNode(0...23)(
        (0...1),
-       HeredocNode(11...23)(
+       InterpolatedStringNode(11...23)(
          HEREDOC_START(4...10)("<<-EOS"),
          [StringNode(11...23)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(0...23)(
             nil,
             "a\xA7b\n" + "cöd\n"
           )],
-         HEREDOC_END(23...27)("EOS\n"),
-         0
+         HEREDOC_END(23...27)("EOS\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_comma_arg.rb
+++ b/test/snapshots/seattlerb/heredoc_comma_arg.rb
@@ -12,7 +12,7 @@ ProgramNode(0...47)(
        BRACKET_RIGHT(16...17)("]")
      ),
      ArrayNode(19...47)(
-       [HeredocNode(29...41)(
+       [InterpolatedStringNode(29...41)(
           HEREDOC_START(20...27)("<<-FILE"),
           [StringNode(29...41)(
              nil,
@@ -20,8 +20,7 @@ ProgramNode(0...47)(
              nil,
              "  some text\n"
            )],
-          HEREDOC_END(41...46)("FILE\n"),
-          0
+          HEREDOC_END(41...46)("FILE\n")
         )],
        BRACKET_LEFT_ARRAY(19...20)("["),
        BRACKET_RIGHT(46...47)("]")

--- a/test/snapshots/seattlerb/heredoc_lineno.rb
+++ b/test/snapshots/seattlerb/heredoc_lineno.rb
@@ -3,7 +3,7 @@ ProgramNode(0...41)(
   StatementsNode(0...41)(
     [LocalVariableWriteNode(0...30)(
        (0...1),
-       HeredocNode(12...30)(
+       InterpolatedStringNode(12...30)(
          HEREDOC_START(4...11)("<<'CCC'"),
          [StringNode(12...30)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(0...41)(
             nil,
             "line2\n" + "line3\n" + "line4\n"
           )],
-         HEREDOC_END(30...34)("CCC\n"),
-         0
+         HEREDOC_END(30...34)("CCC\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_squiggly.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly.rb
@@ -3,7 +3,7 @@ ProgramNode(0...25)(
   StatementsNode(0...25)(
     [LocalVariableWriteNode(0...25)(
        (0...1),
-       HeredocNode(13...25)(
+       InterpolatedStringNode(13...25)(
          HEREDOC_START(4...12)("<<~\"EOF\""),
          [StringNode(13...25)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(0...25)(
             nil,
             "x\n" + "y\n" + "z\n"
           )],
-         HEREDOC_END(25...31)("  EOF\n"),
-         2
+         HEREDOC_END(25...31)("  EOF\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.rb
@@ -16,7 +16,7 @@ ProgramNode(0...20)(
                    nil,
                    STRING_CONTENT(21...26)("\n" + "    "),
                    nil,
-                   "\n" + "    "
+                   "\n"
                  ),
                  StringInterpolatedNode(26...32)(
                    EMBEXPR_BEGIN(26...28)("\#{"),

--- a/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_blank_line_plus_interpolation.rb
@@ -10,7 +10,7 @@ ProgramNode(0...20)(
          PARENTHESIS_LEFT(7...8)("("),
          ArgumentsNode(21...19)(
            [CallNode(21...19)(
-              HeredocNode(21...36)(
+              InterpolatedStringNode(21...36)(
                 HEREDOC_START(8...14)("<<~EOF"),
                 [StringNode(21...26)(
                    nil,
@@ -40,8 +40,7 @@ ProgramNode(0...20)(
                    nil,
                    "baz\n"
                  )],
-                HEREDOC_END(36...42)("  EOF\n"),
-                0
+                HEREDOC_END(36...42)("  EOF\n")
               ),
               DOT(14...15)("."),
               IDENTIFIER(15...19)("chop"),

--- a/test/snapshots/seattlerb/heredoc_squiggly_blank_lines.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_blank_lines.rb
@@ -3,7 +3,7 @@ ProgramNode(0...20)(
   StatementsNode(0...20)(
     [LocalVariableWriteNode(0...20)(
        (0...1),
-       HeredocNode(11...20)(
+       InterpolatedStringNode(11...20)(
          HEREDOC_START(4...10)("<<~EOF"),
          [StringNode(11...20)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(0...20)(
             nil,
             "x\n" + "\n" + "z\n"
           )],
-         HEREDOC_END(20...24)("EOF\n"),
-         2
+         HEREDOC_END(20...24)("EOF\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_squiggly_empty.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_empty.rb
@@ -1,11 +1,10 @@
 ProgramNode(0...4)(
   ScopeNode(0...0)([]),
   StatementsNode(0...4)(
-    [HeredocNode(0...4)(
+    [InterpolatedStringNode(0...4)(
        HEREDOC_START(0...4)("<<~A"),
        [],
-       HEREDOC_END(5...7)("A\n"),
-       0
+       HEREDOC_END(5...7)("A\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_squiggly_interp.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_interp.rb
@@ -3,7 +3,7 @@ ProgramNode(0...36)(
   StatementsNode(0...36)(
     [LocalVariableWriteNode(0...36)(
        (0...1),
-       HeredocNode(11...36)(
+       InterpolatedStringNode(11...36)(
          HEREDOC_START(4...10)("<<~EOF"),
          [StringNode(11...22)(
             nil,
@@ -22,8 +22,7 @@ ProgramNode(0...36)(
             nil,
             " y\n" + "  z\n"
           )],
-         HEREDOC_END(36...42)("  EOF\n"),
-         2
+         HEREDOC_END(36...42)("  EOF\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_squiggly_no_indent.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_no_indent.rb
@@ -1,11 +1,10 @@
 ProgramNode(5...7)(
   ScopeNode(0...0)([]),
   StatementsNode(5...7)(
-    [HeredocNode(5...7)(
+    [InterpolatedStringNode(5...7)(
        HEREDOC_START(0...4)("<<~A"),
        [StringNode(5...7)(nil, STRING_CONTENT(5...7)("a\n"), nil, "a\n")],
-       HEREDOC_END(7...9)("A\n"),
-       0
+       HEREDOC_END(7...9)("A\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_squiggly_tabs.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_tabs.rb
@@ -3,7 +3,7 @@ ProgramNode(0...43)(
   StatementsNode(0...43)(
     [LocalVariableWriteNode(0...43)(
        (0...1),
-       HeredocNode(13...43)(
+       InterpolatedStringNode(13...43)(
          HEREDOC_START(4...12)("<<~\"EOF\""),
          [StringNode(13...43)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(0...43)(
             nil,
             "blah blah\n" + " blah blah\n"
           )],
-         HEREDOC_END(43...49)("  EOF\n"),
-         8
+         HEREDOC_END(43...49)("  EOF\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_squiggly_tabs_extra.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_tabs_extra.rb
@@ -3,7 +3,7 @@ ProgramNode(0...37)(
   StatementsNode(0...37)(
     [LocalVariableWriteNode(0...37)(
        (0...1),
-       HeredocNode(13...37)(
+       InterpolatedStringNode(13...37)(
          HEREDOC_START(4...12)("<<~\"EOF\""),
          [StringNode(13...37)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(0...37)(
             nil,
             "blah blah\n" + "\tblah blah\n"
           )],
-         HEREDOC_END(37...43)("  EOF\n"),
-         2
+         HEREDOC_END(37...43)("  EOF\n")
        ),
        (2...3),
        0

--- a/test/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.rb
+++ b/test/snapshots/seattlerb/heredoc_squiggly_visually_blank_lines.rb
@@ -1,0 +1,20 @@
+ProgramNode(0...21)(
+  ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
+  StatementsNode(0...21)(
+    [LocalVariableWriteNode(0...21)(
+       (0...1),
+       InterpolatedStringNode(11...21)(
+         HEREDOC_START(4...10)("<<~EOF"),
+         [StringNode(11...21)(
+            nil,
+            STRING_CONTENT(11...21)("  x\n" + " \n" + "  z\n"),
+            nil,
+            "x\n" + "\n" + "z\n"
+          )],
+         HEREDOC_END(21...25)("EOF\n")
+       ),
+       (2...3),
+       0
+     )]
+  )
+)

--- a/test/snapshots/seattlerb/heredoc_unicode.rb
+++ b/test/snapshots/seattlerb/heredoc_unicode.rb
@@ -1,11 +1,10 @@
 ProgramNode(10...12)(
   ScopeNode(0...0)([]),
   StatementsNode(10...12)(
-    [HeredocNode(10...12)(
+    [InterpolatedStringNode(10...12)(
        HEREDOC_START(0...9)("<<OOTPÜT"),
        [StringNode(10...12)(nil, STRING_CONTENT(10...12)(".\n"), nil, ".\n")],
-       HEREDOC_END(12...20)("OOTPÜT\n"),
-       0
+       HEREDOC_END(12...20)("OOTPÜT\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes.rb
+++ b/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes.rb
@@ -1,7 +1,7 @@
 ProgramNode(6...21)(
   ScopeNode(0...0)([]),
   StatementsNode(6...21)(
-    [HeredocNode(6...21)(
+    [InterpolatedStringNode(6...21)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...21)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(6...21)(
           nil,
           "foo\rbar\n" + "baz\r\n"
         )],
-       HEREDOC_END(21...25)("EOS\n"),
-       0
+       HEREDOC_END(21...25)("EOS\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_carriage_return_escapes_windows.rb
@@ -1,7 +1,7 @@
 ProgramNode(7...24)(
   ScopeNode(0...0)([]),
   StatementsNode(7...24)(
-    [HeredocNode(7...24)(
+    [InterpolatedStringNode(7...24)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...24)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(7...24)(
           nil,
           "foo\rbar\r\n" + "baz\r\r\n"
         )],
-       HEREDOC_END(24...29)("EOS\r\n"),
-       0
+       HEREDOC_END(24...29)("EOS\r\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix?.rb
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_horrible_mix?.rb
@@ -1,7 +1,7 @@
 ProgramNode(9...15)(
   ScopeNode(0...0)([]),
   StatementsNode(9...15)(
-    [HeredocNode(9...15)(
+    [InterpolatedStringNode(9...15)(
        HEREDOC_START(0...7)("<<'eot'"),
        [StringNode(9...15)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(9...15)(
           nil,
           "body\r\n"
         )],
-       HEREDOC_END(15...19)("eot\n"),
-       0
+       HEREDOC_END(15...19)("eot\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns.rb
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns.rb
@@ -1,7 +1,7 @@
 ProgramNode(6...19)(
   ScopeNode(0...0)([]),
   StatementsNode(6...19)(
-    [HeredocNode(6...19)(
+    [InterpolatedStringNode(6...19)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...19)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(6...19)(
           nil,
           "foo\rbar\r\n" + "baz\n"
         )],
-       HEREDOC_END(19...23)("EOS\n"),
-       0
+       HEREDOC_END(19...23)("EOS\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_extra_carriage_returns_windows.rb
@@ -1,7 +1,7 @@
 ProgramNode(7...22)(
   ScopeNode(0...0)([]),
   StatementsNode(7...22)(
-    [HeredocNode(7...22)(
+    [InterpolatedStringNode(7...22)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...22)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(7...22)(
           nil,
           "foo\rbar\r\r\n" + "baz\r\n"
         )],
-       HEREDOC_END(22...27)("EOS\r\n"),
-       0
+       HEREDOC_END(22...27)("EOS\r\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.rb
+++ b/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes.rb
@@ -1,7 +1,7 @@
 ProgramNode(6...17)(
   ScopeNode(0...0)([]),
   StatementsNode(6...17)(
-    [HeredocNode(6...17)(
+    [InterpolatedStringNode(6...17)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...11)(
           nil,
@@ -11,8 +11,7 @@ ProgramNode(6...17)(
         ),
         InstanceVariableReadNode(12...16)(),
         StringNode(16...17)(nil, STRING_CONTENT(16...17)("\n"), nil, "\n")],
-       HEREDOC_END(17...21)("EOS\n"),
-       0
+       HEREDOC_END(17...21)("EOS\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_interpolation_and_carriage_return_escapes_windows.rb
@@ -1,7 +1,7 @@
 ProgramNode(7...19)(
   ScopeNode(0...0)([]),
   StatementsNode(7...19)(
-    [HeredocNode(7...19)(
+    [InterpolatedStringNode(7...19)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...12)(
           nil,
@@ -16,8 +16,7 @@ ProgramNode(7...19)(
           nil,
           "\r\n"
         )],
-       HEREDOC_END(19...24)("EOS\r\n"),
-       0
+       HEREDOC_END(19...24)("EOS\r\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_not_global_interpolation.rb
+++ b/test/snapshots/seattlerb/heredoc_with_not_global_interpolation.rb
@@ -1,7 +1,7 @@
 ProgramNode(11...15)(
   ScopeNode(0...0)([]),
   StatementsNode(11...15)(
-    [HeredocNode(11...15)(
+    [InterpolatedStringNode(11...15)(
        HEREDOC_START(0...10)("<<-HEREDOC"),
        [StringNode(11...15)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(11...15)(
           nil,
           "\#${\n"
         )],
-       HEREDOC_END(15...23)("HEREDOC\n"),
-       0
+       HEREDOC_END(15...23)("HEREDOC\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_only_carriage_returns.rb
+++ b/test/snapshots/seattlerb/heredoc_with_only_carriage_returns.rb
@@ -1,7 +1,7 @@
 ProgramNode(6...14)(
   ScopeNode(0...0)([]),
   StatementsNode(6...14)(
-    [HeredocNode(6...14)(
+    [InterpolatedStringNode(6...14)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(6...14)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(6...14)(
           nil,
           "\r\n" + "\r\r\n" + "\r\n"
         )],
-       HEREDOC_END(14...18)("EOS\n"),
-       0
+       HEREDOC_END(14...18)("EOS\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.rb
+++ b/test/snapshots/seattlerb/heredoc_with_only_carriage_returns_windows.rb
@@ -1,7 +1,7 @@
 ProgramNode(7...18)(
   ScopeNode(0...0)([]),
   StatementsNode(7...18)(
-    [HeredocNode(7...18)(
+    [InterpolatedStringNode(7...18)(
        HEREDOC_START(0...5)("<<EOS"),
        [StringNode(7...18)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(7...18)(
           nil,
           "\r\r\n" + "\r\r\r\n" + "\r\r\n"
         )],
-       HEREDOC_END(18...23)("EOS\r\n"),
-       0
+       HEREDOC_END(18...23)("EOS\r\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/heredoc_wtf_I_hate_you.rb
+++ b/test/snapshots/seattlerb/heredoc_wtf_I_hate_you.rb
@@ -9,7 +9,7 @@ ProgramNode(0...1)(
        ArgumentsNode(12...30)(
          [CallNode(12...30)(
             CallNode(12...26)(
-              HeredocNode(12...16)(
+              InterpolatedStringNode(12...16)(
                 HEREDOC_START(2...8)("<<-END"),
                 [StringNode(12...16)(
                    nil,
@@ -17,8 +17,7 @@ ProgramNode(0...1)(
                    nil,
                    "  a\n"
                  )],
-                HEREDOC_END(16...22)("  END\n"),
-                0
+                HEREDOC_END(16...22)("  END\n")
               ),
               nil,
               PLUS(8...9)("+"),

--- a/test/snapshots/seattlerb/parse_line_heredoc.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc.rb
@@ -4,7 +4,7 @@ ProgramNode(6...81)(
     [LocalVariableWriteNode(6...31)(
        (6...12),
        CallNode(32...31)(
-         HeredocNode(32...57)(
+         InterpolatedStringNode(32...57)(
            HEREDOC_START(15...25)("<<-HEREDOC"),
            [StringNode(32...57)(
               nil,
@@ -12,8 +12,7 @@ ProgramNode(6...81)(
               nil,
               "        very long string\n"
             )],
-           HEREDOC_END(57...71)("      HEREDOC\n"),
-           0
+           HEREDOC_END(57...71)("      HEREDOC\n")
          ),
          DOT(25...26)("."),
          IDENTIFIER(26...31)("strip"),

--- a/test/snapshots/seattlerb/parse_line_heredoc_evstr.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc_evstr.rb
@@ -1,7 +1,7 @@
 ProgramNode(5...12)(
   ScopeNode(0...0)([]),
   StatementsNode(5...12)(
-    [HeredocNode(5...12)(
+    [InterpolatedStringNode(5...12)(
        HEREDOC_START(0...4)("<<-A"),
        [StringNode(5...7)(nil, STRING_CONTENT(5...7)("a\n"), nil, "a\n"),
         StringInterpolatedNode(7...11)(
@@ -21,8 +21,7 @@ ProgramNode(5...12)(
           EMBEXPR_END(10...11)("}")
         ),
         StringNode(11...12)(nil, STRING_CONTENT(11...12)("\n"), nil, "\n")],
-       HEREDOC_END(12...14)("A\n"),
-       0
+       HEREDOC_END(12...14)("A\n")
      )]
   )
 )

--- a/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc_hardnewline.rb
@@ -1,7 +1,7 @@
 ProgramNode(9...48)(
   ScopeNode(0...0)([]),
   StatementsNode(9...48)(
-    [HeredocNode(9...28)(
+    [InterpolatedStringNode(9...28)(
        HEREDOC_START(0...8)("<<-EOFOO"),
        [StringNode(9...28)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(9...48)(
           nil,
           "\n" + "\n" + "\n" + "\n" + "\n" + "\n" + "\n" + "\n" + "\n" + "\n"
         )],
-       HEREDOC_END(28...34)("EOFOO\n"),
-       0
+       HEREDOC_END(28...34)("EOFOO\n")
      ),
      ClassNode(35...48)(
        ScopeNode(35...40)([]),

--- a/test/snapshots/seattlerb/parse_line_heredoc_regexp_chars.rb
+++ b/test/snapshots/seattlerb/parse_line_heredoc_regexp_chars.rb
@@ -3,7 +3,7 @@ ProgramNode(6...67)(
   StatementsNode(6...67)(
     [LocalVariableWriteNode(6...48)(
        (6...12),
-       HeredocNode(23...48)(
+       InterpolatedStringNode(23...48)(
          HEREDOC_START(15...22)("<<-\"^D\""),
          [StringNode(23...48)(
             nil,
@@ -11,8 +11,7 @@ ProgramNode(6...67)(
             nil,
             "        very long string\n"
           )],
-         HEREDOC_END(48...57)("      ^D\n"),
-         0
+         HEREDOC_END(48...57)("      ^D\n")
        ),
        (13...14),
        0

--- a/test/snapshots/seattlerb/str_heredoc_interp.rb
+++ b/test/snapshots/seattlerb/str_heredoc_interp.rb
@@ -1,7 +1,7 @@
 ProgramNode(5...16)(
   ScopeNode(0...0)([]),
   StatementsNode(5...16)(
-    [HeredocNode(5...16)(
+    [InterpolatedStringNode(5...16)(
        HEREDOC_START(0...4)("<<\"\""),
        [StringInterpolatedNode(5...9)(
           EMBEXPR_BEGIN(5...7)("\#{"),
@@ -25,8 +25,7 @@ ProgramNode(5...16)(
           nil,
           "\n" + "blah2\n"
         )],
-       HEREDOC_END(16...17)("\n"),
-       0
+       HEREDOC_END(16...17)("\n")
      )]
   )
 )

--- a/test/snapshots/tilde_heredocs.rb
+++ b/test/snapshots/tilde_heredocs.rb
@@ -1,13 +1,12 @@
-ProgramNode(7...248)(
+ProgramNode(7...271)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...248)(
-    [HeredocNode(7...11)(
+  StatementsNode(7...271)(
+    [InterpolatedStringNode(7...11)(
        HEREDOC_START(0...6)("<<~EOF"),
        [StringNode(7...11)(nil, STRING_CONTENT(7...11)("  a\n"), nil, "a\n")],
-       HEREDOC_END(11...15)("EOF\n"),
-       2
+       HEREDOC_END(11...15)("EOF\n")
      ),
-     HeredocNode(23...34)(
+     InterpolatedStringNode(23...34)(
        HEREDOC_START(16...22)("<<~EOF"),
        [StringNode(23...34)(
           nil,
@@ -15,10 +14,9 @@ ProgramNode(7...248)(
           nil,
           "\ta\n" + "b\n" + "\t\tc\n"
         )],
-       HEREDOC_END(34...38)("EOF\n"),
-       2
+       HEREDOC_END(34...38)("EOF\n")
      ),
-     HeredocNode(46...55)(
+     InterpolatedStringNode(46...55)(
        HEREDOC_START(39...45)("<<~EOF"),
        [StringNode(46...48)(nil, STRING_CONTENT(46...48)("  "), nil, ""),
         StringInterpolatedNode(48...52)(
@@ -32,10 +30,9 @@ ProgramNode(7...248)(
           nil,
           " a\n"
         )],
-       HEREDOC_END(55...59)("EOF\n"),
-       2
+       HEREDOC_END(55...59)("EOF\n")
      ),
-     HeredocNode(67...76)(
+     InterpolatedStringNode(67...76)(
        HEREDOC_START(60...66)("<<~EOF"),
        [StringNode(67...71)(nil, STRING_CONTENT(67...71)("  a "), nil, "a "),
         StringInterpolatedNode(71...75)(
@@ -44,10 +41,9 @@ ProgramNode(7...248)(
           EMBEXPR_END(74...75)("}")
         ),
         StringNode(75...76)(nil, STRING_CONTENT(75...76)("\n"), nil, "\n")],
-       HEREDOC_END(76...80)("EOF\n"),
-       2
+       HEREDOC_END(76...80)("EOF\n")
      ),
-     HeredocNode(88...98)(
+     InterpolatedStringNode(88...98)(
        HEREDOC_START(81...87)("<<~EOF"),
        [StringNode(88...93)(
           nil,
@@ -57,25 +53,13 @@ ProgramNode(7...248)(
         ),
         StringInterpolatedNode(93...97)(
           EMBEXPR_BEGIN(93...95)("\#{"),
-          StatementsNode(95...96)(
-            [CallNode(95...96)(
-               nil,
-               nil,
-               IDENTIFIER(95...96)("b"),
-               nil,
-               nil,
-               nil,
-               nil,
-               "b"
-             )]
-          ),
+          StatementsNode(95...96)([IntegerNode(95...96)()]),
           EMBEXPR_END(96...97)("}")
         ),
         StringNode(97...98)(nil, STRING_CONTENT(97...98)("\n"), nil, "\n")],
-       HEREDOC_END(98...102)("EOF\n"),
-       1
+       HEREDOC_END(98...102)("EOF\n")
      ),
-     HeredocNode(110...121)(
+     InterpolatedStringNode(110...121)(
        HEREDOC_START(103...109)("<<~EOF"),
        [StringNode(110...116)(
           nil,
@@ -85,18 +69,7 @@ ProgramNode(7...248)(
         ),
         StringInterpolatedNode(116...120)(
           EMBEXPR_BEGIN(116...118)("\#{"),
-          StatementsNode(118...119)(
-            [CallNode(118...119)(
-               nil,
-               nil,
-               IDENTIFIER(118...119)("b"),
-               nil,
-               nil,
-               nil,
-               nil,
-               "b"
-             )]
-          ),
+          StatementsNode(118...119)([IntegerNode(118...119)()]),
           EMBEXPR_END(119...120)("}")
         ),
         StringNode(120...121)(
@@ -105,10 +78,9 @@ ProgramNode(7...248)(
           nil,
           "\n"
         )],
-       HEREDOC_END(121...125)("EOF\n"),
-       2
+       HEREDOC_END(121...125)("EOF\n")
      ),
-     HeredocNode(133...141)(
+     InterpolatedStringNode(133...141)(
        HEREDOC_START(126...132)("<<~EOF"),
        [StringNode(133...141)(
           nil,
@@ -116,68 +88,67 @@ ProgramNode(7...248)(
           nil,
           "a\n" + "b\n"
         )],
-       HEREDOC_END(141...145)("EOF\n"),
-       2
+       HEREDOC_END(141...145)("EOF\n")
      ),
-     ArrayNode(146...148)(
-       [],
-       BRACKET_LEFT_ARRAY(146...147)("["),
-       BRACKET_RIGHT(147...148)("]")
-     ),
-     HeredocNode(157...166)(
-       HEREDOC_START(150...156)("<<~EOF"),
-       [StringNode(157...166)(
+     InterpolatedStringNode(153...162)(
+       HEREDOC_START(146...152)("<<~EOF"),
+       [StringNode(153...162)(
           nil,
-          STRING_CONTENT(157...166)("  a\n" + "   b\n"),
+          STRING_CONTENT(153...162)("  a\n" + "   b\n"),
           nil,
           "a\n" + " b\n"
         )],
-       HEREDOC_END(166...170)("EOF\n"),
-       2
+       HEREDOC_END(162...166)("EOF\n")
      ),
-     HeredocNode(178...187)(
-       HEREDOC_START(171...177)("<<~EOF"),
-       [StringNode(178...187)(
+     InterpolatedStringNode(174...183)(
+       HEREDOC_START(167...173)("<<~EOF"),
+       [StringNode(174...183)(
           nil,
-          STRING_CONTENT(178...187)("\t\t\ta\n" + "\t\tb\n"),
+          STRING_CONTENT(174...183)("\t\t\ta\n" + "\t\tb\n"),
           nil,
           "\ta\n" + "b\n"
         )],
-       HEREDOC_END(187...191)("EOF\n"),
-       16
+       HEREDOC_END(183...187)("EOF\n")
      ),
-     HeredocNode(201...210)(
-       HEREDOC_START(192...200)("<<~'EOF'"),
-       [StringNode(201...210)(
+     InterpolatedStringNode(197...206)(
+       HEREDOC_START(188...196)("<<~'EOF'"),
+       [StringNode(197...206)(
           nil,
-          STRING_CONTENT(201...210)("  a \#{1}\n"),
+          STRING_CONTENT(197...206)("  a \#{1}\n"),
           nil,
           "a \#{1}\n"
         )],
-       HEREDOC_END(210...214)("EOF\n"),
-       2
+       HEREDOC_END(206...210)("EOF\n")
      ),
-     HeredocNode(222...229)(
-       HEREDOC_START(215...221)("<<~EOF"),
-       [StringNode(222...229)(
+     InterpolatedStringNode(218...225)(
+       HEREDOC_START(211...217)("<<~EOF"),
+       [StringNode(218...225)(
           nil,
-          STRING_CONTENT(222...229)("\ta\n" + "\t b\n"),
+          STRING_CONTENT(218...225)("\ta\n" + "\t b\n"),
           nil,
           "a\n" + " b\n"
         )],
-       HEREDOC_END(229...233)("EOF\n"),
-       8
+       HEREDOC_END(225...229)("EOF\n")
      ),
-     HeredocNode(241...248)(
-       HEREDOC_START(234...240)("<<~EOF"),
-       [StringNode(241...248)(
+     InterpolatedStringNode(237...244)(
+       HEREDOC_START(230...236)("<<~EOF"),
+       [StringNode(237...244)(
           nil,
-          STRING_CONTENT(241...248)("\t a\n" + "\tb\n"),
+          STRING_CONTENT(237...244)("\t a\n" + "\tb\n"),
           nil,
           " a\n" + "b\n"
         )],
-       HEREDOC_END(248...252)("EOF\n"),
-       8
+       HEREDOC_END(244...248)("EOF\n")
+     ),
+     InterpolatedStringNode(256...271)(
+       HEREDOC_START(249...255)("<<~EOF"),
+       [StringNode(256...271)(
+          nil,
+          STRING_CONTENT(256...271)("  \ta\n" + "        b\n"),
+          nil,
+          "a\n" + "b\n"
+        )],
+       HEREDOC_END(271...275)("EOF\n")
      )]
   )
 )

--- a/test/snapshots/tilde_heredocs.rb
+++ b/test/snapshots/tilde_heredocs.rb
@@ -1,6 +1,6 @@
-ProgramNode(7...271)(
+ProgramNode(7...349)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...271)(
+  StatementsNode(7...349)(
     [InterpolatedStringNode(7...11)(
        HEREDOC_START(0...6)("<<~EOF"),
        [StringNode(7...11)(nil, STRING_CONTENT(7...11)("  a\n"), nil, "a\n")],
@@ -149,6 +149,38 @@ ProgramNode(7...271)(
           "a\n" + "b\n"
         )],
        HEREDOC_END(271...275)("EOF\n")
+     ),
+     InterpolatedStringNode(283...293)(
+       HEREDOC_START(276...282)("<<~EOF"),
+       [StringNode(283...293)(
+          nil,
+          STRING_CONTENT(283...293)("  a\n" + " \n" + "  b\n"),
+          nil,
+          "a\n" + "\n" + "b\n"
+        )],
+       HEREDOC_END(293...297)("EOF\n")
+     ),
+     InterpolatedStringNode(305...318)(
+       HEREDOC_START(298...304)("<<~EOF"),
+       [StringNode(305...318)(
+          nil,
+          STRING_CONTENT(305...318)("  a\n" + "    \n" + "  b\n"),
+          nil,
+          "a\n" + "  \n" + "b\n"
+        )],
+       HEREDOC_END(318...322)("EOF\n")
+     ),
+     InterpolatedStringNode(330...349)(
+       HEREDOC_START(323...329)("<<~EOF"),
+       [StringNode(330...349)(
+          nil,
+          STRING_CONTENT(330...349)(
+            "  a\n" + "    \n" + "\n" + "    \n" + "  b\n"
+          ),
+          nil,
+          "a\n" + "  \n" + "\n" + "  \n" + "b\n"
+        )],
+       HEREDOC_END(349...353)("EOF\n")
      )]
   )
 )

--- a/test/snapshots/tilde_heredocs.rb
+++ b/test/snapshots/tilde_heredocs.rb
@@ -1,6 +1,6 @@
-ProgramNode(7...349)(
+ProgramNode(7...370)(
   ScopeNode(0...0)([]),
-  StatementsNode(7...349)(
+  StatementsNode(7...370)(
     [InterpolatedStringNode(7...11)(
        HEREDOC_START(0...6)("<<~EOF"),
        [StringNode(7...11)(nil, STRING_CONTENT(7...11)("  a\n"), nil, "a\n")],
@@ -181,6 +181,27 @@ ProgramNode(7...349)(
           "a\n" + "  \n" + "\n" + "  \n" + "b\n"
         )],
        HEREDOC_END(349...353)("EOF\n")
+     ),
+     InterpolatedStringNode(361...370)(
+       HEREDOC_START(354...360)("<<~EOF"),
+       [StringNode(361...364)(
+          nil,
+          STRING_CONTENT(361...364)("\n" + "  "),
+          nil,
+          "\n"
+        ),
+        StringInterpolatedNode(364...368)(
+          EMBEXPR_BEGIN(364...366)("\#{"),
+          StatementsNode(366...367)([IntegerNode(366...367)()]),
+          EMBEXPR_END(367...368)("}")
+        ),
+        StringNode(368...370)(
+          nil,
+          STRING_CONTENT(368...370)("a\n"),
+          nil,
+          "a\n"
+        )],
+       HEREDOC_END(370...378)("    EOF\n")
      )]
   )
 )

--- a/test/snapshots/unescaping.rb
+++ b/test/snapshots/unescaping.rb
@@ -23,7 +23,7 @@ ProgramNode(0...50)(
        STRING_END(29...30)("\""),
        "\u0003{1}"
      ),
-     HeredocNode(40...50)(
+     InterpolatedStringNode(40...50)(
        HEREDOC_START(32...39)("<<~HERE"),
        [StringNode(40...50)(
           nil,
@@ -31,8 +31,7 @@ ProgramNode(0...50)(
           nil,
           "\u0003{1}\n"
         )],
-       HEREDOC_END(50...55)("HERE\n"),
-       3
+       HEREDOC_END(50...55)("HERE\n")
      )]
   )
 )

--- a/test/snapshots/unparser/corpus/literal/assignment.rb
+++ b/test/snapshots/unparser/corpus/literal/assignment.rb
@@ -626,7 +626,7 @@ ProgramNode(0...711)(
      ),
      LocalVariableWriteNode(562...583)(
        (562...563),
-       HeredocNode(577...583)(
+       InterpolatedStringNode(577...583)(
          HEREDOC_START(566...576)("<<-HEREDOC"),
          [StringNode(577...579)(
             nil,
@@ -645,8 +645,7 @@ ProgramNode(0...711)(
             nil,
             "\n"
           )],
-         HEREDOC_END(583...591)("HEREDOC\n"),
-         0
+         HEREDOC_END(583...591)("HEREDOC\n")
        ),
        (564...565),
        0
@@ -657,7 +656,7 @@ ProgramNode(0...711)(
        IDENTIFIER(593...594)("x"),
        nil,
        ArgumentsNode(606...612)(
-         [HeredocNode(606...612)(
+         [InterpolatedStringNode(606...612)(
             HEREDOC_START(595...605)("<<-HEREDOC"),
             [StringNode(606...608)(
                nil,
@@ -676,8 +675,7 @@ ProgramNode(0...711)(
                nil,
                "\n"
              )],
-            HEREDOC_END(612...620)("HEREDOC\n"),
-            0
+            HEREDOC_END(612...620)("HEREDOC\n")
           )]
        ),
        nil,
@@ -690,7 +688,7 @@ ProgramNode(0...711)(
        BRACKET_LEFT_RIGHT_EQUAL(621...622)("["),
        BRACKET_LEFT(621...622)("["),
        ArgumentsNode(637...643)(
-         [HeredocNode(637...643)(
+         [InterpolatedStringNode(637...643)(
             HEREDOC_START(626...636)("<<-HEREDOC"),
             [StringNode(637...639)(
                nil,
@@ -709,8 +707,7 @@ ProgramNode(0...711)(
                nil,
                "\n"
              )],
-            HEREDOC_END(643...651)("HEREDOC\n"),
-            0
+            HEREDOC_END(643...651)("HEREDOC\n")
           )]
        ),
        BRACKET_RIGHT(622...623)("]"),
@@ -724,7 +721,7 @@ ProgramNode(0...711)(
          BRACKET_LEFT_RIGHT_EQUAL(652...653)("["),
          BRACKET_LEFT(652...653)("["),
          ArgumentsNode(673...679)(
-           [HeredocNode(673...679)(
+           [InterpolatedStringNode(673...679)(
               HEREDOC_START(653...663)("<<-HEREDOC"),
               [StringNode(673...675)(
                  nil,
@@ -743,8 +740,7 @@ ProgramNode(0...711)(
                  nil,
                  "\n"
                )],
-              HEREDOC_END(679...687)("HEREDOC\n"),
-              0
+              HEREDOC_END(679...687)("HEREDOC\n")
             )]
          ),
          BRACKET_RIGHT(663...664)("]"),
@@ -765,7 +761,7 @@ ProgramNode(0...711)(
      ),
      OperatorOrAssignmentNode(687...711)(
        InstanceVariableWriteNode(687...689)((687...689), nil, nil),
-       HeredocNode(705...711)(
+       InterpolatedStringNode(705...711)(
          HEREDOC_START(694...704)("<<-HEREDOC"),
          [StringNode(705...707)(
             nil,
@@ -784,8 +780,7 @@ ProgramNode(0...711)(
             nil,
             "\n"
           )],
-         HEREDOC_END(711...719)("HEREDOC\n"),
-         0
+         HEREDOC_END(711...719)("HEREDOC\n")
        ),
        (690...693)
      )]

--- a/test/snapshots/unparser/corpus/literal/def.rb
+++ b/test/snapshots/unparser/corpus/literal/def.rb
@@ -1007,7 +1007,7 @@ ProgramNode(0...913)(
        nil,
        nil,
        StatementsNode(875...883)(
-         [HeredocNode(875...883)(
+         [InterpolatedStringNode(875...883)(
             HEREDOC_START(864...874)("<<-HEREDOC"),
             [StringNode(875...879)(
                nil,
@@ -1026,8 +1026,7 @@ ProgramNode(0...913)(
                nil,
                "\n"
              )],
-            HEREDOC_END(883...893)("  HEREDOC\n"),
-            0
+            HEREDOC_END(883...893)("  HEREDOC\n")
           )]
        ),
        ScopeNode(856...859)([]),

--- a/test/snapshots/unparser/corpus/literal/dstr.rb
+++ b/test/snapshots/unparser/corpus/literal/dstr.rb
@@ -23,7 +23,7 @@ ProgramNode(0...299)(
        KEYWORD_IF(21...23)("if"),
        TrueNode(24...28)(),
        StatementsNode(42...64)(
-         [HeredocNode(42...51)(
+         [InterpolatedStringNode(42...51)(
             HEREDOC_START(31...41)("<<-HEREDOC"),
             [StringNode(42...44)(
                nil,
@@ -42,8 +42,7 @@ ProgramNode(0...299)(
                nil,
                "a\n" + "b\n"
              )],
-            HEREDOC_END(51...61)("  HEREDOC\n"),
-            0
+            HEREDOC_END(51...61)("  HEREDOC\n")
           ),
           CallNode(63...64)(
             nil,
@@ -59,7 +58,7 @@ ProgramNode(0...299)(
        nil,
        KEYWORD_END(65...68)("end")
      ),
-     HeredocNode(80...101)(
+     InterpolatedStringNode(80...101)(
        HEREDOC_START(69...79)("<<-HEREDOC"),
        [StringNode(80...89)(
           nil,
@@ -90,11 +89,10 @@ ProgramNode(0...299)(
           nil,
           "\n"
         )],
-       HEREDOC_END(101...109)("HEREDOC\n"),
-       0
+       HEREDOC_END(101...109)("HEREDOC\n")
      ),
      RescueModifierNode(131...130)(
-       HeredocNode(131...137)(
+       InterpolatedStringNode(131...137)(
          HEREDOC_START(109...119)("<<-HEREDOC"),
          [StringInterpolatedNode(131...134)(
             EMBEXPR_BEGIN(131...133)("\#{"),
@@ -107,8 +105,7 @@ ProgramNode(0...299)(
             nil,
             "\n" + "a\n"
           )],
-         HEREDOC_END(137...145)("HEREDOC\n"),
-         0
+         HEREDOC_END(137...145)("HEREDOC\n")
        ),
        KEYWORD_RESCUE_MODIFIER(120...126)("rescue"),
        NilNode(127...130)()
@@ -144,7 +141,7 @@ ProgramNode(0...299)(
          [ReturnNode(184...212)(
             KEYWORD_RETURN(184...190)("return"),
             ArgumentsNode(202...212)(
-              [HeredocNode(202...212)(
+              [InterpolatedStringNode(202...212)(
                  HEREDOC_START(191...201)("<<-HEREDOC"),
                  [StringNode(202...206)(
                     nil,
@@ -163,8 +160,7 @@ ProgramNode(0...299)(
                     nil,
                     "\n"
                   )],
-                 HEREDOC_END(212...222)("  HEREDOC\n"),
-                 0
+                 HEREDOC_END(212...222)("  HEREDOC\n")
                )]
             )
           )]
@@ -178,7 +174,7 @@ ProgramNode(0...299)(
        IDENTIFIER(226...229)("foo"),
        PARENTHESIS_LEFT(229...230)("("),
        ArgumentsNode(242...251)(
-         [HeredocNode(242...251)(
+         [InterpolatedStringNode(242...251)(
             HEREDOC_START(230...240)("<<-HEREDOC"),
             [StringNode(242...244)(
                nil,
@@ -208,8 +204,7 @@ ProgramNode(0...299)(
                nil,
                "\n"
              )],
-            HEREDOC_END(251...259)("HEREDOC\n"),
-            0
+            HEREDOC_END(251...259)("HEREDOC\n")
           )]
        ),
        PARENTHESIS_RIGHT(240...241)(")"),
@@ -222,7 +217,7 @@ ProgramNode(0...299)(
        IDENTIFIER(259...262)("foo"),
        PARENTHESIS_LEFT(262...263)("("),
        ArgumentsNode(281...290)(
-         [HeredocNode(281...290)(
+         [InterpolatedStringNode(281...290)(
             HEREDOC_START(263...273)("<<-HEREDOC"),
             [StringNode(281...283)(
                nil,
@@ -252,8 +247,7 @@ ProgramNode(0...299)(
                nil,
                "\n"
              )],
-            HEREDOC_END(290...298)("HEREDOC\n"),
-            0
+            HEREDOC_END(290...298)("HEREDOC\n")
           )]
        ),
        PARENTHESIS_RIGHT(273...274)(")"),

--- a/test/snapshots/unparser/corpus/literal/literal.rb
+++ b/test/snapshots/unparser/corpus/literal/literal.rb
@@ -10,7 +10,7 @@ ProgramNode(2...916)(
             STRING_END(6...7)("\""),
             "foo"
           ),
-          HeredocNode(39...45)(
+          InterpolatedStringNode(39...45)(
             HEREDOC_START(11...21)("<<-HEREDOC"),
             [StringNode(39...41)(
                nil,
@@ -29,8 +29,7 @@ ProgramNode(2...916)(
                nil,
                "\n"
              )],
-            HEREDOC_END(45...53)("HEREDOC\n"),
-            0
+            HEREDOC_END(45...53)("HEREDOC\n")
           ),
           EQUAL_GREATER(8...10)("=>")
         ),
@@ -108,7 +107,7 @@ ProgramNode(2...916)(
          IDENTIFIER(98...99)("a"),
          PARENTHESIS_LEFT(99...100)("("),
          ArgumentsNode(114...120)(
-           [HeredocNode(114...120)(
+           [InterpolatedStringNode(114...120)(
               HEREDOC_START(100...110)("<<-HEREDOC"),
               [StringNode(114...116)(
                  nil,
@@ -127,8 +126,7 @@ ProgramNode(2...916)(
                  nil,
                  "\n"
                )],
-              HEREDOC_END(120...128)("HEREDOC\n"),
-              0
+              HEREDOC_END(120...128)("HEREDOC\n")
             )]
          ),
          PARENTHESIS_RIGHT(110...111)(")"),
@@ -178,7 +176,7 @@ ProgramNode(2...916)(
             STRING_END(143...144)("\""),
             "foo"
           ),
-          HeredocNode(168...174)(
+          InterpolatedStringNode(168...174)(
             HEREDOC_START(148...158)("<<-HEREDOC"),
             [StringNode(168...170)(
                nil,
@@ -197,8 +195,7 @@ ProgramNode(2...916)(
                nil,
                "\n"
              )],
-            HEREDOC_END(174...182)("HEREDOC\n"),
-            0
+            HEREDOC_END(174...182)("HEREDOC\n")
           ),
           EQUAL_GREATER(145...147)("=>")
         ),

--- a/test/snapshots/unparser/corpus/semantic/block.rb
+++ b/test/snapshots/unparser/corpus/semantic/block.rb
@@ -99,7 +99,7 @@ ProgramNode(0...148)(
        IDENTIFIER(82...85)("foo"),
        PARENTHESIS_LEFT(85...86)("("),
        ArgumentsNode(101...105)(
-         [HeredocNode(101...105)(
+         [InterpolatedStringNode(101...105)(
             HEREDOC_START(86...92)("<<-DOC"),
             [StringNode(101...105)(
                nil,
@@ -107,8 +107,7 @@ ProgramNode(0...148)(
                nil,
                "  b\n"
              )],
-            HEREDOC_END(105...109)("DOC\n"),
-            0
+            HEREDOC_END(105...109)("DOC\n")
           )]
        ),
        PARENTHESIS_RIGHT(92...93)(")"),
@@ -140,7 +139,7 @@ ProgramNode(0...148)(
        IDENTIFIER(118...121)("foo"),
        PARENTHESIS_LEFT(121...122)("("),
        ArgumentsNode(133...137)(
-         [HeredocNode(133...137)(
+         [InterpolatedStringNode(133...137)(
             HEREDOC_START(122...128)("<<-DOC"),
             [StringNode(133...137)(
                nil,
@@ -148,8 +147,7 @@ ProgramNode(0...148)(
                nil,
                "  b\n"
              )],
-            HEREDOC_END(137...141)("DOC\n"),
-            0
+            HEREDOC_END(137...141)("DOC\n")
           )]
        ),
        PARENTHESIS_RIGHT(128...129)(")"),

--- a/test/snapshots/unparser/corpus/semantic/dstr.rb
+++ b/test/snapshots/unparser/corpus/semantic/dstr.rb
@@ -1,31 +1,27 @@
 ProgramNode(0...608)(
   ScopeNode(0...0)([]),
   StatementsNode(0...608)(
-    [HeredocNode(0...5)(
+    [InterpolatedStringNode(0...5)(
        HEREDOC_START(0...5)("<<DOC"),
        [],
-       HEREDOC_END(6...10)("DOC\n"),
-       0
+       HEREDOC_END(6...10)("DOC\n")
      ),
-     HeredocNode(11...18)(
+     InterpolatedStringNode(11...18)(
        HEREDOC_START(11...18)("<<'DOC'"),
        [],
-       HEREDOC_END(19...23)("DOC\n"),
-       0
+       HEREDOC_END(19...23)("DOC\n")
      ),
-     HeredocNode(24...30)(
+     InterpolatedStringNode(24...30)(
        HEREDOC_START(24...30)("<<~DOC"),
        [],
-       HEREDOC_END(31...35)("DOC\n"),
-       0
+       HEREDOC_END(31...35)("DOC\n")
      ),
-     HeredocNode(36...44)(
+     InterpolatedStringNode(36...44)(
        HEREDOC_START(36...44)("<<~'DOC'"),
        [],
-       HEREDOC_END(45...49)("DOC\n"),
-       0
+       HEREDOC_END(45...49)("DOC\n")
      ),
-     HeredocNode(56...60)(
+     InterpolatedStringNode(56...60)(
        HEREDOC_START(50...55)("<<DOC"),
        [StringNode(56...60)(
           nil,
@@ -33,10 +29,9 @@ ProgramNode(0...608)(
           nil,
           "  a\n"
         )],
-       HEREDOC_END(60...64)("DOC\n"),
-       0
+       HEREDOC_END(60...64)("DOC\n")
      ),
-     HeredocNode(73...77)(
+     InterpolatedStringNode(73...77)(
        HEREDOC_START(65...72)("<<'DOC'"),
        [StringNode(73...77)(
           nil,
@@ -44,10 +39,9 @@ ProgramNode(0...608)(
           nil,
           "  a\n"
         )],
-       HEREDOC_END(77...81)("DOC\n"),
-       0
+       HEREDOC_END(77...81)("DOC\n")
      ),
-     HeredocNode(88...98)(
+     InterpolatedStringNode(88...98)(
        HEREDOC_START(82...87)("<<DOC"),
        [StringNode(88...94)(
           nil,
@@ -61,10 +55,9 @@ ProgramNode(0...608)(
           EMBEXPR_END(96...97)("}")
         ),
         StringNode(97...98)(nil, STRING_CONTENT(97...98)("\n"), nil, "\n")],
-       HEREDOC_END(98...102)("DOC\n"),
-       0
+       HEREDOC_END(98...102)("DOC\n")
      ),
-     HeredocNode(110...120)(
+     InterpolatedStringNode(110...120)(
        HEREDOC_START(103...109)("<<~DOC"),
        [StringNode(110...116)(
           nil,
@@ -83,10 +76,9 @@ ProgramNode(0...608)(
           nil,
           "\n"
         )],
-       HEREDOC_END(120...124)("DOC\n"),
-       2
+       HEREDOC_END(120...124)("DOC\n")
      ),
-     HeredocNode(132...146)(
+     InterpolatedStringNode(132...146)(
        HEREDOC_START(125...131)("<<~DOC"),
        [StringNode(132...138)(
           nil,
@@ -105,10 +97,9 @@ ProgramNode(0...608)(
           nil,
           "\n" + "b\n"
         )],
-       HEREDOC_END(146...150)("DOC\n"),
-       2
+       HEREDOC_END(146...150)("DOC\n")
      ),
-     HeredocNode(158...168)(
+     InterpolatedStringNode(158...168)(
        HEREDOC_START(151...157)("<<~DOC"),
        [StringNode(158...168)(
           nil,
@@ -116,10 +107,9 @@ ProgramNode(0...608)(
           nil,
           "a\n" + "  b\n"
         )],
-       HEREDOC_END(168...172)("DOC\n"),
-       2
+       HEREDOC_END(168...172)("DOC\n")
      ),
-     HeredocNode(181...186)(
+     InterpolatedStringNode(181...186)(
        HEREDOC_START(173...180)("<<'DOC'"),
        [StringNode(181...186)(
           nil,
@@ -127,10 +117,9 @@ ProgramNode(0...608)(
           nil,
           "a\n" + "\n" + "b\n"
         )],
-       HEREDOC_END(186...190)("DOC\n"),
-       0
+       HEREDOC_END(186...190)("DOC\n")
      ),
-     HeredocNode(199...206)(
+     InterpolatedStringNode(199...206)(
        HEREDOC_START(191...198)("<<'DOC'"),
        [StringNode(199...206)(
           nil,
@@ -138,10 +127,9 @@ ProgramNode(0...608)(
           nil,
           " a\n" + "\n" + " b\n"
         )],
-       HEREDOC_END(206...210)("DOC\n"),
-       0
+       HEREDOC_END(206...210)("DOC\n")
      ),
-     HeredocNode(219...225)(
+     InterpolatedStringNode(219...225)(
        HEREDOC_START(211...218)("<<'DOC'"),
        [StringNode(219...225)(
           nil,
@@ -149,10 +137,9 @@ ProgramNode(0...608)(
           nil,
           " a\n" + "b\n"
         )],
-       HEREDOC_END(225...229)("DOC\n"),
-       0
+       HEREDOC_END(225...229)("DOC\n")
      ),
-     HeredocNode(236...247)(
+     InterpolatedStringNode(236...247)(
        HEREDOC_START(230...235)("<<DOC"),
        [StringInterpolatedNode(236...239)(
           EMBEXPR_BEGIN(236...238)("\#{"),
@@ -176,10 +163,9 @@ ProgramNode(0...608)(
           nil,
           "a\n"
         )],
-       HEREDOC_END(247...251)("DOC\n"),
-       0
+       HEREDOC_END(247...251)("DOC\n")
      ),
-     HeredocNode(258...271)(
+     InterpolatedStringNode(258...271)(
        HEREDOC_START(252...257)("<<DOC"),
        [StringNode(258...260)(nil, STRING_CONTENT(258...260)("  "), nil, "  "),
         StringInterpolatedNode(260...263)(
@@ -193,10 +179,9 @@ ProgramNode(0...608)(
           nil,
           "\n" + "  \#{}\n"
         )],
-       HEREDOC_END(271...275)("DOC\n"),
-       0
+       HEREDOC_END(271...275)("DOC\n")
      ),
-     HeredocNode(282...292)(
+     InterpolatedStringNode(282...292)(
        HEREDOC_START(276...281)("<<DOC"),
        [StringNode(282...284)(nil, STRING_CONTENT(282...284)(" a"), nil, " a"),
         StringInterpolatedNode(284...287)(
@@ -210,10 +195,9 @@ ProgramNode(0...608)(
           nil,
           "b\n" + " c\n"
         )],
-       HEREDOC_END(292...296)("DOC\n"),
-       0
+       HEREDOC_END(292...296)("DOC\n")
      ),
-     HeredocNode(304...310)(
+     InterpolatedStringNode(304...310)(
        HEREDOC_START(297...303)("<<~DOC"),
        [StringNode(304...306)(nil, STRING_CONTENT(304...306)("  "), nil, ""),
         StringInterpolatedNode(306...309)(
@@ -227,14 +211,13 @@ ProgramNode(0...608)(
           nil,
           "\n"
         )],
-       HEREDOC_END(310...314)("DOC\n"),
-       2
+       HEREDOC_END(310...314)("DOC\n")
      ),
      IfNode(315...340)(
        KEYWORD_IF(315...317)("if"),
        TrueNode(318...322)(),
        StatementsNode(332...340)(
-         [HeredocNode(332...340)(
+         [InterpolatedStringNode(332...340)(
             HEREDOC_START(325...331)("<<~DOC"),
             [StringNode(332...336)(
                nil,
@@ -253,8 +236,7 @@ ProgramNode(0...608)(
                nil,
                "\n"
              )],
-            HEREDOC_END(340...346)("  DOC\n"),
-            4
+            HEREDOC_END(340...346)("  DOC\n")
           )]
        ),
        nil,
@@ -264,7 +246,7 @@ ProgramNode(0...608)(
        KEYWORD_IF(351...353)("if"),
        TrueNode(354...358)(),
        StatementsNode(368...377)(
-         [HeredocNode(368...377)(
+         [InterpolatedStringNode(368...377)(
             HEREDOC_START(361...367)("<<~DOC"),
             [StringNode(368...373)(
                nil,
@@ -283,8 +265,7 @@ ProgramNode(0...608)(
                nil,
                "\n"
              )],
-            HEREDOC_END(377...383)("  DOC\n"),
-            4
+            HEREDOC_END(377...383)("  DOC\n")
           )]
        ),
        nil,
@@ -294,7 +275,7 @@ ProgramNode(0...608)(
        KEYWORD_IF(388...390)("if"),
        TrueNode(391...395)(),
        StatementsNode(405...414)(
-         [HeredocNode(405...414)(
+         [InterpolatedStringNode(405...414)(
             HEREDOC_START(398...404)("<<~DOC"),
             [StringNode(405...409)(
                nil,
@@ -313,8 +294,7 @@ ProgramNode(0...608)(
                nil,
                "a\n"
              )],
-            HEREDOC_END(414...420)("  DOC\n"),
-            4
+            HEREDOC_END(414...420)("  DOC\n")
           )]
        ),
        nil,
@@ -324,7 +304,7 @@ ProgramNode(0...608)(
        KEYWORD_IF(425...427)("if"),
        TrueNode(428...432)(),
        StatementsNode(444...455)(
-         [HeredocNode(444...455)(
+         [InterpolatedStringNode(444...455)(
             HEREDOC_START(435...443)("<<-'DOC'"),
             [StringNode(444...455)(
                nil,
@@ -332,8 +312,7 @@ ProgramNode(0...608)(
                nil,
                "   a\n" + "\n" + "   b\n"
              )],
-            HEREDOC_END(455...461)("  DOC\n"),
-            0
+            HEREDOC_END(455...461)("  DOC\n")
           )]
        ),
        nil,

--- a/test/snapshots/unparser/corpus/semantic/while.rb
+++ b/test/snapshots/unparser/corpus/semantic/while.rb
@@ -155,11 +155,10 @@ ProgramNode(2...188)(
          IDENTIFIER(106...107)("b"),
          PARENTHESIS_LEFT(107...108)("("),
          ArgumentsNode(108...114)(
-           [HeredocNode(108...114)(
+           [InterpolatedStringNode(108...114)(
               HEREDOC_START(108...114)("<<-FOO"),
               [],
-              HEREDOC_END(119...123)("FOO\n"),
-              0
+              HEREDOC_END(119...123)("FOO\n")
             )]
          ),
          PARENTHESIS_RIGHT(114...115)(")"),

--- a/test/snapshots/whitequark/bug_heredoc_do.rb
+++ b/test/snapshots/whitequark/bug_heredoc_do.rb
@@ -7,11 +7,10 @@ ProgramNode(0...23)(
        IDENTIFIER(0...1)("f"),
        nil,
        ArgumentsNode(2...10)(
-         [HeredocNode(2...10)(
+         [InterpolatedStringNode(2...10)(
             HEREDOC_START(2...10)("<<-TABLE"),
             [],
-            HEREDOC_END(14...20)("TABLE\n"),
-            0
+            HEREDOC_END(14...20)("TABLE\n")
           )]
        ),
        nil,

--- a/test/snapshots/whitequark/dedenting_heredoc.rb
+++ b/test/snapshots/whitequark/dedenting_heredoc.rb
@@ -7,7 +7,7 @@ ProgramNode(0...306)(
        IDENTIFIER(0...1)("p"),
        nil,
        ArgumentsNode(9...26)(
-         [HeredocNode(9...26)(
+         [InterpolatedStringNode(9...26)(
             HEREDOC_START(2...8)("<<~\"E\""),
             [StringNode(9...17)(
                nil,
@@ -33,8 +33,7 @@ ProgramNode(0...306)(
                nil,
                "\n"
              )],
-            HEREDOC_END(26...28)("E\n"),
-            2
+            HEREDOC_END(26...28)("E\n")
           )]
        ),
        nil,
@@ -47,7 +46,7 @@ ProgramNode(0...306)(
        IDENTIFIER(29...30)("p"),
        nil,
        ArgumentsNode(38...53)(
-         [HeredocNode(38...53)(
+         [InterpolatedStringNode(38...53)(
             HEREDOC_START(31...37)("<<~\"E\""),
             [StringNode(38...46)(
                nil,
@@ -77,8 +76,7 @@ ProgramNode(0...306)(
                nil,
                "\n"
              )],
-            HEREDOC_END(53...55)("E\n"),
-            2
+            HEREDOC_END(53...55)("E\n")
           )]
        ),
        nil,
@@ -91,7 +89,7 @@ ProgramNode(0...306)(
        IDENTIFIER(56...57)("p"),
        nil,
        ArgumentsNode(63...76)(
-         [HeredocNode(63...76)(
+         [InterpolatedStringNode(63...76)(
             HEREDOC_START(58...62)("<<~E"),
             [StringNode(63...76)(
                nil,
@@ -99,8 +97,7 @@ ProgramNode(0...306)(
                nil,
                "x\n" + "y\n"
              )],
-            HEREDOC_END(76...78)("E\n"),
-            8
+            HEREDOC_END(76...78)("E\n")
           )]
        ),
        nil,
@@ -113,7 +110,7 @@ ProgramNode(0...306)(
        IDENTIFIER(79...80)("p"),
        nil,
        ArgumentsNode(86...95)(
-         [HeredocNode(86...95)(
+         [InterpolatedStringNode(86...95)(
             HEREDOC_START(81...85)("<<~E"),
             [StringNode(86...95)(
                nil,
@@ -121,8 +118,7 @@ ProgramNode(0...306)(
                nil,
                "\tx\n" + "y\n"
              )],
-            HEREDOC_END(95...97)("E\n"),
-            4
+            HEREDOC_END(95...97)("E\n")
           )]
        ),
        nil,
@@ -135,16 +131,15 @@ ProgramNode(0...306)(
        IDENTIFIER(98...99)("p"),
        nil,
        ArgumentsNode(105...122)(
-         [HeredocNode(105...122)(
+         [InterpolatedStringNode(105...122)(
             HEREDOC_START(100...104)("<<~E"),
             [StringNode(105...122)(
                nil,
                STRING_CONTENT(105...122)("    \tx\n" + "        y\n"),
                nil,
-               "\tx\n" + "y\n"
+               "x\n" + "y\n"
              )],
-            HEREDOC_END(122...124)("E\n"),
-            8
+            HEREDOC_END(122...124)("E\n")
           )]
        ),
        nil,
@@ -157,7 +152,7 @@ ProgramNode(0...306)(
        IDENTIFIER(125...126)("p"),
        nil,
        ArgumentsNode(132...146)(
-         [HeredocNode(132...146)(
+         [InterpolatedStringNode(132...146)(
             HEREDOC_START(127...131)("<<~E"),
             [StringNode(132...146)(
                nil,
@@ -165,8 +160,7 @@ ProgramNode(0...306)(
                nil,
                "\tx\n" + "y\n"
              )],
-            HEREDOC_END(146...148)("E\n"),
-            8
+            HEREDOC_END(146...148)("E\n")
           )]
        ),
        nil,
@@ -179,7 +173,7 @@ ProgramNode(0...306)(
        IDENTIFIER(149...150)("p"),
        nil,
        ArgumentsNode(156...168)(
-         [HeredocNode(156...168)(
+         [InterpolatedStringNode(156...168)(
             HEREDOC_START(151...155)("<<~E"),
             [StringNode(156...168)(
                nil,
@@ -187,8 +181,7 @@ ProgramNode(0...306)(
                nil,
                "  x\n" + "\ty\n"
              )],
-            HEREDOC_END(168...170)("E\n"),
-            2
+            HEREDOC_END(168...170)("E\n")
           )]
        ),
        nil,
@@ -201,7 +194,7 @@ ProgramNode(0...306)(
        IDENTIFIER(171...172)("p"),
        nil,
        ArgumentsNode(178...191)(
-         [HeredocNode(178...191)(
+         [InterpolatedStringNode(178...191)(
             HEREDOC_START(173...177)("<<~E"),
             [StringNode(178...191)(
                nil,
@@ -209,8 +202,7 @@ ProgramNode(0...306)(
                nil,
                "  x\n" + "  y\n"
              )],
-            HEREDOC_END(191...193)("E\n"),
-            2
+            HEREDOC_END(191...193)("E\n")
           )]
        ),
        nil,
@@ -223,11 +215,10 @@ ProgramNode(0...306)(
        IDENTIFIER(194...195)("p"),
        nil,
        ArgumentsNode(196...200)(
-         [HeredocNode(196...200)(
+         [InterpolatedStringNode(196...200)(
             HEREDOC_START(196...200)("<<~E"),
             [],
-            HEREDOC_END(201...205)("  E\n"),
-            0
+            HEREDOC_END(201...205)("  E\n")
           )]
        ),
        nil,
@@ -240,7 +231,7 @@ ProgramNode(0...306)(
        IDENTIFIER(206...207)("p"),
        nil,
        ArgumentsNode(213...220)(
-         [HeredocNode(213...220)(
+         [InterpolatedStringNode(213...220)(
             HEREDOC_START(208...212)("<<~E"),
             [StringNode(213...220)(
                nil,
@@ -248,8 +239,7 @@ ProgramNode(0...306)(
                nil,
                "  x\n" + "\n" + "y\n"
              )],
-            HEREDOC_END(220...222)("E\n"),
-            0
+            HEREDOC_END(220...222)("E\n")
           )]
        ),
        nil,
@@ -262,7 +252,7 @@ ProgramNode(0...306)(
        IDENTIFIER(223...224)("p"),
        nil,
        ArgumentsNode(230...243)(
-         [HeredocNode(230...243)(
+         [InterpolatedStringNode(230...243)(
             HEREDOC_START(225...229)("<<~E"),
             [StringNode(230...243)(
                nil,
@@ -270,8 +260,7 @@ ProgramNode(0...306)(
                nil,
                "x\n" + "  \n" + "y\n"
              )],
-            HEREDOC_END(243...245)("E\n"),
-            2
+            HEREDOC_END(243...245)("E\n")
           )]
        ),
        nil,
@@ -284,7 +273,7 @@ ProgramNode(0...306)(
        IDENTIFIER(246...247)("p"),
        nil,
        ArgumentsNode(253...263)(
-         [HeredocNode(253...263)(
+         [InterpolatedStringNode(253...263)(
             HEREDOC_START(248...252)("<<~E"),
             [StringNode(253...263)(
                nil,
@@ -292,8 +281,7 @@ ProgramNode(0...306)(
                nil,
                "x\n" + "  y\n"
              )],
-            HEREDOC_END(263...265)("E\n"),
-            2
+            HEREDOC_END(263...265)("E\n")
           )]
        ),
        nil,
@@ -306,7 +294,7 @@ ProgramNode(0...306)(
        IDENTIFIER(266...267)("p"),
        nil,
        ArgumentsNode(273...277)(
-         [HeredocNode(273...277)(
+         [InterpolatedStringNode(273...277)(
             HEREDOC_START(268...272)("<<~E"),
             [StringNode(273...277)(
                nil,
@@ -314,8 +302,7 @@ ProgramNode(0...306)(
                nil,
                "x\n"
              )],
-            HEREDOC_END(277...279)("E\n"),
-            2
+            HEREDOC_END(277...279)("E\n")
           )]
        ),
        nil,
@@ -328,7 +315,7 @@ ProgramNode(0...306)(
        IDENTIFIER(280...281)("p"),
        nil,
        ArgumentsNode(287...292)(
-         [HeredocNode(287...292)(
+         [InterpolatedStringNode(287...292)(
             HEREDOC_START(282...286)("<<~E"),
             [StringNode(287...292)(
                nil,
@@ -336,8 +323,7 @@ ProgramNode(0...306)(
                nil,
                "ð\n"
              )],
-            HEREDOC_END(292...294)("E\n"),
-            2
+            HEREDOC_END(292...294)("E\n")
           )]
        ),
        nil,
@@ -350,11 +336,10 @@ ProgramNode(0...306)(
        IDENTIFIER(295...296)("p"),
        nil,
        ArgumentsNode(297...301)(
-         [HeredocNode(297...301)(
+         [InterpolatedStringNode(297...301)(
             HEREDOC_START(297...301)("<<~E"),
             [],
-            HEREDOC_END(302...304)("E\n"),
-            0
+            HEREDOC_END(302...304)("E\n")
           )]
        ),
        nil,

--- a/test/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.rb
+++ b/test/snapshots/whitequark/dedenting_interpolating_heredoc_fake_line_continuation.rb
@@ -1,7 +1,7 @@
 ProgramNode(9...23)(
   ScopeNode(0...0)([]),
   StatementsNode(9...23)(
-    [HeredocNode(9...23)(
+    [InterpolatedStringNode(9...23)(
        HEREDOC_START(0...8)("<<~'FOO'"),
        [StringNode(9...23)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(9...23)(
           nil,
           "baz\\\n" + "qux\n"
         )],
-       HEREDOC_END(23...27)("FOO\n"),
-       2
+       HEREDOC_END(23...27)("FOO\n")
      )]
   )
 )

--- a/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.rb
+++ b/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.rb
@@ -1,7 +1,7 @@
 ProgramNode(9...22)(
   ScopeNode(0...0)([]),
   StatementsNode(9...22)(
-    [HeredocNode(9...22)(
+    [InterpolatedStringNode(9...22)(
        HEREDOC_START(0...8)("<<~'FOO'"),
        [StringNode(9...22)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(9...22)(
           nil,
           "baz\n" + "qux\n"
         )],
-       HEREDOC_END(22...26)("FOO\n"),
-       2
+       HEREDOC_END(22...26)("FOO\n")
      )]
   )
 )

--- a/test/snapshots/whitequark/heredoc.rb
+++ b/test/snapshots/whitequark/heredoc.rb
@@ -1,7 +1,7 @@
 ProgramNode(9...61)(
   ScopeNode(0...0)([]),
   StatementsNode(9...61)(
-    [HeredocNode(9...17)(
+    [InterpolatedStringNode(9...17)(
        HEREDOC_START(0...8)("<<'HERE'"),
        [StringNode(9...17)(
           nil,
@@ -9,10 +9,9 @@ ProgramNode(9...61)(
           nil,
           "foo\n" + "bar\n"
         )],
-       HEREDOC_END(17...22)("HERE\n"),
-       0
+       HEREDOC_END(17...22)("HERE\n")
      ),
-     HeredocNode(30...38)(
+     InterpolatedStringNode(30...38)(
        HEREDOC_START(23...29)("<<HERE"),
        [StringNode(30...38)(
           nil,
@@ -20,8 +19,7 @@ ProgramNode(9...61)(
           nil,
           "foo\n" + "bar\n"
         )],
-       HEREDOC_END(38...43)("HERE\n"),
-       0
+       HEREDOC_END(38...43)("HERE\n")
      ),
      InterpolatedXStringNode(53...61)(
        HEREDOC_START(44...52)("<<`HERE`"),

--- a/test/snapshots/whitequark/interp_digit_var.rb
+++ b/test/snapshots/whitequark/interp_digit_var.rb
@@ -233,7 +233,7 @@ ProgramNode(1...471)(
        STRING_END(350...351)("`"),
        "\#@@1"
      ),
-     HeredocNode(364...368)(
+     InterpolatedStringNode(364...368)(
        HEREDOC_START(354...363)("<<-\"HERE\""),
        [StringNode(364...368)(
           nil,
@@ -241,10 +241,9 @@ ProgramNode(1...471)(
           nil,
           "\#@1\n"
         )],
-       HEREDOC_END(368...373)("HERE\n"),
-       0
+       HEREDOC_END(368...373)("HERE\n")
      ),
-     HeredocNode(384...389)(
+     InterpolatedStringNode(384...389)(
        HEREDOC_START(374...383)("<<-\"HERE\""),
        [StringNode(384...389)(
           nil,
@@ -252,10 +251,9 @@ ProgramNode(1...471)(
           nil,
           "\#@@1\n"
         )],
-       HEREDOC_END(389...394)("HERE\n"),
-       0
+       HEREDOC_END(389...394)("HERE\n")
      ),
-     HeredocNode(405...409)(
+     InterpolatedStringNode(405...409)(
        HEREDOC_START(395...404)("<<-'HERE'"),
        [StringNode(405...409)(
           nil,
@@ -263,10 +261,9 @@ ProgramNode(1...471)(
           nil,
           "\#@1\n"
         )],
-       HEREDOC_END(409...414)("HERE\n"),
-       0
+       HEREDOC_END(409...414)("HERE\n")
      ),
-     HeredocNode(425...430)(
+     InterpolatedStringNode(425...430)(
        HEREDOC_START(415...424)("<<-'HERE'"),
        [StringNode(425...430)(
           nil,
@@ -274,8 +271,7 @@ ProgramNode(1...471)(
           nil,
           "\#@@1\n"
         )],
-       HEREDOC_END(430...435)("HERE\n"),
-       0
+       HEREDOC_END(430...435)("HERE\n")
      ),
      InterpolatedXStringNode(446...450)(
        HEREDOC_START(436...445)("<<-`HERE`"),

--- a/test/snapshots/whitequark/parser_bug_640.rb
+++ b/test/snapshots/whitequark/parser_bug_640.rb
@@ -1,7 +1,7 @@
 ProgramNode(7...20)(
   ScopeNode(0...0)([]),
   StatementsNode(7...20)(
-    [HeredocNode(7...20)(
+    [InterpolatedStringNode(7...20)(
        HEREDOC_START(0...6)("<<~FOO"),
        [StringNode(7...20)(
           nil,
@@ -9,8 +9,7 @@ ProgramNode(7...20)(
           nil,
           "baz\n" + "qux\n"
         )],
-       HEREDOC_END(20...24)("FOO\n"),
-       2
+       HEREDOC_END(20...24)("FOO\n")
      )]
   )
 )

--- a/test/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.rb
+++ b/test/snapshots/whitequark/parser_drops_truncated_parts_of_squiggly_heredoc.rb
@@ -1,7 +1,7 @@
 ProgramNode(8...14)(
   ScopeNode(0...0)([]),
   StatementsNode(8...14)(
-    [HeredocNode(8...14)(
+    [InterpolatedStringNode(8...14)(
        HEREDOC_START(0...7)("<<~HERE"),
        [StringNode(8...10)(nil, STRING_CONTENT(8...10)("  "), nil, ""),
         StringInterpolatedNode(10...13)(
@@ -10,8 +10,7 @@ ProgramNode(8...14)(
           EMBEXPR_END(12...13)("}")
         ),
         StringNode(13...14)(nil, STRING_CONTENT(13...14)("\n"), nil, "\n")],
-       HEREDOC_END(14...19)("HERE\n"),
-       2
+       HEREDOC_END(14...19)("HERE\n")
      )]
   )
 )

--- a/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
+++ b/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
@@ -111,7 +111,7 @@ ProgramNode(0...210)(
        STRING_END(138...139)("'"),
        "a\n" + "b"
      ),
-     HeredocNode(151...156)(
+     InterpolatedStringNode(151...156)(
        HEREDOC_START(141...150)("<<-\"HERE\""),
        [StringNode(151...156)(
           nil,
@@ -119,10 +119,9 @@ ProgramNode(0...210)(
           nil,
           "a\n" + "b\n"
         )],
-       HEREDOC_END(156...161)("HERE\n"),
-       0
+       HEREDOC_END(156...161)("HERE\n")
      ),
-     HeredocNode(172...177)(
+     InterpolatedStringNode(172...177)(
        HEREDOC_START(162...171)("<<-'HERE'"),
        [StringNode(172...177)(
           nil,
@@ -130,8 +129,7 @@ ProgramNode(0...210)(
           nil,
           "a\n" + "b\n"
         )],
-       HEREDOC_END(177...182)("HERE\n"),
-       0
+       HEREDOC_END(177...182)("HERE\n")
      ),
      InterpolatedXStringNode(193...198)(
        HEREDOC_START(183...192)("<<-`HERE`"),

--- a/test/snapshots/whitequark/ruby_bug_11989.rb
+++ b/test/snapshots/whitequark/ruby_bug_11989.rb
@@ -7,7 +7,7 @@ ProgramNode(0...1)(
        IDENTIFIER(0...1)("p"),
        nil,
        ArgumentsNode(9...19)(
-         [HeredocNode(9...19)(
+         [InterpolatedStringNode(9...19)(
             HEREDOC_START(2...8)("<<~\"E\""),
             [StringNode(9...19)(
                nil,
@@ -15,8 +15,7 @@ ProgramNode(0...1)(
                nil,
                "x\n" + " y\n"
              )],
-            HEREDOC_END(19...21)("E\n"),
-            2
+            HEREDOC_END(19...21)("E\n")
           )]
        ),
        nil,

--- a/test/snapshots/whitequark/ruby_bug_11990.rb
+++ b/test/snapshots/whitequark/ruby_bug_11990.rb
@@ -8,7 +8,7 @@ ProgramNode(0...1)(
        nil,
        ArgumentsNode(13...12)(
          [StringConcatNode(13...12)(
-            HeredocNode(13...17)(
+            InterpolatedStringNode(13...17)(
               HEREDOC_START(2...6)("<<~E"),
               [StringNode(13...17)(
                  nil,
@@ -16,8 +16,7 @@ ProgramNode(0...1)(
                  nil,
                  "x\n"
                )],
-              HEREDOC_END(17...19)("E\n"),
-              2
+              HEREDOC_END(17...19)("E\n")
             ),
             StringNode(7...12)(
               STRING_BEGIN(7...8)("\""),

--- a/test/snapshots/whitequark/slash_newline_in_heredocs.rb
+++ b/test/snapshots/whitequark/slash_newline_in_heredocs.rb
@@ -1,7 +1,7 @@
 ProgramNode(5...54)(
   ScopeNode(0...0)([]),
   StatementsNode(5...54)(
-    [HeredocNode(5...25)(
+    [InterpolatedStringNode(5...25)(
        HEREDOC_START(0...4)("<<-E"),
        [StringNode(5...25)(
           nil,
@@ -9,10 +9,9 @@ ProgramNode(5...54)(
           nil,
           "    1 \n" + "    2\n" + "    3\n"
         )],
-       HEREDOC_END(25...27)("E\n"),
-       0
+       HEREDOC_END(25...27)("E\n")
      ),
-     HeredocNode(34...54)(
+     InterpolatedStringNode(34...54)(
        HEREDOC_START(29...33)("<<~E"),
        [StringNode(34...54)(
           nil,
@@ -20,8 +19,7 @@ ProgramNode(5...54)(
           nil,
           "1 \n" + "2\n" + "3\n"
         )],
-       HEREDOC_END(54...56)("E\n"),
-       4
+       HEREDOC_END(54...56)("E\n")
      )]
   )
 )


### PR DESCRIPTION
* Extract out the heredoc dedent functions
* Fold heredocs into interpolated strings, fixes #470 
* Split out `yp_string_ensure_owned` which copies if necessary
* Blank lines shouldn't count toward common leading whitespace calculation, fixes one of the seattlerb ones
* Support nested heredocs, fixes #418
* Instead of allocating a new string, copying into it, then copying back, use memmove to shift left