### PR TITLE
Allow generic option collection in templating parameters

### DIFF
--- a/bin/template.rb
+++ b/bin/template.rb
@@ -4,9 +4,30 @@ require "erb"
 require "fileutils"
 require "yaml"
 
+class Param
+  attr_reader :name, :options
+  
+  def initialize(name:, type:, **options)
+    @name, @type, @options = name, type, options
+  end
+end
+
+module CTypes
+  def c_type
+    if options[:kind]
+      "yp_#{options[:kind].gsub(/(?<=.)[A-Z]/, "_\\0").downcase}"
+    else
+      "yp_node"
+    end
+  end
+end
+
+
 # This represents a parameter to a node that is itself a node. We pass them as
 # references and store them as references.
-class NodeParam < Struct.new(:name, :c_type)
+class NodeParam < Param
+  include CTypes
+  
   def param = "yp_node_t *#{name}"
   def rbs_class = "Node"
   def java_type = "Node"
@@ -14,7 +35,9 @@ end
 
 # This represents a parameter to a node that is itself a node and can be
 # optionally null. We pass them as references and store them as references.
-class OptionalNodeParam < Struct.new(:name, :c_type, :fallback)
+class OptionalNodeParam < Param
+  include CTypes
+  
   def param = "yp_node_t *#{name}"
   def rbs_class = "Node?"
   def java_type = "Node"
@@ -24,7 +47,7 @@ SingleNodeParam = -> (node) { NodeParam === node or OptionalNodeParam === node }
 
 # This represents a parameter to a node that is a list of nodes. We pass them as
 # references and store them as references.
-class NodeListParam < Struct.new(:name)
+class NodeListParam < Param
   def param = nil
   def rbs_class = "Array[Node]"
   def java_type = "Node[]"
@@ -32,53 +55,66 @@ end
 
 # This represents a parameter to a node that is a token. We pass them as
 # references and store them by copying.
-class TokenParam < Struct.new(:name)
+class TokenParam < Param
   def param = "const yp_token_t *#{name}"
   def rbs_class = "Token"
   def java_type = "Token"
 end
 
 # This represents a parameter to a node that is a token that is optional.
-class OptionalTokenParam < Struct.new(:name)
+class OptionalTokenParam < Param
   def param = "const yp_token_t *#{name}"
   def rbs_class = "Token?"
   def java_type = "Token"
 end
 
 # This represents a parameter to a node that is a list of tokens.
-class TokenListParam < Struct.new(:name)
+class TokenListParam < Param
   def param = nil
   def rbs_class = "Array[Token]"
   def java_type = "Token[]"
 end
 
 # This represents a parameter to a node that is a string.
-class StringParam < Struct.new(:name)
+class StringParam < Param
   def param = nil
   def rbs_class = "String"
   def java_type = "byte[]"
 end
 
 # This represents a parameter to a node that is a location.
-class LocationParam < Struct.new(:name)
+class LocationParam < Param
   def param = "const yp_location_t *#{name}"
   def rbs_class = "Location"
   def java_type = "Location"
 end
 
 # This represents a parameter to a node that is a location that is optional.
-class OptionalLocationParam < Struct.new(:name)
+class OptionalLocationParam < Param
   def param = "const yp_location_t *#{name}"
   def rbs_class = "Location?"
   def java_type = "Location"
 end
 
 # This represents an integer parameter.
-class IntegerParam < Struct.new(:name)
+class IntegerParam < Param
   def param = "int #{name}"
   def rbs_class = "Integer"
   def java_type = "int"
 end
+
+PARAM_TYPES = {
+  "node" => NodeParam,
+  "node?" => OptionalNodeParam,
+  "node[]" => NodeListParam,
+  "string" => StringParam,
+  "token" => TokenParam,
+  "token?" => OptionalTokenParam,
+  "token[]" => TokenListParam,
+  "location" => LocationParam,
+  "location?" => OptionalLocationParam,
+  "integer" => IntegerParam,
+  }
 
 # This class represents a node in the tree, configured by the config.yml file in
 # YAML format. It contains information about the name of the node and the
@@ -92,36 +128,11 @@ class NodeType
     type = @name.gsub(/(?<=.)[A-Z]/, "_\\0")
     @type = "YP_NODE_#{type.upcase}"
     @human = type.downcase
-
-    @params =
-      config.fetch("child_nodes", []).map do |param|
-        name = param.fetch("name")
-
-        case (type = param.fetch("type"))
-        when "node", "node?"
-          c_type = param["kind"].nil? ? "yp_node" : "yp_#{param["kind"].gsub(/(?<=.)[A-Z]/, "_\\0").downcase}"
-          (type == "node" ? NodeParam : OptionalNodeParam).new(name, c_type)
-        when "node[]"
-          NodeListParam.new(name)
-        when "string"
-          StringParam.new(name)
-        when "token"
-          TokenParam.new(name)
-        when "token?"
-          OptionalTokenParam.new(name)
-        when "token[]"
-          TokenListParam.new(name)
-        when "location"
-          LocationParam.new(name)
-        when "location?"
-          OptionalLocationParam.new(name)
-        when "integer"
-          IntegerParam.new(name)
-        else
-          raise "Unknown param type: #{param["type"].inspect}"
-        end
-      end
-
+    @params = config.fetch("child_nodes", []).map do |param|
+      param_type = PARAM_TYPES[param.fetch("type")] ||
+                   raise("Unknown param type: #{param["type"].inspect}")
+      param_type.new(**param.transform_keys(&:to_sym))
+    end
     @comment = config.fetch("comment")
   end
 end

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -28,7 +28,6 @@ end
 class NodeParam < Param
   include CTypes
   
-  def param = "yp_node_t *#{name}"
   def rbs_class = "Node"
   def java_type = "Node"
 end
@@ -38,7 +37,6 @@ end
 class OptionalNodeParam < Param
   include CTypes
   
-  def param = "yp_node_t *#{name}"
   def rbs_class = "Node?"
   def java_type = "Node"
 end
@@ -48,7 +46,6 @@ SingleNodeParam = -> (node) { NodeParam === node or OptionalNodeParam === node }
 # This represents a parameter to a node that is a list of nodes. We pass them as
 # references and store them as references.
 class NodeListParam < Param
-  def param = nil
   def rbs_class = "Array[Node]"
   def java_type = "Node[]"
 end
@@ -56,49 +53,42 @@ end
 # This represents a parameter to a node that is a token. We pass them as
 # references and store them by copying.
 class TokenParam < Param
-  def param = "const yp_token_t *#{name}"
   def rbs_class = "Token"
   def java_type = "Token"
 end
 
 # This represents a parameter to a node that is a token that is optional.
 class OptionalTokenParam < Param
-  def param = "const yp_token_t *#{name}"
   def rbs_class = "Token?"
   def java_type = "Token"
 end
 
 # This represents a parameter to a node that is a list of tokens.
 class TokenListParam < Param
-  def param = nil
   def rbs_class = "Array[Token]"
   def java_type = "Token[]"
 end
 
 # This represents a parameter to a node that is a string.
 class StringParam < Param
-  def param = nil
   def rbs_class = "String"
   def java_type = "byte[]"
 end
 
 # This represents a parameter to a node that is a location.
 class LocationParam < Param
-  def param = "const yp_location_t *#{name}"
   def rbs_class = "Location"
   def java_type = "Location"
 end
 
 # This represents a parameter to a node that is a location that is optional.
 class OptionalLocationParam < Param
-  def param = "const yp_location_t *#{name}"
   def rbs_class = "Location?"
   def java_type = "Location"
 end
 
 # This represents an integer parameter.
 class IntegerParam < Param
-  def param = "int #{name}"
   def rbs_class = "Integer"
   def java_type = "int"
 end

--- a/bin/template.rb
+++ b/bin/template.rb
@@ -104,7 +104,7 @@ PARAM_TYPES = {
   "location" => LocationParam,
   "location?" => OptionalLocationParam,
   "integer" => IntegerParam,
-  }
+}
 
 # This class represents a node in the tree, configured by the config.yml file in
 # YAML format. It contains information about the name of the node and the


### PR DESCRIPTION
This is a transitional PR which allows extra attributes of parameters from config.yml to get saved as 'options' to the parameter we interact with when generating code via ERB.

Why? In my current branch I have marked syntactical tokens that execution is uninterested in serializing (and then loading into an AST) as 'exclude: execute'.  My templates for serialize.c, Nodes.java, and Loader.java then will skip those elements altogether. I can think of other useful attributes we can put in to help with generation.