### PR TITLE
Emit an error message for endless setters

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3403,6 +3403,15 @@ token_is_numbered_parameter(yp_token_t *token) {
     (yp_char_is_decimal_digit(token->start[1]));
 }
 
+static inline bool
+token_is_setter_name(yp_token_t *token) {
+  return (
+    (token->type == YP_TOKEN_IDENTIFIER) &&
+    (token->end - token->start >= 2) &&
+    (token->end[-1] == '=')
+  );
+}
+
 /******************************************************************************/
 /* Stack helpers                                                              */
 /******************************************************************************/
@@ -10060,6 +10069,9 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
       yp_token_t end_keyword;
 
       if (accept(parser, YP_TOKEN_EQUAL)) {
+        if (token_is_setter_name(&name)) {
+          yp_diagnostic_list_append(&parser->error_list, name.start, name.end, "Setter method cannot be defined in an endless method definition");
+        }
         equal = parser->previous;
 
         context_push(parser, YP_CONTEXT_DEF);

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -884,7 +884,25 @@ class ErrorsTest < Test::Unit::TestCase
 
     assert_errors expected, "case :a\nelse\nend", ["Unexpected else without no when clauses in case statement."]
   end
-  
+
+  test "setter method cannot be defined in an endless method definition"  do
+    expected = DefNode(
+      IDENTIFIER("a="),
+      nil,
+      nil,
+      StatementsNode([IntegerNode()]),
+      ScopeNode([]),
+      Location(),
+      nil,
+      Location(),
+      Location(),
+      Location(),
+      nil
+    )
+
+    assert_errors expected, "def a=() = 42", ["Setter method cannot be defined in an endless method definition"]
+  end
+
   private
 
   def assert_errors(expected, source, errors)


### PR DESCRIPTION
Mirror the CRuby behavior for setter methods in endless method definitions.

```ruby
def a=() = 42
```

```
test.rb: test.rb:1: setter method cannot be defined in an endless method definition (SyntaxError)
def a=() = 42
^~~~~~
```