### PR TITLE
Start node_type and token_type enums at 1

### DIFF
--- a/bin/templates/include/yarp/ast.h.erb
+++ b/bin/templates/include/yarp/ast.h.erb
@@ -39,7 +39,7 @@ typedef struct yp_node_list {
 
 typedef enum {
 <%- nodes.each_with_index do |node, index| -%>
-  <%= node.type %> = <%= index %>,
+  <%= node.type %> = <%= index + 1 %>,
 <%- end -%>
 } yp_node_type_t;
 

--- a/bin/templates/lib/yarp/serialize.rb.erb
+++ b/bin/templates/lib/yarp/serialize.rb.erb
@@ -32,7 +32,7 @@ module YARP
         type =
           case number
           <%- tokens.each_with_index do |token, index| -%>
-          when <%= index %> then :<%= token.name %>
+          when <%= index + 1 %> then :<%= token.name %>
           <%- end -%>
           end
 
@@ -76,7 +76,7 @@ module YARP
 
         case type
         <%- nodes.each_with_index do |node, index| -%>
-        when <%= index %> then <%= node.name %>.new(<%= (node.params.map { |param|
+        when <%= index + 1 %> then <%= node.name %>.new(<%= (node.params.map { |param|
           case param
           when NodeParam then "load_node"
           when OptionalNodeParam then "load_optional_node"

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 tokens:
   - name: EOF
-    value: 0
+    value: 1
     comment: final token in the file
   - name: MISSING
     comment: "a token that was expected but not found"


### PR DESCRIPTION
This allows us to distinguish between not provided and having actual values

Closes #665 