### PR TITLE
Fix escaping in single quote heredocs

### DIFF
--- a/test/fixtures/single_quote_heredocs.rb
+++ b/test/fixtures/single_quote_heredocs.rb
@@ -1,0 +1,3 @@
+<<-'EOS'
+    cd L:\Work\MG3710IQPro\Develop
+EOS

--- a/test/snapshots/single_quote_heredocs.rb
+++ b/test/snapshots/single_quote_heredocs.rb
@@ -1,0 +1,15 @@
+ProgramNode(0...48)(
+  ScopeNode(0...0)([]),
+  StatementsNode(0...48)(
+    [InterpolatedStringNode(0...48)(
+       HEREDOC_START(0...8)("<<-'EOS'"),
+       [StringNode(9...44)(
+          nil,
+          STRING_CONTENT(9...44)("    cd L:\\Work\\MG3710IQPro\\Develop\n"),
+          nil,
+          "    cd L:\\Work\\MG3710IQPro\\Develop\n"
+        )],
+       HEREDOC_END(44...48)("EOS\n")
+     )]
+  )
+)

--- a/test/snapshots/unparser/corpus/semantic/dstr.rb
+++ b/test/snapshots/unparser/corpus/semantic/dstr.rb
@@ -135,7 +135,7 @@ ProgramNode(0...608)(
           nil,
           STRING_CONTENT(219...225)(" a\\nb\n"),
           nil,
-          " a\n" + "b\n"
+          " a\\nb\n"
         )],
        HEREDOC_END(225...229)("DOC\n")
      ),

--- a/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.rb
+++ b/test/snapshots/whitequark/dedenting_non_interpolating_heredoc_line_continuation.rb
@@ -7,7 +7,7 @@ ProgramNode(0...26)(
           nil,
           STRING_CONTENT(9...22)("  baz\\\n" + "  qux\n"),
           nil,
-          "baz\n" + "qux\n"
+          "baz\\\n" + "qux\n"
         )],
        HEREDOC_END(22...26)("FOO\n")
      )]

--- a/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
+++ b/test/snapshots/whitequark/parser_slash_slash_n_escaping_in_literals.rb
@@ -127,7 +127,7 @@ ProgramNode(0...210)(
           nil,
           STRING_CONTENT(172...177)("a\\\n" + "b\n"),
           nil,
-          "a\n" + "b\n"
+          "a\\\n" + "b\n"
         )],
        HEREDOC_END(177...182)("HERE\n")
      ),


### PR DESCRIPTION
Escaping in single quoted heredocs should use YP_UNESCAPE_MINIMAL, not YP_UNESCAPE_ALL.

Closes #884 