### PR TITLE
Fix small embdoc off at end

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -4593,13 +4593,13 @@ lex_embdoc(yp_parser_t *parser) {
 
   // Now, loop until we find the end of the embedded documentation or the end of
   // the file.
-  while (parser->current.end + 4 < parser->end) {
+  while (parser->current.end + 4 <= parser->end) {
     parser->current.start = parser->current.end;
 
     // If we've hit the end of the embedded documentation then we'll return that
     // token here.
     if (strncmp(parser->current.end, "=end", 4) == 0 &&
-	(yp_char_is_whitespace(parser->current.end[4]) || parser->current.end + 4 == parser->end)) {
+	(parser->current.end + 4 == parser->end || yp_char_is_whitespace(parser->current.end[4]))) {
       const char *newline = memchr(parser->current.end, '\n', (size_t) (parser->end - parser->current.end));
       parser->current.end = newline == NULL ? parser->end : newline + 1;
       parser->current.type = YP_TOKEN_EMBDOC_END;

--- a/test/fixtures/embdoc_no_newline_at_end.rb
+++ b/test/fixtures/embdoc_no_newline_at_end.rb
@@ -1,0 +1,2 @@
+=begin
+=end

--- a/test/snapshots/embdoc_no_newline_at_end.rb
+++ b/test/snapshots/embdoc_no_newline_at_end.rb
@@ -1,0 +1,1 @@
+ProgramNode(0...0)(ScopeNode(0...0)([]), StatementsNode(0...0)([]))


### PR DESCRIPTION
There is an embdoc off by one error which causes =end with no newline to not be returned in the lex. This fixes that error and adds a test