### PR TITLE
add line number and line event support

### DIFF
--- a/bin/dump
+++ b/bin/dump
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$:.unshift(File.expand_path("../lib", __dir__))
+require "yarp"
+
+source = File.read("test.rb")
+
+pp YARP.load(source, YARP.dump(source, "test.rb"))

--- a/bin/templates/lib/yarp/serialize.rb.erb
+++ b/bin/templates/lib/yarp/serialize.rb.erb
@@ -68,7 +68,9 @@ module YARP
 
       def load_location
         start_offset, end_offset = io.read(8).unpack("LL")
-        Location.new(start_offset, end_offset)
+        start_line, start_column = io.read(8).unpack("LL")
+        end_line, end_column = io.read(8).unpack("LL")
+        Location.new(start_offset, end_offset, start_line, start_column, end_line, end_column)
       end
 
       def load_optional_location

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -8,27 +8,68 @@
 #include "yarp/util/yp_buffer.h"
 #include "yarp/util/yp_conversion.h"
 
+static inline uint32_t
+line_number(char **newline_locations, const char *start) {
+  uint32_t index = 0;
+
+  while (newline_locations[index] != NULL) {
+    if (start < newline_locations[index]) {
+      return index + 1;
+    }
+    index++;
+  }
+  return index == 0 ? 1 : index;
+}
+
+static inline uint32_t
+column_number(yp_parser_t *parser, char **newline_locations, const char *start) {
+  uint32_t index = 0;
+
+  while (newline_locations[index] != NULL) {
+    if (start < newline_locations[index]) {
+      if (index == 0) {
+        return start - parser->start;
+      } else {
+        return start - newline_locations[index - 1];
+      }
+    }
+    index++;
+  }
+  return index == 0 ? 1 : index;
+}
+
 static void
-serialize_token(yp_parser_t *parser, yp_token_t *token, yp_buffer_t *buffer) {
+serialize_token(yp_parser_t *parser, yp_token_t *token, char **newline_locations, yp_buffer_t *buffer) {
   assert(token->start);
   assert(token->end);
+
 
   yp_buffer_append_u8(buffer, token->type);
   yp_buffer_append_u32(buffer, yp_long_to_u32(token->start - parser->start));
   yp_buffer_append_u32(buffer, yp_long_to_u32(token->end - parser->start));
+
+  yp_buffer_append_u32(buffer, line_number(newline_locations, token->start));
+  yp_buffer_append_u32(buffer, column_number(parser, newline_locations, token->start));
+  yp_buffer_append_u32(buffer, line_number(newline_locations, token->end));
+  yp_buffer_append_u32(buffer, column_number(parser, newline_locations, token->end));
 }
 
 static void
-serialize_location(yp_parser_t *parser, yp_location_t *location, yp_buffer_t *buffer) {
+serialize_location(yp_parser_t *parser, yp_location_t *location, char **newline_locations, yp_buffer_t *buffer) {
   assert(location->start);
   assert(location->end);
 
   yp_buffer_append_u32(buffer, yp_long_to_u32(location->start - parser->start));
   yp_buffer_append_u32(buffer, yp_long_to_u32(location->end - parser->start));
+
+  yp_buffer_append_u32(buffer, line_number(newline_locations, location->start));
+  yp_buffer_append_u32(buffer, column_number(parser, newline_locations, location->start));
+  yp_buffer_append_u32(buffer, line_number(newline_locations, location->end));
+  yp_buffer_append_u32(buffer, column_number(parser, newline_locations, location->end));
 }
 
 void
-yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
+yp_serialize_node(yp_parser_t *parser, yp_node_t *node, char ** newline_locations, yp_buffer_t *buffer) {
   yp_buffer_append_u8(buffer, node->type);
 
   size_t offset = buffer->length;
@@ -37,8 +78,7 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
   assert(node->location.start);
   assert(node->location.end);
 
-  yp_buffer_append_u32(buffer, yp_long_to_u32(node->location.start - parser->start));
-  yp_buffer_append_u32(buffer, yp_long_to_u32(node->location.end - parser->start));
+  serialize_location(parser, &node->location, newline_locations, buffer);
 
   switch (node->type) {
     <%- nodes.each do |node| -%>
@@ -46,12 +86,12 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
       <%- node.params.each do |param| -%>
       <%- case param -%>
       <%- when NodeParam -%>
-      yp_serialize_node(parser, (yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
+      yp_serialize_node(parser, (yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>, newline_locations, buffer);
       <%- when OptionalNodeParam -%>
       if (((yp_<%= node.human %>_t *)node)-><%= param.name %> == NULL) {
         yp_buffer_append_u8(buffer, 0);
       } else {
-        yp_serialize_node(parser, (yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
+        yp_serialize_node(parser, (yp_node_t *)((yp_<%= node.human %>_t *)node)-><%= param.name %>, newline_locations, buffer);
       }
       <%- when StringParam -%>
       uint32_t <%= param.name %>_length = yp_ulong_to_u32(yp_string_length(&((yp_<%= node.human %>_t *)node)-><%= param.name %>));
@@ -61,30 +101,30 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
       uint32_t <%= param.name %>_size = yp_ulong_to_u32(((yp_<%= node.human %>_t *)node)-><%= param.name %>.size);
       yp_buffer_append_u32(buffer, <%= param.name %>_size);
       for (uint32_t index = 0; index < <%= param.name %>_size; index++) {
-        yp_serialize_node(parser, (yp_node_t *) ((yp_<%= node.human %>_t *)node)-><%= param.name %>.nodes[index], buffer);
+        yp_serialize_node(parser, (yp_node_t *) ((yp_<%= node.human %>_t *)node)-><%= param.name %>.nodes[index], newline_locations, buffer);
       }
       <%- when TokenParam -%>
-      serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
+      serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, newline_locations, buffer);
       <%- when OptionalTokenParam -%>
       if (((yp_<%= node.human %>_t *)node)-><%= param.name %>.type == YP_TOKEN_NOT_PROVIDED) {
         yp_buffer_append_u8(buffer, 0);
       } else {
-        serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
+        serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, newline_locations, buffer);
       }
       <%- when TokenListParam -%>
       uint32_t <%= param.name %>_size = yp_ulong_to_u32(((yp_<%= node.human %>_t *)node)-><%= param.name %>.size);
       yp_buffer_append_u32(buffer, <%= param.name %>_size);
       for (uint32_t index = 0; index < <%= param.name %>_size; index++) {
-        serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>.tokens[index], buffer);
+        serialize_token(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>.tokens[index], newline_locations, buffer);
       }
       <%- when LocationParam -%>
-      serialize_location(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
+      serialize_location(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, newline_locations, buffer);
       <%- when OptionalLocationParam -%>
       if (((yp_<%= node.human %>_t *)node)-><%= param.name %>.start == NULL) {
         yp_buffer_append_u8(buffer, 0);
       } else {
         yp_buffer_append_u8(buffer, 1);
-        serialize_location(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, buffer);
+        serialize_location(parser, &((yp_<%= node.human %>_t *)node)-><%= param.name %>, newline_locations, buffer);
       }
       <%- when IntegerParam -%>
       yp_buffer_append_int(buffer, ((yp_<%= node.human %>_t *)node)-><%= param.name %>);

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -19,6 +19,10 @@ After the header comes the body of the serialized string. The body consistents o
 | `4` | byte offset into the serialized string where this node ends |
 | `4` | byte offset into the source string where this node begins |
 | `4` | byte offset into the source string where this node ends |
+| `4` | line number where this node begins |
+| `4` | column number where this node begins |
+| `4` | line number where this node end |
+| `4` | column number where this node ends |
 
 Each node's child is then appended to the serialized string. The child node types can be determined by referencing `config.yml`. Depending on the type of child node, it could take a couple of different forms, described below:
 

--- a/ext/yarp/extension.c
+++ b/ext/yarp/extension.c
@@ -441,7 +441,7 @@ compile(VALUE self, VALUE string) {
     if (source[i] == '\n') {
       if (index + 1 == size) {
         size *= 2;
-        realloc(newline_locations, size);
+        newline_locations = realloc(newline_locations, sizeof(char*) * size);
       }
       
       newline_locations[index++] = &source[i];

--- a/ext/yarp/extension.h
+++ b/ext/yarp/extension.h
@@ -19,7 +19,7 @@ VALUE
 yp_node_new(yp_parser_t *parser, yp_node_t *node, rb_encoding *encoding);
 
 VALUE
-yp_compile(yp_node_t *node);
+yp_compile(yp_node_t *node, char **newline_locations);
 
 void
 Init_yarp_pack(void);

--- a/include/yarp.h
+++ b/include/yarp.h
@@ -26,7 +26,7 @@
 #define YP_VERSION_PATCH 0
 
 void
-yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer);
+yp_serialize_node(yp_parser_t *parser, yp_node_t *node, char **newline_locations, yp_buffer_t *buffer);
 
 void
 yp_print_node(yp_parser_t *parser, yp_node_t *node);

--- a/lib/yarp.rb
+++ b/lib/yarp.rb
@@ -5,9 +5,14 @@ module YARP
   class Location
     attr_reader :start_offset, :end_offset
 
-    def initialize(start_offset, end_offset)
+    def initialize(start_offset, end_offset, start_line = nil, start_column = nil, end_line = nil, end_column = nil)
       @start_offset = start_offset
       @end_offset = end_offset
+
+      @start_line = start_line
+      @start_column = start_column
+      @end_line = end_line
+      @end_column = end_column
     end
 
     def deconstruct_keys(keys)
@@ -15,7 +20,11 @@ module YARP
     end
 
     def pretty_print(q)
-      q.text("(#{start_offset}...#{end_offset})")
+      if @start_line
+        q.text("(#{start_offset}...#{end_offset})#{@start_line}:#{@start_column}-#{@end_line}:#{@end_column}")
+      else
+        q.text("(#{start_offset}...#{end_offset})")
+      end
     end
 
     def ==(other)

--- a/test/compile_test.rb
+++ b/test/compile_test.rb
@@ -188,6 +188,8 @@ class CompileTest < Test::Unit::TestCase
         assert_equal_iseqs expected_block, actual_block
       in Array | :RUBY_EVENT_B_CALL | :RUBY_EVENT_B_RETURN | /^label_\d+/
         assert_equal insn, actual[13].shift
+      in Integer | :RUBY_EVENT_LINE
+        assert_equal insn, actual[13].shift
       in Integer | /^RUBY_EVENT_/
         # skip these for now
       else


### PR DESCRIPTION
Now we can emit line events and line numbers like Ruby does!

example, 

```
1 +
  2 +
  3
```

```
[1,
  :RUBY_EVENT_LINE,
  [:putobject, 1],
  2,
  [:putobject, 2],
  1,
  [:send, {:mid=>:+, :flag=>16, :orig_argc=>1}, nil],
  3,
  [:putobject, 3],
  2,
  [:send, {:mid=>:+, :flag=>16, :orig_argc=>1}, nil],
  [:leave]]]
```

Related: https://github.com/Shopify/yarp/discussions/667