### PR TITLE
Add `-e` switch to the `bin/parse` script

### DIFF
--- a/bin/parse
+++ b/bin/parse
@@ -4,4 +4,12 @@
 $:.unshift(File.expand_path("../lib", __dir__))
 require "yarp"
 
-pp YARP.parse_file_dup(ARGV[0])
+# Usage:
+#   bin/parser <filename>
+#   bin/parse -e "<source-code>"
+
+if ARGV[0] == "-e"
+  pp YARP.parse(ARGV[1])
+else
+  pp YARP.parse_file_dup(ARGV[0])
+end


### PR DESCRIPTION
It's easier to provide an argument instead of a file for quick testing (when Ruby expression is short enough)

Example:

```shell
bin/parse -e "FOO::BAR = 1"
```