### PR TITLE
Remove unused length field from serialization.

### DIFF
--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -102,7 +102,6 @@ public class Loader {
 
     private Nodes.Node loadNode() {
         int type = buffer.get() & 0xFF;
-        int length = buffer.getInt();
         int startOffset = buffer.getInt();
         int endOffset = buffer.getInt();
 

--- a/bin/templates/lib/yarp/serialize.rb.erb
+++ b/bin/templates/lib/yarp/serialize.rb.erb
@@ -71,7 +71,7 @@ module YARP
       end
 
       def load_node
-        type, _length = io.read(5).unpack("CL")
+        type = io.read(1).unpack1("C")
         location = load_location
 
         case type

--- a/bin/templates/src/serialize.c.erb
+++ b/bin/templates/src/serialize.c.erb
@@ -26,9 +26,6 @@ void
 yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
   yp_buffer_append_u8(buffer, node->type);
 
-  size_t offset = buffer->length;
-  yp_buffer_append_u32(buffer, 0); /* Updated below */
-
   assert(node->location.start);
   assert(node->location.end);
 
@@ -91,7 +88,4 @@ yp_serialize_node(yp_parser_t *parser, yp_node_t *node, yp_buffer_t *buffer) {
     }
     <%- end -%>
   }
-
-  uint32_t length = yp_ulong_to_u32(buffer->length - offset - sizeof(uint32_t));
-  memcpy(buffer->value + offset, &length, sizeof(uint32_t));
 }


### PR DESCRIPTION
This appears to be skipped over and it removes 4 bytes per Node from the serialized blob.