### PR TITLE
Fix array node location

### DIFF
--- a/src/yarp.c
+++ b/src/yarp.c
@@ -490,6 +490,7 @@ yp_array_node_size(yp_array_node_t *node) {
 static inline void
 yp_array_node_elements_append(yp_array_node_t *node, yp_node_t *element) {
   yp_node_list_append2(&node->elements, element);
+  node->base.location.end = element->location.end;
 }
 
 // Set the closing token and end location of an array node.

--- a/test/snapshots/arrays.rb
+++ b/test/snapshots/arrays.rb
@@ -18,7 +18,7 @@ ProgramNode(0...502)(
        BRACKET_LEFT_ARRAY(0...1)("["),
        BRACKET_RIGHT(3...4)("]")
      ),
-     CallNode(6...0)(
+     CallNode(6...29)(
        CallNode(6...9)(
          nil,
          nil,
@@ -32,7 +32,7 @@ ProgramNode(0...502)(
        nil,
        BRACKET_LEFT_RIGHT_EQUAL(9...10)("["),
        BRACKET_LEFT(9...10)("["),
-       ArgumentsNode(10...0)(
+       ArgumentsNode(10...29)(
          [CallNode(10...13)(
             nil,
             nil,
@@ -53,7 +53,7 @@ ProgramNode(0...502)(
             nil,
             "baz"
           ),
-          ArrayNode(0...0)(
+          ArrayNode(0...29)(
             [IntegerNode(22...23)(),
              IntegerNode(25...26)(),
              IntegerNode(28...29)()],
@@ -392,7 +392,7 @@ ProgramNode(0...502)(
        nil,
        "[]="
      ),
-     MultiWriteNode(191...0)(
+     MultiWriteNode(191...212)(
        [CallNode(191...197)(
           CallNode(191...194)(
             nil,
@@ -432,7 +432,7 @@ ProgramNode(0...502)(
           "[]="
         )],
        EQUAL(206...207)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...212)(
          [IntegerNode(208...209)(), IntegerNode(211...212)()],
          nil,
          nil

--- a/test/snapshots/method_calls.rb
+++ b/test/snapshots/method_calls.rb
@@ -430,7 +430,7 @@ ProgramNode(0...1187)(
        nil,
        "b"
      ),
-     MultiWriteNode(173...0)(
+     MultiWriteNode(173...196)(
        [CallNode(173...180)(
           CallNode(173...176)(
             nil,
@@ -470,7 +470,7 @@ ProgramNode(0...1187)(
           "bar="
         )],
        EQUAL(190...191)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...196)(
          [IntegerNode(192...193)(), IntegerNode(195...196)()],
          nil,
          nil

--- a/test/snapshots/seattlerb/lasgn_middle_splat.rb
+++ b/test/snapshots/seattlerb/lasgn_middle_splat.rb
@@ -1,9 +1,9 @@
-ProgramNode(0...0)(
+ProgramNode(0...12)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...0)(
-    [LocalVariableWriteNode(0...0)(
+  StatementsNode(0...12)(
+    [LocalVariableWriteNode(0...12)(
        (0...1),
-       ArrayNode(0...0)(
+       ArrayNode(0...12)(
          [CallNode(4...5)(
             nil,
             nil,

--- a/test/snapshots/seattlerb/masgn_colon2.rb
+++ b/test/snapshots/seattlerb/masgn_colon2.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...0)(
+ProgramNode(0...14)(
   ScopeNode(0...0)([IDENTIFIER(0...1)("a")]),
-  StatementsNode(0...0)(
-    [MultiWriteNode(0...0)(
+  StatementsNode(0...14)(
+    [MultiWriteNode(0...14)(
        [LocalVariableWriteNode(0...1)((0...1), nil, nil, 0),
         ConstantPathWriteNode(3...7)(
           ConstantPathNode(3...7)(
@@ -22,7 +22,7 @@ ProgramNode(0...0)(
           nil
         )],
        EQUAL(8...9)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...14)(
          [IntegerNode(10...11)(), IntegerNode(13...14)()],
          nil,
          nil

--- a/test/snapshots/seattlerb/masgn_colon3.rb
+++ b/test/snapshots/seattlerb/masgn_colon3.rb
@@ -1,7 +1,7 @@
-ProgramNode(0...0)(
+ProgramNode(0...15)(
   ScopeNode(0...0)([]),
-  StatementsNode(0...0)(
-    [MultiWriteNode(0...0)(
+  StatementsNode(0...15)(
+    [MultiWriteNode(0...15)(
        [ConstantPathWriteNode(0...3)(
           ConstantPathNode(0...3)(nil, ConstantReadNode(2...3)(), (0...2)),
           nil,
@@ -13,7 +13,7 @@ ProgramNode(0...0)(
           nil
         )],
        EQUAL(9...10)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...15)(
          [IntegerNode(11...12)(), IntegerNode(14...15)()],
          nil,
          nil

--- a/test/snapshots/seattlerb/masgn_lhs_splat.rb
+++ b/test/snapshots/seattlerb/masgn_lhs_splat.rb
@@ -1,13 +1,13 @@
-ProgramNode(0...0)(
+ProgramNode(0...12)(
   ScopeNode(0...0)([IDENTIFIER(1...2)("a")]),
-  StatementsNode(0...0)(
-    [MultiWriteNode(0...0)(
+  StatementsNode(0...12)(
+    [MultiWriteNode(0...12)(
        [SplatNode(0...2)(
           USTAR(0...1)("*"),
           LocalVariableWriteNode(1...2)((1...2), nil, nil, 0)
         )],
        EQUAL(3...4)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...12)(
          [IntegerNode(5...6)(), IntegerNode(8...9)(), IntegerNode(11...12)()],
          nil,
          nil

--- a/test/snapshots/variables.rb
+++ b/test/snapshots/variables.rb
@@ -20,9 +20,9 @@ ProgramNode(0...293)(
        nil,
        nil
      ),
-     ClassVariableWriteNode(36...0)(
+     ClassVariableWriteNode(36...48)(
        (36...41),
-       ArrayNode(0...0)(
+       ArrayNode(0...48)(
          [IntegerNode(44...45)(), IntegerNode(47...48)()],
          nil,
          nil
@@ -73,10 +73,10 @@ ProgramNode(0...293)(
        nil,
        nil
      ),
-     GlobalVariableWriteNode(110...0)(
+     GlobalVariableWriteNode(110...121)(
        GLOBAL_VARIABLE(110...114)("$foo"),
        EQUAL(115...116)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...121)(
          [IntegerNode(117...118)(), IntegerNode(120...121)()],
          nil,
          nil
@@ -90,9 +90,9 @@ ProgramNode(0...293)(
        nil,
        nil
      ),
-     InstanceVariableWriteNode(139...0)(
+     InstanceVariableWriteNode(139...150)(
        (139...143),
-       ArrayNode(0...0)(
+       ArrayNode(0...150)(
          [IntegerNode(146...147)(), IntegerNode(149...150)()],
          nil,
          nil
@@ -105,9 +105,9 @@ ProgramNode(0...293)(
        (156...157),
        0
      ),
-     LocalVariableWriteNode(161...0)(
+     LocalVariableWriteNode(161...171)(
        (161...164),
-       ArrayNode(0...0)(
+       ArrayNode(0...171)(
          [IntegerNode(167...168)(), IntegerNode(170...171)()],
          nil,
          nil
@@ -115,9 +115,9 @@ ProgramNode(0...293)(
        (165...166),
        0
      ),
-     LocalVariableWriteNode(173...0)(
+     LocalVariableWriteNode(173...183)(
        (173...176),
-       ArrayNode(0...0)(
+       ArrayNode(0...183)(
          [IntegerNode(179...180)(), IntegerNode(182...183)()],
          nil,
          nil
@@ -125,11 +125,11 @@ ProgramNode(0...293)(
        (177...178),
        0
      ),
-     MultiWriteNode(185...0)(
+     MultiWriteNode(185...198)(
        [LocalVariableWriteNode(185...188)((185...188), nil, nil, 0),
         SplatNode(190...191)(USTAR(190...191)("*"), nil)],
        EQUAL(192...193)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...198)(
          [IntegerNode(194...195)(), IntegerNode(197...198)()],
          nil,
          nil
@@ -137,11 +137,11 @@ ProgramNode(0...293)(
        nil,
        nil
      ),
-     MultiWriteNode(200...0)(
+     MultiWriteNode(200...211)(
        [LocalVariableWriteNode(200...203)((200...203), nil, nil, 0),
         SplatNode(203...204)(COMMA(203...204)(","), nil)],
        EQUAL(205...206)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...211)(
          [IntegerNode(207...208)(), IntegerNode(210...211)()],
          nil,
          nil
@@ -149,14 +149,14 @@ ProgramNode(0...293)(
        nil,
        nil
      ),
-     MultiWriteNode(213...0)(
+     MultiWriteNode(213...229)(
        [LocalVariableWriteNode(213...216)((213...216), nil, nil, 0),
         SplatNode(218...222)(
           USTAR(218...219)("*"),
           LocalVariableWriteNode(219...222)((219...222), nil, nil, 0)
         )],
        EQUAL(223...224)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...229)(
          [IntegerNode(225...226)(), IntegerNode(228...229)()],
          nil,
          nil
@@ -164,7 +164,7 @@ ProgramNode(0...293)(
        nil,
        nil
      ),
-     MultiWriteNode(231...0)(
+     MultiWriteNode(231...258)(
        [LocalVariableWriteNode(231...234)((231...234), nil, nil, 0),
         MultiWriteNode(237...246)(
           [LocalVariableWriteNode(237...240)((237...240), nil, nil, 0),
@@ -175,7 +175,7 @@ ProgramNode(0...293)(
           (245...246)
         )],
        EQUAL(247...248)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...258)(
          [IntegerNode(249...250)(),
           ArrayNode(252...258)(
             [IntegerNode(253...254)(), IntegerNode(256...257)()],
@@ -197,10 +197,10 @@ ProgramNode(0...293)(
        (264...265),
        0
      ),
-     ConstantPathWriteNode(272...0)(
+     ConstantPathWriteNode(272...282)(
        ConstantReadNode(272...275)(),
        EQUAL(276...277)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...282)(
          [IntegerNode(278...279)(), IntegerNode(281...282)()],
          nil,
          nil

--- a/test/snapshots/whitequark/asgn_mrhs.rb
+++ b/test/snapshots/whitequark/asgn_mrhs.rb
@@ -1,6 +1,6 @@
-ProgramNode(0...0)(
+ProgramNode(0...41)(
   ScopeNode(0...0)([IDENTIFIER(0...3)("foo")]),
-  StatementsNode(0...0)(
+  StatementsNode(0...41)(
     [LocalVariableWriteNode(0...10)(
        (0...3),
        SplatNode(6...10)(
@@ -19,9 +19,9 @@ ProgramNode(0...0)(
        (4...5),
        0
      ),
-     LocalVariableWriteNode(12...0)(
+     LocalVariableWriteNode(12...24)(
        (12...15),
-       ArrayNode(0...0)(
+       ArrayNode(0...24)(
          [CallNode(18...21)(
             nil,
             nil,
@@ -39,9 +39,9 @@ ProgramNode(0...0)(
        (16...17),
        0
      ),
-     LocalVariableWriteNode(26...0)(
+     LocalVariableWriteNode(26...41)(
        (26...29),
-       ArrayNode(0...0)(
+       ArrayNode(0...41)(
          [CallNode(32...35)(
             nil,
             nil,

--- a/test/snapshots/whitequark/masgn.rb
+++ b/test/snapshots/whitequark/masgn.rb
@@ -1,15 +1,15 @@
-ProgramNode(1...0)(
+ProgramNode(1...56)(
   ScopeNode(0...0)(
     [IDENTIFIER(1...4)("foo"),
      IDENTIFIER(6...9)("bar"),
      IDENTIFIER(46...49)("baz")]
   ),
-  StatementsNode(1...0)(
-    [MultiWriteNode(1...0)(
+  StatementsNode(1...56)(
+    [MultiWriteNode(1...17)(
        [LocalVariableWriteNode(1...4)((1...4), nil, nil, 0),
         LocalVariableWriteNode(6...9)((6...9), nil, nil, 0)],
        EQUAL(11...12)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...17)(
          [IntegerNode(13...14)(), IntegerNode(16...17)()],
          nil,
          nil
@@ -17,11 +17,11 @@ ProgramNode(1...0)(
        (0...1),
        (9...10)
      ),
-     MultiWriteNode(19...0)(
+     MultiWriteNode(19...34)(
        [LocalVariableWriteNode(19...22)((19...22), nil, nil, 0),
         LocalVariableWriteNode(24...27)((24...27), nil, nil, 0)],
        EQUAL(28...29)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...34)(
          [IntegerNode(30...31)(), IntegerNode(33...34)()],
          nil,
          nil
@@ -29,12 +29,12 @@ ProgramNode(1...0)(
        nil,
        nil
      ),
-     MultiWriteNode(36...0)(
+     MultiWriteNode(36...56)(
        [LocalVariableWriteNode(36...39)((36...39), nil, nil, 0),
         LocalVariableWriteNode(41...44)((41...44), nil, nil, 0),
         LocalVariableWriteNode(46...49)((46...49), nil, nil, 0)],
        EQUAL(50...51)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...56)(
          [IntegerNode(52...53)(), IntegerNode(55...56)()],
          nil,
          nil

--- a/test/snapshots/whitequark/masgn_splat.rb
+++ b/test/snapshots/whitequark/masgn_splat.rb
@@ -1,11 +1,11 @@
-ProgramNode(0...0)(
+ProgramNode(0...139)(
   ScopeNode(0...0)(
     [IDENTIFIER(12...13)("c"),
      IDENTIFIER(15...16)("d"),
      IDENTIFIER(25...26)("b"),
      IDENTIFIER(67...68)("a")]
   ),
-  StatementsNode(0...0)(
+  StatementsNode(0...139)(
     [MultiWriteNode(0...7)(
        [SplatNode(0...1)(USTAR(0...1)("*"), nil)],
        EQUAL(2...3)("="),
@@ -187,11 +187,11 @@ ProgramNode(0...0)(
        nil,
        nil
      ),
-     MultiWriteNode(123...0)(
+     MultiWriteNode(123...139)(
        [LocalVariableWriteNode(123...124)((123...124), nil, nil, 0),
         LocalVariableWriteNode(126...127)((126...127), nil, nil, 0)],
        EQUAL(128...129)("="),
-       ArrayNode(0...0)(
+       ArrayNode(0...139)(
          [SplatNode(130...134)(
             USTAR(130...131)("*"),
             CallNode(131...134)(


### PR DESCRIPTION
The location of the `ArrayNode` is not set correctly when there is no opening and closing nodes for it. E.g. `a = 1, 2, 3` 

This PR updates the end location of the `ArrayNode` every time we append an element to it.