### PR TITLE
Emit error for `return`s in class/module body

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -3947,25 +3947,6 @@ context_def_p(yp_parser_t *parser) {
   return false;
 }
 
-static bool
-context_class_or_module_p(yp_parser_t *parser) {
-  yp_context_node_t *context_node = parser->current_context;
-
-  while (context_node != NULL) {
-    switch (context_node->context) {
-      case YP_CONTEXT_DEF:
-        return false;
-      case YP_CONTEXT_CLASS:
-      case YP_CONTEXT_MODULE:
-        return true;
-      default:
-        context_node = context_node->prev;
-    }
-  }
-
-  return false;
-}
-
 /******************************************************************************/
 /* Specific token lexers                                                      */
 /******************************************************************************/
@@ -9840,7 +9821,10 @@ parse_expression_prefix(yp_parser_t *parser, yp_binding_power_t binding_power) {
         case YP_TOKEN_KEYWORD_NEXT:
           return (yp_node_t *) yp_next_node_create(parser, &keyword, arguments);
         case YP_TOKEN_KEYWORD_RETURN: {
-          if (context_class_or_module_p(parser)) {
+          if (
+            (parser->current_context->context == YP_CONTEXT_CLASS) ||
+            (parser->current_context->context == YP_CONTEXT_MODULE)
+          ) {
             yp_diagnostic_list_append(&parser->error_list, parser->current.start, parser->current.end, "Invalid return in class/module body");
           }
           return (yp_node_t *) yp_return_node_create(parser, &keyword, arguments);

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -414,6 +414,34 @@ class ErrorsTest < Test::Unit::TestCase
     ", ["Module definition in method body"]
   end
 
+  test "class definition in method body" do
+    expected = DefNode(
+      IDENTIFIER("foo"),
+      nil,
+      nil,
+      StatementsNode(
+        [ClassNode(
+           ScopeNode([]),
+           KEYWORD_CLASS("class"),
+           ConstantReadNode(),
+           nil,
+           nil,
+           nil,
+           KEYWORD_END("end")
+         )]
+      ),
+      ScopeNode([]),
+      Location(),
+      nil,
+      nil,
+      nil,
+      nil,
+      Location()
+    )
+
+    assert_errors expected, "def foo;class A;end;end", ["Class definition in method body"]
+  end
+
   test "bad arguments" do
     expected = DefNode(
       IDENTIFIER("foo"),
@@ -901,6 +929,32 @@ class ErrorsTest < Test::Unit::TestCase
     )
 
     assert_errors expected, "def a=() = 42", ["Setter method cannot be defined in an endless method definition"]
+  end
+
+  test "don't allow return inside class body" do
+    expected = ClassNode(
+      ScopeNode([]),
+      KEYWORD_CLASS("class"),
+      ConstantReadNode(),
+      nil,
+      nil,
+      StatementsNode([ReturnNode(KEYWORD_RETURN("return"), nil)]),
+      KEYWORD_END("end")
+    )
+
+    assert_errors expected, "class A; return; end", ["Invalid return in class/module body"]
+  end
+
+  test "don't allow return inside module body" do
+    expected = ModuleNode(
+      ScopeNode([]),
+      KEYWORD_MODULE("module"),
+      ConstantReadNode(),
+      StatementsNode([ReturnNode(KEYWORD_RETURN("return"), nil)]),
+      KEYWORD_END("end")
+    )
+
+    assert_errors expected, "module A; return; end", ["Invalid return in class/module body"]
   end
 
   private


### PR DESCRIPTION
- Emit error for `return` in class/module body
- Emit error for class definition inside a `def` body