### PR TITLE
Use node kinds for Java code

### DIFF
--- a/bin/template.rb
+++ b/bin/template.rb
@@ -12,12 +12,22 @@ class Param
   end
 end
 
-module CTypes
+module KindTypes
   def c_type
     if options[:kind]
       "yp_#{options[:kind].gsub(/(?<=.)[A-Z]/, "_\\0").downcase}"
     else
       "yp_node"
+    end
+  end
+
+  def java_type = options[:kind] || "Node"
+
+  def java_cast
+    if options[:kind]
+      "(Nodes.#{options[:kind]}) "
+    else
+      ""
     end
   end
 end
@@ -26,19 +36,17 @@ end
 # This represents a parameter to a node that is itself a node. We pass them as
 # references and store them as references.
 class NodeParam < Param
-  include CTypes
+  include KindTypes
   
   def rbs_class = "Node"
-  def java_type = "Node"
 end
 
 # This represents a parameter to a node that is itself a node and can be
 # optionally null. We pass them as references and store them as references.
 class OptionalNodeParam < Param
-  include CTypes
+  include KindTypes
   
   def rbs_class = "Node?"
-  def java_type = "Node"
 end
 
 SingleNodeParam = -> (node) { NodeParam === node or OptionalNodeParam === node }

--- a/bin/templates/java/org/yarp/Loader.java.erb
+++ b/bin/templates/java/org/yarp/Loader.java.erb
@@ -120,8 +120,8 @@ public class Loader {
             case <%= index + 1 %>:
                 return new Nodes.<%= node.name %>(<%= (node.params.map { |param|
                     case param
-                    when NodeParam then "loadNode()"
-                    when OptionalNodeParam then "loadOptionalNode()"
+                    when NodeParam then "#{param.java_cast}loadNode()"
+                    when OptionalNodeParam then "#{param.java_cast}loadOptionalNode()"
                     when StringParam then "loadString()"
                     when NodeListParam then "loadNodes()"
                     when TokenParam then "loadToken()"


### PR DESCRIPTION
So it's like:
```java
    public static final class BeginNode extends Node {
        public final Token begin_keyword; // optional
        public final StatementsNode statements; // optional
        public final RescueNode rescue_clause; // optional
        public final ElseNode else_clause; // optional
        public final EnsureNode ensure_clause; // optional
        public final Token end_keyword; // optional
```
instead of:
```java
    public static final class BeginNode extends Node {
        public final Token begin_keyword; // optional
        public final Node statements; // optional
        public final Node rescue_clause; // optional
        public final Node else_clause; // optional
        public final Node ensure_clause; // optional
        public final Token end_keyword; // optional
```