### PR TITLE
Lex against top 100 gems as part of CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,18 @@ jobs:
     - name: Lex discourse/discourse
       run: bundle exec rake lex:discourse
 
+  lex-top-100:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+    - name: Lex Top 100 Gems
+      run: bundle exec rake lex:topgems
+
   memcheck:
     runs-on: ubuntu-latest
     steps:

--- a/tasks/lex.rake
+++ b/tasks/lex.rake
@@ -224,3 +224,113 @@ task "lex:rubygems": :compile do
     PERCENT=#{(passing_gem_count.to_f / (passing_gem_count + failing_gem_count) * 100).round(2)}%
   RESULTS
 end
+
+# This task lexes against the top 100 gems, and will exit(1)
+# if the existing failures in tasks/top-100-gems.yml are no
+# longer correct.
+desc "Lex against the top 100 rubygems"
+task "lex:topgems": :compile do
+  TOP_100_GEM_FILENAME = "tasks/top-100-gems.yml"
+
+  $:.unshift(File.expand_path("../lib", __dir__))
+  require "net/http"
+  require "ripper"
+  require "rubygems/package"
+  require "tmpdir"
+  require "yarp"
+
+  previous_todos_by_gem_name = {}
+
+  YAML.safe_load_file(TOP_100_GEM_FILENAME).each do |gem_info|
+    if gem_info.class == Hash
+      previous_todos_by_gem_name.merge!(gem_info)
+    else
+      previous_todos_by_gem_name[gem_info] = []
+    end
+  end
+
+  queue = Queue.new
+  previous_todos_by_gem_name.keys.each do |gem_name|
+    gem_url = "https://rubygems.org/gems/#{gem_name}.gem"
+    queue << [gem_name, gem_url]
+  end
+
+  warn_failing = ENV.fetch("VERBOSE", false)
+
+  # An array of hashes with gem_name => [new_failing_files] for any new
+  # failures that we didn't previously have. If there is anything in
+  # this list, the task will report it and exit(1)
+  new_failing_files_by_gem = []
+
+  # An array of hashes with gem_name => [all_failing_files] for all failures
+  # (including pre-existing ones). If there are fewer failures than before,
+  # this list will be used to generate the new yml file before exit(1)
+  updated_todos_by_gem_name = {}
+
+  workers =
+    ENV.fetch("WORKERS", 16).times.map do
+      Thread.new do
+        Net::HTTP.start("rubygems.org", 443, use_ssl: true) do |http|
+          until queue.empty?
+            (gem_name, gem_url) = queue.shift
+            puts "Lexing #{gem_name}"
+
+            http.request(Net::HTTP::Get.new(gem_url)) do |response|
+              # Skip unexpected responses
+              next unless response.is_a?(Net::HTTPSuccess)
+
+              Dir.mktmpdir do |directory|
+                filepath = File.join(directory, "#{gem_name}.gem")
+                File.write(filepath, response.body)
+
+                begin
+                  Gem::Package.new(filepath).extract_files(directory, "[!~]*")
+
+                  todos = previous_todos_by_gem_name[gem_name].map do |todo_filepath|
+                    File.join(directory, todo_filepath)
+                  end
+                  lex_task = YARP::LexTask.new(todos)
+                  Dir[File.join(directory, "**", "*.rb")].each do |filepath|
+                    lex_task.compare(filepath)
+                  end
+
+                  todos = lex_task.todos.map { _1.gsub("#{directory}/", "") }
+
+                  updated_todos_by_gem_name.merge!({ gem_name => todos })
+
+                  if lex_task.failed?
+                    new_failing_files_by_gem << { gem_name => todos }
+                  end
+                rescue
+                  # If the gem fails to extract, we'll just skip it
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+  workers.each(&:join)
+
+  failing_gem_count, passing_gem_count = updated_todos_by_gem_name.partition { |_, todos| todos.any? }.map(&:size)
+
+  puts(<<~RESULTS)
+    PASSING=#{passing_gem_count}
+    FAILING=#{failing_gem_count}
+    PERCENT=#{(passing_gem_count.to_f / (passing_gem_count + failing_gem_count) * 100).round(2)}%
+  RESULTS
+
+  if new_failing_files_by_gem.any?
+    puts "Oh no! There were new failures:"
+    puts new_failing_files_by_gem.to_yaml
+    exit(1)
+  elsif (updated_todos_by_gem_name != previous_todos_by_gem_name)
+    puts "There are files that were previously failing but are no longer failing:"
+    puts "Please update #{TOP_100_GEM_FILENAME} with the following"
+    puts (updated_todos_by_gem_name.map do |k, v|
+      v.any? ? { k => v } : k
+    end).to_yaml
+    exit(1)
+  end
+end

--- a/tasks/top-100-gems.yml
+++ b/tasks/top-100-gems.yml
@@ -1,0 +1,112 @@
+---
+- actioncable-7.0.4.3
+- actionmailbox-7.0.4.3
+- actionmailer-7.0.4.3
+- actionpack-7.0.4.3
+- actiontext-7.0.4.3
+- actionview-7.0.4.3
+- activejob-7.0.4.3
+- activemodel-7.0.4.3
+- activerecord-7.0.4.3
+- activestorage-7.0.4.3
+- activesupport-7.0.4.3:
+  - lib/active_support/messages/rotator.rb
+- addressable-2.8.4
+- autoprefixer-rails-10.4.13.0
+- aws-partitions-1.744.0
+- aws-sdk-cloudformation-1.77.0
+- aws-sdk-cloudfront-1.76.0
+- aws-sdk-cloudwatch-1.72.0
+- aws-sdk-core-3.171.0
+- aws-sdk-dynamodb-1.83.0
+- aws-sdk-ec2-1.375.0
+- aws-sdk-iam-1.77.0
+- aws-sdk-kinesis-1.45.0
+- aws-sdk-kms-1.63.0
+- aws-sdk-lambda-1.93.0
+- aws-sdk-rds-1.175.0
+- aws-sdk-resources-3.162.0
+- aws-sdk-s3-1.120.1
+- aws-sdk-secretsmanager-1.73.0
+- aws-sdk-sns-1.60.0
+- aws-sdk-ssm-1.150.0
+- backports-3.24.1
+- brakeman-5.4.1:
+  - bundle/ruby/3.1.0/gems/erubis-2.7.0/lib/erubis/helpers/rails_form_helper.rb
+- bundler-2.4.11
+- capybara-3.39.0
+- concurrent-ruby-1.2.2
+- connection_pool-2.4.0
+- dalli-3.2.4
+- database_cleaner-2.0.2
+- devise-4.9.2:
+  - lib/generators/active_record/templates/migration.rb
+  - lib/generators/active_record/templates/migration_existing.rb
+  - lib/generators/templates/controllers/confirmations_controller.rb
+  - lib/generators/templates/controllers/omniauth_callbacks_controller.rb
+  - lib/generators/templates/controllers/passwords_controller.rb
+  - lib/generators/templates/controllers/registrations_controller.rb
+  - lib/generators/templates/controllers/sessions_controller.rb
+  - lib/generators/templates/controllers/unlocks_controller.rb
+- dry-types-1.7.1
+- elasticsearch-8.7.0
+- elasticsearch-api-8.7.0
+- excon-0.99.0
+- faker-3.1.1
+- faraday-retry-2.1.0
+- fastlane-2.212.1:
+  - fastlane/lib/assets/custom_action_template.rb
+- fog-aws-3.18.0
+- git-1.18.0
+- google-cloud-errors-1.3.1
+- google-protobuf-3.22.2
+- googleauth-1.5.1
+- graphql-2.0.21
+- grpc-1.53.0
+- jwt-2.7.0
+- loofah-2.20.0
+- mail-2.8.1
+- mime-types-data-3.2023.0218.1
+- minitest-5.18.0
+- msgpack-1.7.0
+- net-http-persistent-4.0.2
+- net-ssh-7.1.0
+- newrelic_rpm-9.1.0
+- nio4r-2.5.9
+- nokogiri-1.14.3
+- octokit-6.1.1
+- oj-3.14.3
+- parser-3.2.2.0
+- pg-1.4.6
+- plist-3.7.0
+- puma-6.2.1
+- rack-3.0.7
+- rack-cors-2.0.1
+- rack-protection-3.0.6
+- rack-test-2.1.0
+- rails-7.0.4.3
+- railties-7.0.4.3
+- raindrops-0.20.1
+- redis-store-1.9.2
+- regexp_parser-2.7.0
+- responders-3.1.0
+- rouge-4.1.0
+- rspec-core-3.12.1
+- rspec-mocks-3.12.5
+- rubocop-1.50.0
+- rubocop-ast-1.28.0
+- rubocop-performance-1.17.1
+- rubocop-rails-2.19.0
+- rubocop-rspec-2.19.0
+- ruby-progressbar-1.13.0
+- ruby_parser-3.20.0
+- rubygems-update-3.4.11
+- selenium-webdriver-4.8.6
+- sidekiq-7.0.8
+- sinatra-3.0.6
+- slop-4.10.1
+- sqlite3-1.6.2
+- thin-1.8.2
+- tilt-2.1.0
+- yard-0.9.32
+- zeitwerk-2.6.7


### PR DESCRIPTION
This commit introduces the `lex:topgems` rake task, and adds it to CI. The rake task lexes against the top 100 gems, and compares their failures to the known failures in `tasks/top-100-gems.yml`. If they are not equivalent, the rake task will fail.

This will ensure we have no regressions when lexing the top 100 gems

Closes #788 