### PR TITLE
Fix existing build warnings

### DIFF
--- a/ext/yarp/compile.c
+++ b/ext/yarp/compile.c
@@ -175,7 +175,7 @@ yp_iseq_new(yp_iseq_compiler_t *compiler) {
   rb_hash_aset(data, ID2SYM(rb_intern("code_location")), code_location);
   rb_hash_aset(data, ID2SYM(rb_intern("node_ids")), compiler->node_ids);
 
-  VALUE type;
+  VALUE type = Qnil;
   switch (compiler->type) {
     case YP_ISEQ_TYPE_TOP:
       type = ID2SYM(rb_intern("top"));

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -231,7 +231,7 @@ unescape(char *dest, size_t *dest_length, const char *backslash, const char *end
 
         while ((*unicode_cursor != '}') && (unicode_cursor < end)) {
           const char *unicode_start = unicode_cursor;
-          int hexadecimal_length = yp_strspn_hexadecimal_digit(unicode_cursor, end - unicode_cursor);
+          size_t hexadecimal_length = yp_strspn_hexadecimal_digit(unicode_cursor, end - unicode_cursor);
 
           // \u{nnnn} character literal allows only 1-6 hexadecimal digits
           if (hexadecimal_length > 6)


### PR DESCRIPTION
Confirmed there are now [no compiler warnings](https://github.com/Shopify/yarp/actions/runs/4612485609/jobs/8153436795?pr=767) where [there previously were](https://github.com/Shopify/yarp/actions/runs/4609053009/jobs/8145649611) on the "Run Ruby tests" tab