### PR TITLE
Fix places where dos newlines create the wrong lex

### DIFF
--- a/lib/yarp/lex_compat.rb
+++ b/lib/yarp/lex_compat.rb
@@ -303,7 +303,7 @@ module YARP
                 if split
                   # Split on "\\\n" to mimic Ripper's behavior. Use a lookbehind
                   # to keep the delimiter in the result.
-                  token.value.split(/(?<=[^\\]\\\n)/).each_with_index do |value, index|
+                  token.value.split(/(?<=[^\\]\\\n)|(?<=[^\\]\\\r\n)/).each_with_index do |value, index|
                     column = 0 if index > 0
                     results << Token.new([[lineno, column], :on_tstring_content, value, token.state])
                     lineno += value.count("\n")
@@ -472,8 +472,12 @@ module YARP
                     # Gather up all of the characters that we're going to
                     # delete, stopping when you hit a character that would put
                     # you over the dedent amount.
-                    line.each_char do |char|
+                    line.each_char.with_index do |char, i|
                       case char
+                      when "\r"
+                        if line.chars[i + 1] == "\n"
+                          break
+                        end
                       when "\n"
                         break
                       when "\t"

--- a/src/unescape.c
+++ b/src/unescape.c
@@ -180,6 +180,20 @@ static const char *
 unescape(char *dest, size_t *dest_length, const char *backslash, const char *end, yp_list_t *error_list, const unsigned char flags, bool write_to_str) {
   switch (backslash[1]) {
     // \a \b \e \f \n \r \s \t \v
+    case '\r': {
+      // if this is an \r\n we need to escape both
+      if (write_to_str) {
+        dest[(*dest_length)++] = (char) unescape_char(unescape_chars[(unsigned char) backslash[1]], flags);
+      }
+
+      if (backslash[2] == '\n') {
+	if (write_to_str) {
+	  dest[(*dest_length)++] = (char) unescape_char(unescape_chars[(unsigned char) backslash[1]], flags);
+	}
+	return backslash + 3;
+      }
+      return backslash + 2;
+    }
     case 'a':
     case 'b':
     case 'e':

--- a/test/fixtures/dos_endings.rb
+++ b/test/fixtures/dos_endings.rb
@@ -1,0 +1,20 @@
+puts "hi"\
+     "there"
+
+%I{a\
+b}
+
+<<-E
+    1 \
+    2
+    3
+E
+
+x = %
+
+
+
+a = foo(<<~EOF.chop)
+
+    baz
+  EOF

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -12,7 +12,6 @@ class ParseTest < Test::Unit::TestCase
   end
 
   known_failures = %w[
-    seattlerb/heredoc__backslash_dos_format.rb
     seattlerb/heredoc_nested.rb
     seattlerb/heredoc_trailing_slash_continued_call.rb
     seattlerb/pct_w_heredoc_interp_nested.rb

--- a/test/snapshots/dos_endings.rb
+++ b/test/snapshots/dos_endings.rb
@@ -1,0 +1,96 @@
+ProgramNode(0...108)(
+  ScopeNode(0...0)([IDENTIFIER(75...76)("x"), IDENTIFIER(88...89)("a")]),
+  StatementsNode(0...108)(
+    [CallNode(0...4)(
+       nil,
+       nil,
+       IDENTIFIER(0...4)("puts"),
+       nil,
+       ArgumentsNode(5...24)(
+         [StringConcatNode(5...24)(
+            StringNode(5...9)(
+              STRING_BEGIN(5...6)("\""),
+              STRING_CONTENT(6...8)("hi"),
+              STRING_END(8...9)("\""),
+              "hi"
+            ),
+            StringNode(17...24)(
+              STRING_BEGIN(17...18)("\""),
+              STRING_CONTENT(18...23)("there"),
+              STRING_END(23...24)("\""),
+              "there"
+            )
+          )]
+       ),
+       nil,
+       nil,
+       "puts"
+     ),
+     ArrayNode(28...37)(
+       [SymbolNode(31...36)(
+          nil,
+          STRING_CONTENT(31...36)("a\\\r\n" + "b"),
+          nil,
+          "a\u0000\u0000b"
+        )],
+       PERCENT_UPPER_I(28...31)("%I{"),
+       STRING_END(36...37)("}")
+     ),
+     InterpolatedStringNode(47...70)(
+       HEREDOC_START(41...45)("<<-E"),
+       [StringNode(47...70)(
+          nil,
+          STRING_CONTENT(47...70)("    1 \\\r\n" + "    2\r\n" + "    3\r\n"),
+          nil,
+          "    1 \u0000\u0000    2\r\n" + "    3\r\n"
+        )],
+       HEREDOC_END(70...73)("E\r\n")
+     ),
+     LocalVariableWriteNode(75...84)(
+       (75...76),
+       StringNode(79...84)(
+         STRING_BEGIN(79...82)("%\r\n"),
+         STRING_CONTENT(82...82)(""),
+         STRING_END(82...84)("\r\n"),
+         ""
+       ),
+       (77...78),
+       0
+     ),
+     LocalVariableWriteNode(88...108)(
+       (88...89),
+       CallNode(92...108)(
+         nil,
+         nil,
+         IDENTIFIER(92...95)("foo"),
+         PARENTHESIS_LEFT(95...96)("("),
+         ArgumentsNode(110...107)(
+           [CallNode(110...107)(
+              InterpolatedStringNode(110...121)(
+                HEREDOC_START(96...102)("<<~EOF"),
+                [StringNode(110...121)(
+                   nil,
+                   STRING_CONTENT(110...121)("\r\n" + "    baz\r\n"),
+                   nil,
+                   "\n" + "baz\r\n"
+                 )],
+                HEREDOC_END(121...128)("  EOF\r\n")
+              ),
+              DOT(102...103)("."),
+              IDENTIFIER(103...107)("chop"),
+              nil,
+              nil,
+              nil,
+              nil,
+              "chop"
+            )]
+         ),
+         PARENTHESIS_RIGHT(107...108)(")"),
+         nil,
+         "foo"
+       ),
+       (90...91),
+       0
+     )]
+  )
+)

--- a/test/snapshots/seattlerb/heredoc__backslash_dos_format.rb
+++ b/test/snapshots/seattlerb/heredoc__backslash_dos_format.rb
@@ -1,0 +1,20 @@
+ProgramNode(0...30)(
+  ScopeNode(0...0)([IDENTIFIER(0...3)("str")]),
+  StatementsNode(0...30)(
+    [LocalVariableWriteNode(0...30)(
+       (0...3),
+       InterpolatedStringNode(14...30)(
+         HEREDOC_START(6...12)("<<-XXX"),
+         [StringNode(14...30)(
+            nil,
+            STRING_CONTENT(14...30)("before\\\r\n" + "after\r\n"),
+            nil,
+            "before\u0000\u0000after\r\n"
+          )],
+         HEREDOC_END(30...35)("XXX\r\n")
+       ),
+       (4...5),
+       0
+     )]
+  )
+)


### PR DESCRIPTION
This fixes some places where we assume that newlines are always unix newlines. Instead now we can handle newlines that are dos style as well.

I also removed a few tabs that probably shouldn't be there.