### PR TITLE
Fix trailing embdoc

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4502,12 +4502,13 @@ lex_embdoc(yp_parser_t *parser) {
 
   // Now, loop until we find the end of the embedded documentation or the end of
   // the file.
-  while (parser->current.end + 5 < parser->end) {
+  while (parser->current.end + 4 < parser->end) {
     parser->current.start = parser->current.end;
 
     // If we've hit the end of the embedded documentation then we'll return that
     // token here.
-    if (strncmp(parser->current.end, "=end", 4) == 0 && yp_char_is_whitespace(parser->current.end[4])) {
+    if (strncmp(parser->current.end, "=end", 4) == 0 &&
+	(yp_char_is_whitespace(parser->current.end[4]) || parser->current.end + 4 == parser->end)) {
       const char *newline = memchr(parser->current.end, '\n', (size_t) (parser->end - parser->current.end));
       parser->current.end = newline == NULL ? parser->end : newline + 1;
       parser->current.type = YP_TOKEN_EMBDOC_END;

--- a/test/comments_test.rb
+++ b/test/comments_test.rb
@@ -40,6 +40,8 @@ class CommentsTest < Test::Unit::TestCase
   private
 
   def assert_comment(source, type)
-    YARP.parse_dup(source) => YARP::ParseResult[comments: [YARP::Comment[type: type]]]
+    result = YARP.parse_dup(source)
+    assert result.errors.empty?, result.errors.map(&:message).join("\n")
+    result => YARP::ParseResult[comments: [YARP::Comment[type: type]]]
   end
 end


### PR DESCRIPTION
Asserted that the changes to comment_test made the existing test fail (since it threw an error) before the fix.

Closes #759 