### PR TITLE
Java Loader fixes

### DIFF
--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -108,7 +108,7 @@ public class Loader {
 
         switch (type) {
             <%- nodes.each_with_index do |node, index| -%>
-            case <%= index %>:
+            case <%= index + 1 %>:
                 return new Nodes.<%= node.name %>(<%= (node.params.map { |param|
                     case param
                     when NodeParam then "loadNode()"

--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -27,7 +27,16 @@ public class Loader {
         expect((byte) 4);
         expect((byte) 0);
 
-        return loadNode();
+        Nodes.Node node = loadNode();
+
+        expect((byte) 0); // yp_serialize() appends a final \0 byte
+
+        int left = buffer.capacity() - buffer.position();
+        if (left != 0) {
+            throw new Error("Expected to consume all bytes while deserializing but there were " + left + " bytes left");
+        }
+
+        return node;
     }
 
     private byte[] loadString() {

--- a/bin/templates/java/org/yarp/Nodes.java.erb
+++ b/bin/templates/java/org/yarp/Nodes.java.erb
@@ -11,6 +11,7 @@ import java.util.Arrays;
 public abstract class Nodes {
 
     public enum TokenType {
+        OPTIONAL_TOKEN,
         <%- tokens.each do |token| -%>
         <%= token.name %>,
         <%- end -%>


### PR DESCRIPTION
Fix Java Loader to use nodes and tokens starting at 1
* Following the change of https://github.com/Shopify/yarp/pull/771

Ensure all bytes are consumed in the Java Loader